### PR TITLE
feat: add dirty cafe sales dataset

### DIFF
--- a/dirty_cafe_sales.csv
+++ b/dirty_cafe_sales.csv
@@ -1,0 +1,10001 @@
+Transaction ID,Item,Quantity,Price Per Unit,Total Spent,Payment Method,Location,Transaction Date
+TXN_1961373,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-09-08
+TXN_4977031,Cake,4,3.0,12.0,Cash,In-store,2023-05-16
+TXN_4271903,Cookie,4,1.0,ERROR,Credit Card,In-store,2023-07-19
+TXN_7034554,Salad,2,5.0,10.0,UNKNOWN,UNKNOWN,2023-04-27
+TXN_3160411,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-06-11
+TXN_2602893,Smoothie,5,4.0,20.0,Credit Card,,2023-03-31
+TXN_4433211,UNKNOWN,3,3.0,9.0,ERROR,Takeaway,2023-10-06
+TXN_6699534,Sandwich,4,4.0,16.0,Cash,UNKNOWN,2023-10-28
+TXN_4717867,,5,3.0,15.0,,Takeaway,2023-07-28
+TXN_2064365,Sandwich,5,4.0,20.0,,In-store,2023-12-31
+TXN_2548360,Salad,5,5.0,25.0,Cash,Takeaway,2023-11-07
+TXN_3051279,Sandwich,2,4.0,8.0,Credit Card,Takeaway,ERROR
+TXN_7619095,Sandwich,2,4.0,8.0,Cash,In-store,2023-05-03
+TXN_9437049,Cookie,5,1.0,5.0,,Takeaway,2023-06-01
+TXN_8915701,ERROR,2,1.5,3.0,,In-store,2023-03-21
+TXN_2847255,Salad,3,5.0,15.0,Credit Card,In-store,2023-11-15
+TXN_3765707,Sandwich,1,4.0,4.0,,,2023-06-10
+TXN_6769710,Juice,2,3.0,6.0,Cash,In-store,2023-02-24
+TXN_8876618,Cake,5,3.0,15.0,Cash,ERROR,2023-03-25
+TXN_3709394,Juice,4,3.0,12.0,Cash,Takeaway,2023-01-15
+TXN_3522028,Smoothie,ERROR,4.0,20.0,Cash,In-store,2023-04-04
+TXN_3567645,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-03-30
+TXN_5132361,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-12-01
+TXN_2616390,Sandwich,2,4.0,8.0,,,2023-09-18
+TXN_9400181,Sandwich,5,4.0,20.0,Cash,In-store,2023-06-03
+TXN_7958992,Smoothie,3,4.0,,UNKNOWN,UNKNOWN,2023-12-13
+TXN_5183041,Cookie,5,1.0,5.0,Credit Card,In-store,2023-04-20
+TXN_5695074,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-04-10
+TXN_8467949,Smoothie,5,4.0,20.0,Credit Card,,2023-03-11
+TXN_7640952,Cake,4,3.0,12.0,Digital Wallet,Takeaway,ERROR
+TXN_1736287,,5,2.0,10.0,Digital Wallet,,2023-06-02
+TXN_8927252,UNKNOWN,2,1.0,ERROR,Credit Card,ERROR,2023-11-06
+TXN_9677376,Smoothie,4,4.0,16.0,,In-store,2023-08-15
+TXN_7710508,UNKNOWN,5,1.0,5.0,Cash,,ERROR
+TXN_8853997,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-10-09
+TXN_9130559,Sandwich,1,4.0,4.0,Credit Card,UNKNOWN,2023-05-28
+TXN_6855453,UNKNOWN,4,3.0,12.0,,In-store,2023-07-17
+TXN_1080432,Salad,2,5.0,10.0,Credit Card,In-store,2023-04-29
+TXN_2655815,Smoothie,4,4.0,16.0,,Takeaway,2023-06-08
+TXN_6688524,Coffee,4,2.0,8.0,ERROR,,2023-06-29
+TXN_2083138,Smoothie,3,4.0,12.0,,In-store,2023-04-17
+TXN_2427584,Sandwich,4,4.0,16.0,,Takeaway,2023-12-22
+TXN_6650263,Tea,2,1.5,UNKNOWN,,Takeaway,2023-01-10
+TXN_9620080,Juice,4,3.0,12.0,,Takeaway,2023-10-02
+TXN_1491578,Cookie,2,1.0,2.0,,,2023-02-23
+TXN_5455792,Salad,3,5.0,15.0,Cash,,2023-03-22
+TXN_8078640,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-11-03
+TXN_9499313,Juice,5,3.0,15.0,,,2023-03-02
+TXN_8201146,Juice,5,3.0,15.0,Cash,,2023-06-26
+TXN_8230936,Cake,3,3.0,9.0,,ERROR,2023-05-02
+TXN_7742742,Cake,5,3.0,15.0,,Takeaway,2023-09-05
+TXN_6342161,Salad,5,5.0,25.0,ERROR,Takeaway,2023-01-08
+TXN_8914892,UNKNOWN,5,5.0,25.0,Digital Wallet,,2023-03-15
+TXN_3363746,Smoothie,3,4.0,12.0,Credit Card,,2023-11-25
+TXN_8614868,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-12-05
+TXN_5522862,Cookie,ERROR,1.0,2.0,Credit Card,Takeaway,2023-03-19
+TXN_3578141,Cake,5,,15.0,,Takeaway,2023-06-27
+TXN_2080895,Cake,UNKNOWN,3.0,3.0,Digital Wallet,In-store,2023-04-19
+TXN_6421134,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-11-03
+TXN_8813311,Juice,5,3.0,15.0,,In-store,2023-10-07
+TXN_9023317,Salad,1,5.0,5.0,,,2023-09-30
+TXN_8051289,,1,3.0,3.0,,In-store,2023-10-09
+TXN_2537617,Sandwich,1,4.0,4.0,Cash,,2023-05-27
+TXN_9099694,UNKNOWN,3,5.0,15.0,,Takeaway,2023-11-18
+TXN_9230615,Smoothie,4,4.0,16.0,Digital Wallet,,2023-06-01
+TXN_4987129,Sandwich,3,,,,In-store,2023-10-20
+TXN_8501819,Juice,,3.0,6.0,Cash,,2023-03-30
+TXN_3068204,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-10-03
+TXN_8427104,Salad,2,ERROR,10.0,,In-store,2023-10-27
+TXN_8471743,ERROR,5,3.0,15.0,Digital Wallet,In-store,2023-04-06
+TXN_2621580,Tea,2,1.5,3.0,Cash,In-store,2023-03-22
+TXN_4726376,Cake,2,3.0,6.0,Credit Card,In-store,2023-01-31
+TXN_6044979,,1,1.0,1.0,Cash,In-store,2023-12-08
+TXN_4238417,Salad,2,5.0,10.0,,ERROR,2023-06-19
+TXN_1900620,Smoothie,2,4.0,8.0,Credit Card,ERROR,2023-12-14
+TXN_6420335,Coffee,1,2.0,2.0,Cash,Takeaway,2023-07-16
+TXN_3858209,Sandwich,4,4.0,16.0,Cash,,2023-02-22
+TXN_2091733,Salad,1,5.0,5.0,,In-store,
+TXN_8735480,Tea,5,1.5,7.5,Cash,,2023-06-02
+TXN_3829165,Juice,4,3.0,12.0,Cash,In-store,2023-06-15
+TXN_3748616,Coffee,2,2.0,4.0,Credit Card,In-store,2023-12-09
+TXN_1993289,Sandwich,2,4.0,8.0,,In-store,2023-04-18
+TXN_2123367,Cookie,2,1.0,2.0,,,2023-11-07
+TXN_5266394,Cake,3,3.0,9.0,Cash,In-store,2023-10-28
+TXN_5107946,Cake,4,3.0,12.0,Credit Card,,2023-12-22
+TXN_8035512,Tea,3,,4.5,Cash,UNKNOWN,2023-10-29
+TXN_8718498,Cake,5,3.0,15.0,Credit Card,ERROR,2023-04-30
+TXN_3955361,Cookie,5,1.0,5.0,,Takeaway,2023-04-02
+TXN_9487821,ERROR,1,5.0,5.0,Digital Wallet,Takeaway,2023-05-24
+TXN_4132730,,5,1.0,5.0,,In-store,2023-03-12
+TXN_8976658,Tea,2,1.5,3.0,Credit Card,In-store,2023-08-16
+TXN_5455936,UNKNOWN,5,3.0,15.0,,In-store,2023-10-28
+TXN_2725602,Juice,5,3.0,15.0,Credit Card,,2023-09-10
+TXN_3011323,Coffee,3,2.0,6.0,Credit Card,,2023-03-07
+TXN_6289610,Juice,3,3.0,UNKNOWN,Cash,Takeaway,2023-08-07
+TXN_8268061,Salad,3,5.0,15.0,ERROR,Takeaway,2023-08-20
+TXN_5220895,Salad,5,5.0,25.0,Cash,In-store,2023-06-10
+TXN_3085509,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-04-15
+TXN_9999113,Juice,4,3.0,12.0,Cash,Takeaway,2023-05-27
+TXN_8779771,Coffee,4,2.0,8.0,Cash,In-store,2023-07-25
+TXN_9517146,,5,5.0,25.0,Cash,Takeaway,2023-10-30
+TXN_1621920,Salad,3,5.0,15.0,,Takeaway,2023-10-28
+TXN_3808639,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-12-15
+TXN_7028009,Cake,4,3.0,12.0,,Takeaway,ERROR
+TXN_7447872,Juice,2,,6.0,,,
+TXN_6955416,Salad,4,5.0,20.0,ERROR,In-store,2023-02-25
+TXN_3775339,Cookie,3,1.0,3.0,Credit Card,UNKNOWN,2023-04-03
+TXN_9547091,Cookie,3,1.0,3.0,Credit Card,,2023-10-08
+TXN_4358673,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-12-28
+TXN_4174591,Tea,4,1.5,6.0,Digital Wallet,,2023-08-30
+TXN_3398520,Sandwich,1,4.0,4.0,,In-store,2023-02-03
+TXN_6171384,Smoothie,2,4.0,8.0,Credit Card,,2023-09-12
+TXN_2530938,Smoothie,5,4.0,20.0,,Takeaway,2023-04-27
+TXN_3314971,Juice,3,3.0,9.0,Digital Wallet,,2023-05-04
+TXN_3092382,Coffee,5,2.0,10.0,Digital Wallet,,2023-02-21
+TXN_1001832,Salad,2,5.0,10.0,Cash,Takeaway,UNKNOWN
+TXN_1535311,Juice,3,3.0,9.0,Cash,,2023-03-16
+TXN_2148617,Juice,ERROR,3.0,9.0,Digital Wallet,UNKNOWN,2023-01-10
+TXN_4633784,ERROR,5,,15.0,,In-store,2023-02-06
+TXN_4368416,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-02-24
+TXN_9790731,Cake,2,3.0,6.0,UNKNOWN,,2023-06-02
+TXN_9339456,Coffee,3,2.0,6.0,,Takeaway,2023-03-29
+TXN_5179020,Cake,2,3.0,6.0,,Takeaway,2023-06-18
+TXN_6258471,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-09-23
+TXN_7945375,Juice,3,3.0,9.0,,,2023-01-14
+TXN_4685453,Tea,4,1.5,6.0,Cash,In-store,2023-09-14
+TXN_9646452,Juice,5,3.0,15.0,Credit Card,,2023-09-16
+TXN_9096052,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-12-28
+TXN_5916991,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-02-06
+TXN_3407169,Sandwich,2,4.0,8.0,Cash,In-store,2023-03-11
+TXN_2277042,Tea,1,1.5,1.5,Cash,,2023-04-08
+TXN_9273729,Tea,1,1.5,1.5,,,2023-12-19
+TXN_2181545,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-07-14
+TXN_1150033,Juice,5,3.0,15.0,Cash,In-store,2023-04-18
+TXN_1443912,Juice,2,3.0,6.0,,,2023-06-08
+TXN_8700451,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-12-12
+TXN_6380550,Coffee,5,2.0,10.0,Cash,In-store,2023-01-05
+TXN_4885518,Salad,3,5.0,15.0,Credit Card,In-store,2023-06-10
+TXN_3972167,Sandwich,5,4.0,20.0,,In-store,2023-01-23
+TXN_4878378,Tea,1,1.5,1.5,Credit Card,,2023-02-20
+TXN_2484241,Cake,3,UNKNOWN,9.0,Digital Wallet,,2023-07-19
+TXN_2368126,Cake,5,3.0,15.0,,In-store,2023-12-06
+TXN_7943008,Coffee,1,2.0,2.0,Credit Card,,ERROR
+TXN_8495063,Juice,1,3.0,UNKNOWN,Cash,,2023-05-31
+TXN_4811133,Salad,2,5.0,10.0,Cash,,2023-08-11
+TXN_8729570,Tea,5,1.5,7.5,UNKNOWN,In-store,2023-09-03
+TXN_7623634,Cake,2,3.0,,Credit Card,In-store,2023-07-11
+TXN_9336980,Salad,4,UNKNOWN,20.0,Cash,In-store,2023-06-06
+TXN_3424331,Cake,4,3.0,12.0,,,2023-01-18
+TXN_5072031,Cake,2,3.0,6.0,Cash,Takeaway,2023-03-23
+TXN_8687151,Salad,5,5.0,25.0,Cash,,2023-06-10
+TXN_4031509,,4,,16.0,Credit Card,Takeaway,2023-01-04
+TXN_5265095,Coffee,1,2.0,2.0,ERROR,,2023-06-23
+TXN_6541415,UNKNOWN,UNKNOWN,3.0,12.0,Cash,In-store,2023-11-25
+TXN_4108138,Coffee,5,2.0,10.0,Cash,,2023-08-03
+TXN_1909796,Smoothie,2,4.0,8.0,,Takeaway,2023-07-12
+TXN_1928241,Coffee,3,2.0,6.0,Cash,In-store,2023-04-30
+TXN_4283157,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-11-25
+TXN_8013032,Coffee,2,2.0,4.0,Credit Card,,2023-03-07
+TXN_8301424,Juice,2,3.0,6.0,,ERROR,2023-06-27
+TXN_1093800,Sandwich,3,4.0,12.0,Cash,Takeaway,
+TXN_7965998,Juice,1,UNKNOWN,3.0,Credit Card,In-store,2023-11-02
+TXN_9238666,Cookie,1,UNKNOWN,1.0,ERROR,Takeaway,2023-07-31
+TXN_1631695,Tea,2,1.5,3.0,,In-store,2023-09-19
+TXN_1435086,Cake,5,,15.0,,ERROR,2023-02-09
+TXN_3226832,UNKNOWN,5,4.0,20.0,Cash,UNKNOWN,2023-09-04
+TXN_1648671,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-05-21
+TXN_4062737,Cake,3,3.0,9.0,Cash,In-store,2023-07-02
+TXN_3494565,,2,4.0,8.0,ERROR,,2023-07-10
+TXN_9249507,Cookie,4,1.0,4.0,Credit Card,In-store,2023-11-21
+TXN_4689500,Sandwich,4,4.0,16.0,,,2023-12-02
+TXN_8989148,Tea,2,1.5,,,,2023-11-25
+TXN_8316826,Coffee,3,2.0,6.0,,In-store,2023-04-17
+TXN_9836934,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-03-13
+TXN_8005489,Cake,3,3.0,9.0,,In-store,2023-08-12
+TXN_6463132,Cookie,5,1.0,5.0,Credit Card,Takeaway,
+TXN_3925836,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-02-16
+TXN_1896955,Salad,ERROR,5.0,25.0,,In-store,2023-09-23
+TXN_5075974,Smoothie,ERROR,4.0,16.0,Digital Wallet,,2023-04-11
+TXN_3978874,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-03-13
+TXN_8955912,Sandwich,1,4.0,4.0,,,2023-11-07
+TXN_1136554,Smoothie,3,4.0,12.0,UNKNOWN,Takeaway,2023-03-26
+TXN_8007337,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-11-01
+TXN_8129834,Salad,1,5.0,5.0,Cash,,2023-07-22
+TXN_3831848,UNKNOWN,1,4.0,4.0,Digital Wallet,Takeaway,2023-11-03
+TXN_5365809,Cake,3,3.0,9.0,Cash,In-store,2023-09-14
+TXN_8166407,Smoothie,2,,8.0,,,2023-07-26
+TXN_6629480,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-02-28
+TXN_3833797,Coffee,4,2.0,8.0,UNKNOWN,In-store,2023-01-27
+TXN_2643815,Cookie,UNKNOWN,1.0,3.0,ERROR,,2023-12-06
+TXN_2996519,Cake,5,3.0,15.0,Cash,,2023-01-19
+TXN_8810894,Smoothie,1,4.0,4.0,,,2023-02-20
+TXN_7412722,Juice,4,3.0,12.0,Cash,In-store,2023-04-07
+TXN_3937509,Smoothie,2,4.0,8.0,,In-store,2023-03-20
+TXN_6000201,Cookie,3,1.0,3.0,Cash,Takeaway,2023-02-16
+TXN_1714274,Cookie,4,1.0,4.0,,In-store,2023-12-27
+TXN_3800182,Tea,2,ERROR,3.0,Cash,In-store,2023-10-26
+TXN_5115080,,5,3.0,15.0,Credit Card,,2023-02-18
+TXN_9788956,Juice,ERROR,3.0,12.0,ERROR,,2023-04-11
+TXN_6311602,Juice,3,3.0,9.0,Credit Card,,2023-05-15
+TXN_2950680,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-12-10
+TXN_6749847,Cake,2,3.0,6.0,Credit Card,,2023-08-15
+TXN_2143187,Smoothie,1,4.0,4.0,,In-store,2023-04-21
+TXN_8964522,,3,3.0,9.0,Credit Card,Takeaway,2023-10-28
+TXN_4088917,Coffee,3,2.0,6.0,Cash,Takeaway,2023-02-04
+TXN_3779366,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-04-15
+TXN_7724048,Smoothie,1,4.0,4.0,ERROR,In-store,2023-11-12
+TXN_2698591,Tea,5,1.5,7.5,,,2023-08-05
+TXN_3171373,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-05-10
+TXN_4129248,Sandwich,2,4.0,8.0,Credit Card,,ERROR
+TXN_6498163,Smoothie,5,4.0,20.0,,In-store,2023-07-15
+TXN_6717827,ERROR,3,5.0,15.0,Digital Wallet,,2023-11-15
+TXN_9089898,Salad,3,ERROR,15.0,Credit Card,,2023-01-11
+TXN_8587583,Cake,1,ERROR,3.0,,,2023-10-01
+TXN_8693704,Salad,ERROR,5.0,25.0,Cash,In-store,2023-05-04
+TXN_3857960,Salad,4,5.0,20.0,Cash,In-store,2023-04-26
+TXN_3499124,ERROR,4,4.0,16.0,Credit Card,,2023-08-25
+TXN_9250710,Salad,1,5.0,5.0,Cash,In-store,2023-05-28
+TXN_7058377,Juice,1,3.0,3.0,,Takeaway,2023-04-30
+TXN_6766492,Salad,1,5.0,5.0,,ERROR,2023-01-14
+TXN_9879996,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-03-01
+TXN_4291940,Cake,3,3.0,9.0,Credit Card,In-store,2023-11-13
+TXN_7433461,Cookie,2,1.0,2.0,Digital Wallet,,2023-07-09
+TXN_4068262,Salad,2,5.0,10.0,Credit Card,,2023-05-13
+TXN_5761073,Cookie,1,1.0,1.0,Cash,In-store,UNKNOWN
+TXN_5047447,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-12-27
+TXN_6623508,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-05-18
+TXN_2651216,UNKNOWN,3,4.0,12.0,,,2023-04-04
+TXN_9350833,Cake,1,UNKNOWN,3.0,Cash,Takeaway,2023-01-17
+TXN_8377564,Cake,5,3.0,15.0,,In-store,2023-07-14
+TXN_7031118,Salad,1,5.0,5.0,Credit Card,ERROR,2023-03-29
+TXN_2230167,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-09-22
+TXN_6446616,Tea,3,1.5,4.5,ERROR,,2023-09-30
+TXN_1721827,Cake,4,3.0,12.0,Digital Wallet,ERROR,2023-08-22
+TXN_6334895,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-07-27
+TXN_7077119,ERROR,1,4.0,4.0,Digital Wallet,In-store,2023-12-30
+TXN_8562645,Salad,ERROR,5.0,UNKNOWN,,In-store,2023-05-18
+TXN_4700144,Coffee,4,2.0,8.0,,In-store,2023-12-21
+TXN_5526852,Sandwich,5,4.0,,Digital Wallet,In-store,2023-09-28
+TXN_6846228,Salad,3,,15.0,,In-store,2023-11-16
+TXN_8570890,Juice,4,3.0,12.0,,,2023-04-14
+TXN_3205009,ERROR,2,1.5,3.0,Cash,In-store,2023-01-03
+TXN_3786188,Tea,3,1.5,4.5,Credit Card,In-store,2023-10-20
+TXN_4530804,Coffee,4,2.0,8.0,,,2023-01-12
+TXN_9642066,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-08-31
+TXN_7328294,Juice,2,3.0,6.0,Cash,,2023-07-07
+TXN_1908636,Tea,2,1.5,3.0,,UNKNOWN,
+TXN_9238066,,5,1.5,7.5,Digital Wallet,In-store,2023-09-15
+TXN_5415901,Cake,2,3.0,6.0,Digital Wallet,,2023-10-21
+TXN_6714420,ERROR,2,3.0,6.0,Credit Card,Takeaway,2023-03-30
+TXN_6616971,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-09-02
+TXN_7803615,Salad,3,5.0,15.0,Cash,In-store,2023-12-13
+TXN_7549542,Cookie,5,1.0,5.0,,Takeaway,
+TXN_3544789,Tea,4,1.5,ERROR,UNKNOWN,In-store,2023-07-14
+TXN_1583597,Salad,1,5.0,5.0,Cash,In-store,2023-05-10
+TXN_8472308,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-08-19
+TXN_1967565,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-03-31
+TXN_2029497,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-01-06
+TXN_8929774,ERROR,3,3.0,9.0,Cash,,2023-10-02
+TXN_5003018,Cookie,4,1.0,UNKNOWN,Digital Wallet,,UNKNOWN
+TXN_7852990,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-07-10
+TXN_2534066,Salad,2,5.0,10.0,Cash,,2023-10-13
+TXN_2059647,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-05-29
+TXN_2485183,Smoothie,5,4.0,20.0,Cash,In-store,2023-07-07
+TXN_7374846,Sandwich,1,4.0,4.0,Credit Card,UNKNOWN,2023-05-29
+TXN_9401522,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-11-16
+TXN_8250651,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-03-13
+TXN_7191245,Cake,4,3.0,12.0,,Takeaway,2023-05-22
+TXN_8982764,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-11-23
+TXN_8669422,,4,3.0,12.0,Cash,Takeaway,2023-10-15
+TXN_1153869,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-11-03
+TXN_5043774,Sandwich,3,4.0,12.0,Cash,,2023-06-08
+TXN_1746320,Salad,1,5.0,5.0,Cash,,2023-11-14
+TXN_1077129,Cookie,1,1.0,1.0,,In-store,2023-09-12
+TXN_4865338,Sandwich,UNKNOWN,4.0,16.0,,In-store,2023-11-26
+TXN_5616583,Smoothie,1,4.0,4.0,,,2023-10-13
+TXN_2078474,Cookie,2,1.0,2.0,,Takeaway,2023-11-03
+TXN_2130245,Smoothie,5,4.0,20.0,Credit Card,,2023-11-13
+TXN_3229409,Juice,UNKNOWN,3.0,UNKNOWN,Cash,Takeaway,2023-04-15
+TXN_9076216,Cake,1,3.0,3.0,Cash,,2023-12-17
+TXN_6371987,Tea,5,1.5,ERROR,UNKNOWN,Takeaway,2023-03-13
+TXN_9913877,ERROR,2,2.0,4.0,Credit Card,,2023-05-09
+TXN_2084377,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-10-22
+TXN_1842675,ERROR,4,1.0,4.0,Credit Card,Takeaway,2023-06-23
+TXN_8605813,Cookie,1,1.0,1.0,,,2023-06-30
+TXN_9755352,Sandwich,5,4.0,20.0,,In-store,2023-05-13
+TXN_7550498,Juice,5,3.0,15.0,,In-store,ERROR
+TXN_2305908,Coffee,UNKNOWN,2.0,8.0,Cash,,2023-04-25
+TXN_6953697,UNKNOWN,3,4.0,12.0,,Takeaway,2023-05-27
+TXN_3495950,,4,ERROR,6.0,Credit Card,In-store,2023-02-19
+TXN_7557340,Tea,5,1.5,7.5,Credit Card,In-store,2023-12-11
+TXN_1157817,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-04-25
+TXN_2020318,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-10-12
+TXN_8692094,Coffee,5,2.0,10.0,,Takeaway,2023-08-30
+TXN_5307411,Cake,3,3.0,ERROR,Digital Wallet,Takeaway,2023-10-21
+TXN_9703120,Coffee,3,2.0,6.0,Credit Card,,2023-11-02
+TXN_1289133,Juice,1,3.0,3.0,Cash,UNKNOWN,2023-09-19
+TXN_2031459,Cake,3,3.0,9.0,Cash,Takeaway,2023-07-04
+TXN_1333682,Smoothie,1,4.0,4.0,Digital Wallet,,2023-01-28
+TXN_2256622,Cookie,2,,2.0,Cash,In-store,2023-10-04
+TXN_1623966,Tea,2,1.5,3.0,Cash,Takeaway,UNKNOWN
+TXN_4912930,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-02-26
+TXN_4942692,Coffee,2,2.0,4.0,,Takeaway,2023-01-15
+TXN_3723007,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-05-18
+TXN_7922392,Sandwich,3,4.0,12.0,,,2023-05-03
+TXN_7498727,Salad,3,5.0,15.0,Cash,,2023-11-06
+TXN_1222338,Cookie,1,1.0,1.0,,In-store,2023-10-11
+TXN_6878866,Smoothie,3,4.0,12.0,Credit Card,,2023-02-25
+TXN_1260335,Cookie,4,1.0,4.0,Digital Wallet,In-store,
+TXN_9223242,Smoothie,2,4.0,8.0,,,2023-09-10
+TXN_6244211,Smoothie,2,4.0,8.0,,,2023-08-11
+TXN_5446858,,1,1.0,1.0,Cash,In-store,2023-11-07
+TXN_4612864,Tea,3,1.5,4.5,,,2023-02-14
+TXN_5411381,Cookie,ERROR,1.0,1.0,,,2023-04-28
+TXN_3047598,Cookie,1,1.0,1.0,,,2023-09-06
+TXN_5754317,Coffee,2,,4.0,Credit Card,Takeaway,2023-01-10
+TXN_7496926,Sandwich,3,4.0,12.0,ERROR,In-store,2023-04-23
+TXN_1726858,Smoothie,3,4.0,12.0,Cash,In-store,
+TXN_7559388,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-02-26
+TXN_8540499,Cookie,3,1.0,3.0,Cash,In-store,2023-01-22
+TXN_4225756,Cookie,3,1.0,3.0,,In-store,2023-03-10
+TXN_6795640,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-01-28
+TXN_6702428,Coffee,5,2.0,10.0,Cash,Takeaway,2023-08-11
+TXN_8955259,ERROR,2,4.0,8.0,Credit Card,,2023-11-18
+TXN_4639319,Coffee,5,2.0,10.0,Cash,,2023-01-09
+TXN_5997803,Coffee,5,2.0,10.0,,In-store,2023-12-03
+TXN_1340956,ERROR,4,2.0,8.0,,,2023-10-26
+TXN_1259671,Sandwich,UNKNOWN,4.0,12.0,Digital Wallet,In-store,2023-10-08
+TXN_8319993,Juice,1,3.0,3.0,Digital Wallet,,2023-08-06
+TXN_8894157,Sandwich,4,4.0,16.0,Credit Card,,ERROR
+TXN_5523450,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-07-02
+TXN_7838964,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-06-15
+TXN_2773987,Smoothie,5,4.0,20.0,ERROR,,2023-01-11
+TXN_1158829,Tea,1,UNKNOWN,1.5,Credit Card,,2023-10-02
+TXN_2523298,,4,,6.0,ERROR,In-store,2023-03-25
+TXN_8685737,Smoothie,2,4.0,8.0,,In-store,2023-11-02
+TXN_5634135,Cookie,2,UNKNOWN,2.0,,ERROR,2023-01-27
+TXN_1524626,Smoothie,2,4.0,8.0,Digital Wallet,,2023-12-29
+TXN_7275407,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-10-20
+TXN_2889622,Juice,4,3.0,12.0,Credit Card,,2023-11-01
+TXN_6849113,Cookie,ERROR,1.0,1.0,Credit Card,,2023-07-14
+TXN_2265316,Cookie,,1.0,3.0,Credit Card,In-store,2023-12-29
+TXN_9472241,Salad,3,5.0,15.0,Cash,Takeaway,2023-06-30
+TXN_7345414,Salad,1,,5.0,,UNKNOWN,2023-02-15
+TXN_4473352,Cake,1,3.0,3.0,UNKNOWN,In-store,2023-11-16
+TXN_2814363,Tea,2,1.5,3.0,,,2023-07-02
+TXN_1846004,Juice,3,3.0,9.0,Cash,In-store,2023-05-21
+TXN_7140471,Cake,1,3.0,3.0,Credit Card,,2023-05-25
+TXN_3119542,Smoothie,1,4.0,4.0,Credit Card,,2023-10-31
+TXN_7773968,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-02-24
+TXN_9081088,Tea,2,1.5,3.0,Cash,Takeaway,2023-02-27
+TXN_8559167,Sandwich,5,4.0,UNKNOWN,UNKNOWN,Takeaway,2023-12-09
+TXN_1130191,Smoothie,2,4.0,8.0,Cash,In-store,2023-04-06
+TXN_5215451,Sandwich,5,4.0,20.0,Digital Wallet,,2023-11-02
+TXN_1040764,Coffee,3,2.0,6.0,Cash,Takeaway,2023-07-27
+TXN_5457133,Juice,5,3.0,15.0,ERROR,In-store,2023-03-03
+TXN_8365478,,3,4.0,12.0,Cash,Takeaway,2023-02-06
+TXN_2100697,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-09-19
+TXN_7676968,Smoothie,4,4.0,16.0,UNKNOWN,In-store,2023-02-21
+TXN_5726998,Cake,3,3.0,9.0,Credit Card,,2023-08-12
+TXN_4134594,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-09-27
+TXN_5079340,Cookie,4,1.0,4.0,Cash,In-store,2023-08-18
+TXN_8276635,,4,4.0,16.0,Digital Wallet,Takeaway,2023-12-16
+TXN_1380601,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-03-11
+TXN_3959152,Juice,1,3.0,3.0,,In-store,2023-05-21
+TXN_7776739,Tea,2,1.5,3.0,,Takeaway,2023-02-23
+TXN_7569615,ERROR,2,3.0,6.0,Cash,Takeaway,2023-06-07
+TXN_8703771,Cake,5,3.0,15.0,,In-store,2023-05-12
+TXN_2052395,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-07-06
+TXN_9421441,,2,4.0,8.0,Cash,,2023-06-20
+TXN_9065402,UNKNOWN,1,5.0,5.0,Cash,Takeaway,2023-12-22
+TXN_3638955,Cookie,2,,2.0,Cash,Takeaway,2023-09-02
+TXN_2635532,ERROR,4,4.0,16.0,Cash,Takeaway,2023-01-14
+TXN_8256593,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-08-09
+TXN_9271457,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-02-27
+TXN_5392603,Coffee,1,2.0,2.0,Cash,In-store,2023-05-14
+TXN_6319728,Coffee,,2.0,4.0,Credit Card,In-store,2023-07-18
+TXN_9263299,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-10-08
+TXN_2301505,Cake,5,3.0,15.0,Digital Wallet,,2023-03-21
+TXN_5895177,Cake,5,3.0,15.0,,,2023-08-16
+TXN_8751516,Tea,3,1.5,4.5,Cash,Takeaway,
+TXN_8147357,Tea,5,1.5,7.5,,Takeaway,2023-04-20
+TXN_1436343,Cookie,1,1.0,1.0,Credit Card,In-store,2023-11-26
+TXN_2214698,Salad,4,5.0,20.0,Credit Card,,2023-10-10
+TXN_7480234,Salad,1,5.0,5.0,Cash,Takeaway,2023-05-10
+TXN_3283097,ERROR,5,2.0,10.0,Cash,Takeaway,2023-02-28
+TXN_2633602,UNKNOWN,2,3.0,6.0,Digital Wallet,In-store,2023-02-02
+TXN_3093219,Juice,5,3.0,UNKNOWN,Cash,,2023-01-28
+TXN_3515730,,1,1.0,1.0,Credit Card,,2023-08-14
+TXN_3665733,Coffee,5,2.0,10.0,Cash,Takeaway,UNKNOWN
+TXN_4010658,Tea,5,1.5,7.5,,,2023-09-26
+TXN_1454467,Juice,3,3.0,9.0,Cash,In-store,2023-03-15
+TXN_2598728,Cake,2,3.0,6.0,Credit Card,,2023-01-13
+TXN_3390285,Tea,2,1.5,3.0,,Takeaway,2023-02-06
+TXN_8224079,Cookie,5,1.0,5.0,Cash,In-store,2023-10-16
+TXN_1916339,Cake,1,3.0,3.0,Cash,In-store,2023-07-15
+TXN_8611035,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-05-28
+TXN_3595735,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-03-26
+TXN_4884822,Cookie,1,1.0,1.0,Credit Card,,2023-04-23
+TXN_3668051,Cake,1,3.0,3.0,UNKNOWN,UNKNOWN,2023-11-17
+TXN_6169633,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-12-20
+TXN_3884811,Coffee,4,2.0,8.0,Credit Card,,2023-06-10
+TXN_7050740,ERROR,1,3.0,3.0,Cash,Takeaway,2023-07-12
+TXN_1234097,Cookie,4,,4.0,Cash,,2023-12-04
+TXN_4518102,Tea,5,1.5,7.5,Credit Card,In-store,2023-02-08
+TXN_5939055,Coffee,3,2.0,UNKNOWN,ERROR,Takeaway,2023-10-21
+TXN_7809183,ERROR,4,1.0,4.0,Digital Wallet,Takeaway,2023-09-08
+TXN_6071202,ERROR,1,1.0,1.0,Cash,In-store,2023-06-07
+TXN_8158496,Tea,4,1.5,6.0,Cash,,2023-06-19
+TXN_2726848,Cake,5,3.0,ERROR,Credit Card,,2023-09-11
+TXN_3666858,Cake,4,3.0,12.0,Credit Card,In-store,2023-12-27
+TXN_5499915,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-02-01
+TXN_4660753,Juice,,3.0,3.0,Credit Card,Takeaway,2023-10-04
+TXN_8089522,Sandwich,4,ERROR,16.0,Cash,Takeaway,2023-02-12
+TXN_1564754,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-03-14
+TXN_1824506,Cake,1,3.0,3.0,Cash,In-store,2023-03-02
+TXN_3229758,Coffee,4,2.0,8.0,Cash,Takeaway,UNKNOWN
+TXN_3677592,Sandwich,2,4.0,8.0,Cash,,2023-05-29
+TXN_1002457,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-09-29
+TXN_8056263,Smoothie,5,4.0,20.0,,In-store,2023-04-20
+TXN_4732351,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-04-22
+TXN_8049191,Cake,3,3.0,9.0,Credit Card,ERROR,2023-07-31
+TXN_4980036,Cake,2,3.0,6.0,Cash,Takeaway,2023-01-05
+TXN_3022839,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-08-25
+TXN_7701070,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-07-28
+TXN_8048037,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-03-31
+TXN_4619029,Sandwich,3,4.0,12.0,Credit Card,In-store,
+TXN_4444463,Cake,4,3.0,12.0,ERROR,,2023-05-16
+TXN_1887522,Sandwich,4,4.0,16.0,Cash,In-store,2023-02-20
+TXN_6908953,Tea,1,1.5,1.5,,In-store,2023-12-08
+TXN_4759769,Sandwich,1,4.0,4.0,,In-store,2023-08-03
+TXN_2254479,Tea,2,1.5,3.0,,Takeaway,2023-08-03
+TXN_7555408,Salad,2,5.0,10.0,UNKNOWN,In-store,2023-06-06
+TXN_6857943,Cake,5,3.0,15.0,,Takeaway,2023-01-08
+TXN_4796350,ERROR,ERROR,4.0,12.0,,Takeaway,UNKNOWN
+TXN_9552845,Sandwich,3,4.0,12.0,Cash,ERROR,2023-02-18
+TXN_6769465,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-06-13
+TXN_7438831,Coffee,5,ERROR,10.0,ERROR,,2023-12-24
+TXN_3871837,Tea,UNKNOWN,1.5,4.5,Digital Wallet,Takeaway,2023-12-15
+TXN_3656762,Sandwich,2,4.0,8.0,,Takeaway,2023-07-31
+TXN_4980282,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-10-22
+TXN_3580786,Tea,1,ERROR,1.5,UNKNOWN,In-store,2023-03-28
+TXN_4355728,,4,3.0,12.0,Credit Card,,2023-03-06
+TXN_2508476,Smoothie,5,4.0,20.0,Cash,ERROR,2023-04-14
+TXN_1325631,Cake,4,UNKNOWN,12.0,Credit Card,In-store,2023-02-11
+TXN_8209125,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-01-30
+TXN_1751164,Salad,2,5.0,10.0,Cash,,2023-09-11
+TXN_3730415,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-04-09
+TXN_4134253,Tea,4,1.5,6.0,Cash,In-store,2023-10-07
+TXN_3256497,Coffee,2,2.0,4.0,Cash,UNKNOWN,2023-08-20
+TXN_8763180,Smoothie,1,4.0,,,Takeaway,2023-04-16
+TXN_3219175,Sandwich,5,4.0,20.0,,ERROR,2023-02-23
+TXN_6234872,Smoothie,1,4.0,ERROR,,ERROR,2023-12-23
+TXN_7919440,Tea,4,1.5,6.0,Cash,UNKNOWN,2023-08-19
+TXN_7558641,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-12-22
+TXN_9940220,Juice,2,3.0,6.0,,Takeaway,2023-03-05
+TXN_8805984,Juice,2,3.0,6.0,Credit Card,Takeaway,
+TXN_2130483,Tea,4,1.5,6.0,Cash,,2023-11-25
+TXN_1972584,Sandwich,5,4.0,20.0,Digital Wallet,,2023-07-10
+TXN_3150792,Coffee,5,2.0,,Cash,,2023-07-02
+TXN_2980008,Cake,3,3.0,9.0,Digital Wallet,,2023-11-17
+TXN_5511805,Juice,1,3.0,UNKNOWN,,Takeaway,2023-06-03
+TXN_7292548,Cookie,4,1.0,4.0,Digital Wallet,,2023-03-24
+TXN_2169664,Smoothie,1,4.0,4.0,Cash,,2023-07-23
+TXN_3234877,Coffee,4,2.0,8.0,Cash,Takeaway,2023-07-29
+TXN_6368719,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-01-03
+TXN_8852585,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-01-05
+TXN_9201010,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-03-15
+TXN_7817014,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,ERROR
+TXN_2873990,Sandwich,2,4.0,8.0,,,2023-03-12
+TXN_3088796,Sandwich,4,4.0,16.0,Credit Card,,2023-08-16
+TXN_3414935,Coffee,4,2.0,8.0,,In-store,2023-08-03
+TXN_3607652,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-06-05
+TXN_8502094,Juice,5,3.0,15.0,Credit Card,In-store,2023-03-21
+TXN_9068244,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-10-19
+TXN_2696664,Cookie,5,1.0,5.0,,In-store,2023-01-07
+TXN_7661609,ERROR,1,3.0,3.0,,In-store,2023-11-29
+TXN_7633490,Cookie,1,1.0,1.0,Cash,Takeaway,2023-10-27
+TXN_9292230,Tea,4,1.5,6.0,Credit Card,In-store,2023-07-14
+TXN_1664665,ERROR,3,3.0,9.0,Credit Card,In-store,2023-05-21
+TXN_5081978,Cake,1,3.0,3.0,,In-store,2023-10-19
+TXN_7314409,Smoothie,5,4.0,20.0,Credit Card,,2023-08-06
+TXN_4573576,,2,3.0,6.0,Cash,In-store,2023-07-05
+TXN_5645919,Coffee,3,ERROR,6.0,Credit Card,,2023-01-17
+TXN_8006668,Tea,4,1.5,6.0,Credit Card,In-store,2023-12-22
+TXN_8818168,Juice,4,,12.0,Digital Wallet,,2023-07-20
+TXN_4369043,Juice,2,3.0,6.0,Cash,,2023-03-25
+TXN_3560062,Cookie,1,1.0,1.0,Cash,In-store,2023-03-20
+TXN_4769307,Tea,5,1.5,7.5,Digital Wallet,,2023-12-24
+TXN_7270652,Sandwich,1,4.0,4.0,,Takeaway,2023-05-14
+TXN_4991815,Cake,5,3.0,15.0,Cash,,2023-11-06
+TXN_6360132,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-09-16
+TXN_8199829,Cake,2,3.0,6.0,Credit Card,,2023-07-29
+TXN_9166449,ERROR,4,1.0,4.0,,Takeaway,2023-07-31
+TXN_7864939,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-08-19
+TXN_2640701,Salad,3,5.0,15.0,,Takeaway,2023-05-07
+TXN_3740963,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-01-22
+TXN_8101633,Sandwich,2,4.0,8.0,,In-store,2023-08-10
+TXN_6063966,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-10-24
+TXN_3779640,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-05-16
+TXN_8278833,Cake,3,3.0,9.0,,,2023-02-26
+TXN_8778598,Sandwich,3,4.0,12.0,Cash,,2023-09-02
+TXN_7550103,Cake,5,3.0,15.0,,Takeaway,2023-01-19
+TXN_3664656,Cookie,5,1.0,5.0,,Takeaway,2023-08-13
+TXN_7296560,Juice,2,3.0,6.0,,,2023-10-20
+TXN_8136881,Salad,3,5.0,15.0,Cash,In-store,2023-08-28
+TXN_3981449,Smoothie,2,4.0,8.0,Cash,In-store,2023-06-21
+TXN_5427506,Cake,UNKNOWN,3.0,9.0,Cash,Takeaway,2023-09-15
+TXN_2641386,Sandwich,3,4.0,12.0,UNKNOWN,Takeaway,2023-03-25
+TXN_1485417,Cookie,3,1.0,3.0,Cash,In-store,ERROR
+TXN_4033802,Tea,3,1.5,4.5,Cash,Takeaway,2023-03-02
+TXN_7752124,ERROR,3,4.0,12.0,Credit Card,UNKNOWN,2023-12-09
+TXN_9762324,Cake,2,3.0,6.0,Cash,In-store,ERROR
+TXN_1628509,Smoothie,5,4.0,20.0,,Takeaway,UNKNOWN
+TXN_8259257,Tea,UNKNOWN,1.5,3.0,,In-store,2023-12-13
+TXN_4183823,Sandwich,4,4.0,16.0,Credit Card,ERROR,2023-03-28
+TXN_2239041,ERROR,4,1.5,6.0,,In-store,2023-10-24
+TXN_4696439,Cookie,1,1.0,1.0,Cash,In-store,2023-05-27
+TXN_8826983,Smoothie,5,4.0,20.0,Cash,In-store,2023-01-14
+TXN_8267034,Juice,2,3.0,6.0,,Takeaway,2023-06-20
+TXN_1959334,Coffee,3,2.0,6.0,,,2023-06-29
+TXN_6842808,Tea,2,1.5,3.0,,UNKNOWN,2023-10-22
+TXN_2947822,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-10-27
+TXN_5531712,,2,1.5,3.0,Cash,UNKNOWN,2023-01-09
+TXN_2148838,Sandwich,2,4.0,8.0,Credit Card,,2023-08-05
+TXN_1330506,Cookie,3,1.0,3.0,Digital Wallet,UNKNOWN,2023-11-10
+TXN_5898743,Juice,4,3.0,ERROR,,Takeaway,UNKNOWN
+TXN_8957369,Salad,4,5.0,20.0,Digital Wallet,,2023-10-18
+TXN_9340653,Smoothie,1,4.0,4.0,Digital Wallet,,2023-10-19
+TXN_2493446,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-05-19
+TXN_4538354,Juice,3,3.0,9.0,Cash,Takeaway,2023-04-21
+TXN_7098730,Cake,2,3.0,6.0,Digital Wallet,,2023-11-10
+TXN_7533411,Cookie,,1.0,1.0,Digital Wallet,In-store,2023-11-09
+TXN_2690314,Tea,5,1.5,7.5,Cash,In-store,2023-08-10
+TXN_8171171,Coffee,1,2.0,2.0,,Takeaway,2023-05-13
+TXN_3791639,,4,3.0,12.0,Digital Wallet,,ERROR
+TXN_2968827,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-09-14
+TXN_4546375,ERROR,1,5.0,5.0,Credit Card,,2023-02-20
+TXN_1387401,Cookie,4,1.0,4.0,Cash,In-store,2023-10-19
+TXN_6727029,Tea,2,1.5,3.0,,Takeaway,2023-07-07
+TXN_3917193,Juice,5,3.0,15.0,Credit Card,Takeaway,2023-11-17
+TXN_8518516,Sandwich,4,4.0,16.0,,,2023-08-16
+TXN_2062854,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-12-01
+TXN_4075863,Smoothie,3,4.0,ERROR,Cash,Takeaway,2023-05-21
+TXN_5624860,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-08-22
+TXN_4621665,Smoothie,5,,20.0,,,2023-01-17
+TXN_6669417,Salad,5,5.0,25.0,,Takeaway,2023-01-03
+TXN_7837381,Sandwich,5,4.0,20.0,,Takeaway,2023-07-17
+TXN_1725926,Juice,5,3.0,15.0,Credit Card,,2023-12-23
+TXN_3403173,Salad,1,5.0,5.0,,ERROR,2023-06-24
+TXN_4186681,ERROR,4,,6.0,Digital Wallet,,2023-05-24
+TXN_4152036,ERROR,,3.0,6.0,Cash,,UNKNOWN
+TXN_4059912,ERROR,3,4.0,12.0,,,2023-04-21
+TXN_3381656,Cake,5,3.0,15.0,Cash,Takeaway,2023-10-26
+TXN_9956154,Cake,4,3.0,12.0,,In-store,2023-05-11
+TXN_7110444,ERROR,4,5.0,20.0,Cash,,2023-12-07
+TXN_6250692,Sandwich,1,4.0,4.0,UNKNOWN,,2023-09-01
+TXN_1183995,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-03-28
+TXN_9452225,Tea,1,1.5,1.5,ERROR,In-store,2023-02-26
+TXN_9113574,Coffee,4,2.0,8.0,,In-store,2023-01-04
+TXN_5813015,Cookie,5,1.0,5.0,Digital Wallet,UNKNOWN,2023-10-07
+TXN_3213035,Smoothie,4,4.0,16.0,,In-store,2023-05-21
+TXN_3789752,Juice,3,ERROR,9.0,Digital Wallet,Takeaway,2023-12-16
+TXN_7578769,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-01-30
+TXN_3515664,Coffee,2,2.0,4.0,Cash,Takeaway,2023-09-25
+TXN_6209258,Juice,1,3.0,3.0,Credit Card,,2023-03-06
+TXN_8594004,Cookie,4,1.0,4.0,Credit Card,,2023-02-25
+TXN_6422433,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-05-09
+TXN_2865033,Coffee,2,2.0,,Cash,,2023-08-03
+TXN_5547519,Salad,4,5.0,20.0,,In-store,2023-05-13
+TXN_2392263,Salad,5,5.0,25.0,,Takeaway,2023-02-08
+TXN_3810451,Juice,4,3.0,12.0,,ERROR,ERROR
+TXN_4669664,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-12-21
+TXN_9470612,Cake,3,3.0,9.0,,Takeaway,2023-04-30
+TXN_7507962,Smoothie,4,UNKNOWN,16.0,UNKNOWN,,2023-06-22
+TXN_1109715,Cake,1,ERROR,3.0,UNKNOWN,In-store,2023-07-15
+TXN_8320245,Tea,3,1.5,4.5,,Takeaway,2023-04-09
+TXN_5904646,Smoothie,1,4.0,4.0,ERROR,ERROR,2023-03-26
+TXN_4498526,Smoothie,3,4.0,12.0,Credit Card,,2023-06-20
+TXN_2744907,Salad,2,5.0,10.0,Digital Wallet,,UNKNOWN
+TXN_5209585,Tea,2,1.5,3.0,,Takeaway,2023-08-12
+TXN_2213556,Coffee,1,2.0,2.0,Cash,In-store,2023-05-30
+TXN_3826038,Salad,1,5.0,5.0,Cash,Takeaway,2023-10-20
+TXN_7596587,Tea,3,1.5,4.5,Credit Card,,2023-02-08
+TXN_7380277,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-04-24
+TXN_1353479,Smoothie,4,4.0,16.0,Cash,,2023-09-20
+TXN_6054137,Juice,3,3.0,9.0,,In-store,2023-05-09
+TXN_7609853,Sandwich,,4.0,4.0,Digital Wallet,In-store,2023-04-22
+TXN_9266394,Cookie,2,1.0,2.0,Credit Card,In-store,2023-07-12
+TXN_5448157,UNKNOWN,3,1.0,3.0,Credit Card,ERROR,2023-01-11
+TXN_8298311,Tea,2,1.5,3.0,Digital Wallet,In-store,
+TXN_6744866,Tea,4,1.5,6.0,,Takeaway,UNKNOWN
+TXN_6152588,Coffee,3,2.0,6.0,Cash,Takeaway,2023-11-21
+TXN_6569656,UNKNOWN,5,1.0,5.0,Cash,,2023-02-28
+TXN_2156206,Smoothie,2,4.0,8.0,,,2023-02-04
+TXN_3142258,Salad,4,5.0,ERROR,,Takeaway,2023-11-03
+TXN_5739806,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-09-18
+TXN_9228978,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-02-09
+TXN_5897205,Cookie,1,1.0,1.0,,In-store,2023-06-10
+TXN_1556652,Cake,5,3.0,15.0,Digital Wallet,ERROR,2023-04-06
+TXN_8608765,Salad,4,5.0,20.0,Credit Card,,2023-09-02
+TXN_8764825,Smoothie,3,4.0,12.0,Cash,,
+TXN_7353972,UNKNOWN,4,3.0,12.0,Cash,In-store,2023-02-02
+TXN_1124753,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-10-19
+TXN_9410981,Cookie,2,1.0,2.0,,Takeaway,2023-02-07
+TXN_9349962,,4,4.0,16.0,,In-store,UNKNOWN
+TXN_7611120,Juice,2,3.0,6.0,Cash,Takeaway,2023-03-30
+TXN_2106959,Sandwich,5,4.0,20.0,Digital Wallet,UNKNOWN,2023-09-05
+TXN_2237115,Coffee,1,2.0,2.0,,Takeaway,2023-01-13
+TXN_6836137,Cake,4,3.0,12.0,,In-store,2023-08-30
+TXN_6316959,Tea,2,1.5,3.0,Cash,In-store,2023-11-10
+TXN_2265984,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-10-18
+TXN_6352917,Salad,5,5.0,UNKNOWN,Cash,UNKNOWN,2023-05-05
+TXN_9564123,Cake,4,3.0,12.0,Credit Card,,2023-03-23
+TXN_3946544,Cake,5,3.0,15.0,Credit Card,,
+TXN_1123138,Salad,1,5.0,5.0,Cash,In-store,2023-02-10
+TXN_9212503,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-10-08
+TXN_1921262,Sandwich,,4.0,8.0,ERROR,ERROR,2023-11-24
+TXN_1259824,Cookie,,1.0,5.0,Digital Wallet,Takeaway,2023-04-29
+TXN_6868049,Juice,5,3.0,15.0,Digital Wallet,,UNKNOWN
+TXN_2806243,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-01-14
+TXN_9759896,Tea,4,1.5,6.0,,UNKNOWN,2023-12-02
+TXN_7560807,Salad,2,5.0,10.0,Credit Card,,2023-04-16
+TXN_3286932,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-07-11
+TXN_3481470,Salad,4,5.0,20.0,Credit Card,In-store,2023-12-24
+TXN_9907327,Salad,ERROR,5.0,10.0,Credit Card,ERROR,2023-10-07
+TXN_3469469,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-10-25
+TXN_2681833,UNKNOWN,3,1.0,3.0,Digital Wallet,In-store,2023-10-05
+TXN_3179966,Tea,2,1.5,3.0,Digital Wallet,,2023-05-27
+TXN_9289174,Cake,ERROR,,12.0,Digital Wallet,In-store,2023-12-30
+TXN_3629351,Cake,1,3.0,3.0,Digital Wallet,,2023-07-21
+TXN_3142836,Cake,2,3.0,6.0,Cash,,2023-11-01
+TXN_4998786,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-10-25
+TXN_7228816,Salad,1,ERROR,5.0,,In-store,2023-04-21
+TXN_6904590,Coffee,4,2.0,8.0,Credit Card,,2023-02-19
+TXN_2126408,Cookie,3,1.0,3.0,Cash,Takeaway,2023-10-19
+TXN_8664315,Salad,2,5.0,10.0,Cash,,2023-08-14
+TXN_8958593,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-07-08
+TXN_2383598,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-09-19
+TXN_2211685,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-06-06
+TXN_1503602,Tea,5,1.5,7.5,Digital Wallet,,2023-12-16
+TXN_2962976,Juice,UNKNOWN,3.0,ERROR,,,2023-03-17
+TXN_8716752,Juice,1,3.0,3.0,,In-store,2023-12-05
+TXN_4266787,Juice,4,,12.0,Credit Card,Takeaway,2023-01-12
+TXN_5933480,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-09-04
+TXN_8255965,Juice,,3.0,6.0,,In-store,2023-11-16
+TXN_4364091,Smoothie,1,4.0,4.0,ERROR,Takeaway,2023-04-14
+TXN_9203920,,4,3.0,12.0,,Takeaway,2023-11-01
+TXN_8964812,Salad,4,,20.0,Digital Wallet,,2023-10-14
+TXN_6721531,Tea,4,1.5,6.0,,In-store,2023-03-06
+TXN_5447508,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-06-28
+TXN_5686113,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-09-09
+TXN_9239779,Salad,1,5.0,5.0,Cash,UNKNOWN,2023-01-09
+TXN_9265319,Salad,3,5.0,15.0,Cash,,2023-11-15
+TXN_9265313,Cake,3,3.0,9.0,,In-store,2023-10-01
+TXN_3397609,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-07-22
+TXN_9347203,Sandwich,5,4.0,20.0,Cash,In-store,2023-04-15
+TXN_2132186,Salad,1,5.0,5.0,Credit Card,,2023-02-01
+TXN_3383926,Cake,3,3.0,9.0,Cash,Takeaway,2023-07-08
+TXN_6905718,Salad,5,5.0,25.0,Credit Card,In-store,2023-02-20
+TXN_3130548,Cookie,4,1.0,4.0,,Takeaway,2023-08-21
+TXN_9356512,Salad,,5.0,15.0,Credit Card,,2023-06-06
+TXN_7993951,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-12-14
+TXN_6362093,,3,2.0,6.0,,,2023-03-19
+TXN_4876440,Cookie,3,1.0,3.0,,Takeaway,2023-07-01
+TXN_9323513,Cake,3,3.0,9.0,,Takeaway,2023-05-04
+TXN_9097641,Cake,4,3.0,12.0,Cash,Takeaway,2023-12-16
+TXN_1775884,Juice,4,3.0,12.0,Cash,,2023-10-08
+TXN_8536115,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-07-11
+TXN_8032010,Tea,1,1.5,1.5,Cash,,2023-06-14
+TXN_2915281,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-07-01
+TXN_3468006,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-07-28
+TXN_7604541,Juice,4,3.0,12.0,Credit Card,In-store,2023-04-16
+TXN_7806146,Cake,3,ERROR,9.0,Digital Wallet,In-store,2023-01-30
+TXN_9238689,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-03-09
+TXN_2601689,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-01-14
+TXN_6428182,Cake,5,3.0,15.0,Cash,In-store,2023-11-10
+TXN_6830557,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-11-08
+TXN_6371264,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-02-27
+TXN_4663299,UNKNOWN,4,4.0,16.0,Digital Wallet,In-store,2023-12-26
+TXN_9236713,Cookie,5,1.0,5.0,Cash,In-store,2023-09-13
+TXN_1079239,Smoothie,1,,4.0,,Takeaway,2023-02-08
+TXN_4690833,Cake,1,3.0,3.0,Cash,Takeaway,2023-05-23
+TXN_7946489,Juice,1,3.0,3.0,Cash,Takeaway,2023-09-11
+TXN_8661288,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-01-27
+TXN_7187207,Coffee,5,2.0,10.0,Cash,,2023-02-18
+TXN_4679409,ERROR,,2.0,2.0,,In-store,2023-03-25
+TXN_2866147,Juice,2,3.0,6.0,UNKNOWN,Takeaway,2023-08-28
+TXN_5637677,UNKNOWN,2,3.0,6.0,Digital Wallet,Takeaway,2023-08-24
+TXN_7444541,Salad,2,5.0,10.0,Cash,,2023-11-29
+TXN_6046604,Cookie,5,1.0,5.0,Credit Card,,2023-06-29
+TXN_6111710,Salad,3,5.0,15.0,Credit Card,In-store,2023-06-18
+TXN_5476465,Cake,,3.0,12.0,Cash,In-store,2023-06-23
+TXN_1773873,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-06-10
+TXN_7688650,Tea,2,1.5,3.0,,,2023-10-26
+TXN_4570711,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-12-11
+TXN_5242469,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-04-01
+TXN_2977414,Cake,4,3.0,ERROR,UNKNOWN,,2023-06-09
+TXN_8938144,Coffee,2,2.0,4.0,Credit Card,,2023-01-27
+TXN_6434414,,1,2.0,,Digital Wallet,Takeaway,2023-03-10
+TXN_1655100,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-12-20
+TXN_1526864,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-01-27
+TXN_1279428,Salad,1,5.0,5.0,Digital Wallet,,2023-03-02
+TXN_9866728,Juice,1,3.0,3.0,Cash,In-store,2023-10-26
+TXN_1706201,Coffee,3,2.0,6.0,Credit Card,In-store,2023-08-23
+TXN_2498488,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-12-06
+TXN_5387067,Salad,3,5.0,15.0,Credit Card,UNKNOWN,2023-06-11
+TXN_4431179,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-08-13
+TXN_5051924,Tea,5,1.5,7.5,,,2023-05-23
+TXN_9033890,Salad,1,5.0,5.0,,Takeaway,2023-08-05
+TXN_1777959,Tea,5,1.5,7.5,,Takeaway,2023-10-18
+TXN_3574059,Cake,1,3.0,3.0,,,2023-01-18
+TXN_8386792,Coffee,UNKNOWN,2.0,6.0,,In-store,2023-10-05
+TXN_2108894,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-10-30
+TXN_6347472,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-03-22
+TXN_8699110,Salad,3,5.0,15.0,,Takeaway,2023-10-11
+TXN_7188412,Sandwich,1,4.0,4.0,,Takeaway,2023-08-08
+TXN_6178152,UNKNOWN,5,1.5,7.5,,ERROR,2023-12-26
+TXN_3477767,Cookie,3,,3.0,Digital Wallet,,UNKNOWN
+TXN_8345723,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-27
+TXN_9989415,Smoothie,5,UNKNOWN,20.0,Credit Card,Takeaway,2023-05-26
+TXN_4476634,Tea,2,1.5,3.0,Credit Card,,2023-06-16
+TXN_1932897,Cookie,1,1.0,1.0,ERROR,Takeaway,UNKNOWN
+TXN_2178964,Tea,4,1.5,6.0,Cash,Takeaway,2023-12-25
+TXN_5213542,UNKNOWN,ERROR,2.0,6.0,Credit Card,In-store,2023-08-21
+TXN_7889745,Sandwich,4,4.0,16.0,,,2023-01-25
+TXN_7020671,Coffee,1,2.0,2.0,,ERROR,2023-09-01
+TXN_8297135,UNKNOWN,2,4.0,UNKNOWN,ERROR,,2023-09-16
+TXN_6581437,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-10-23
+TXN_1347965,Cookie,5,1.0,5.0,UNKNOWN,In-store,2023-02-19
+TXN_6128621,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-11-10
+TXN_5758199,Coffee,4,2.0,8.0,Credit Card,,2023-06-11
+TXN_3145041,Tea,5,1.5,7.5,,UNKNOWN,2023-09-23
+TXN_9960577,Sandwich,1,4.0,4.0,Cash,,2023-06-24
+TXN_1349738,Sandwich,3,4.0,ERROR,Cash,ERROR,2023-03-26
+TXN_4512118,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-04-20
+TXN_5763254,Coffee,3,UNKNOWN,6.0,Digital Wallet,Takeaway,2023-09-15
+TXN_8167279,Salad,5,5.0,25.0,,In-store,UNKNOWN
+TXN_8696094,Sandwich,UNKNOWN,4.0,,,Takeaway,2023-05-14
+TXN_8114990,Juice,1,3.0,3.0,,UNKNOWN,2023-02-27
+TXN_4961655,Juice,5,3.0,15.0,Cash,Takeaway,2023-05-06
+TXN_5595352,Juice,1,3.0,3.0,Cash,In-store,2023-02-20
+TXN_2070818,Smoothie,5,4.0,20.0,UNKNOWN,Takeaway,2023-06-05
+TXN_1090854,Cookie,UNKNOWN,1.0,3.0,Credit Card,In-store,2023-01-07
+TXN_2004851,Salad,5,5.0,25.0,Credit Card,,
+TXN_1869814,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-05-24
+TXN_8296518,UNKNOWN,2,4.0,8.0,Credit Card,In-store,2023-02-08
+TXN_6910915,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-05-06
+TXN_3183527,Coffee,3,2.0,6.0,Digital Wallet,,2023-10-26
+TXN_6916047,Coffee,2,2.0,,Digital Wallet,In-store,ERROR
+TXN_5787508,ERROR,3,UNKNOWN,9.0,Credit Card,Takeaway,2023-07-23
+TXN_2611960,Sandwich,3,4.0,12.0,Credit Card,,2023-09-11
+TXN_7923140,Coffee,2,2.0,4.0,Digital Wallet,,2023-04-02
+TXN_5229169,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-09-08
+TXN_1018880,Smoothie,5,4.0,20.0,Digital Wallet,,2023-07-15
+TXN_4074732,Salad,3,UNKNOWN,15.0,Credit Card,UNKNOWN,2023-04-09
+TXN_9409728,Tea,2,1.5,3.0,,In-store,2023-03-06
+TXN_5840223,Tea,4,ERROR,6.0,Cash,,2023-12-20
+TXN_5576265,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-04-08
+TXN_7399897,,4,3.0,12.0,,Takeaway,2023-11-14
+TXN_5098938,Tea,5,1.5,7.5,,,2023-05-06
+TXN_6119823,Tea,2,1.5,3.0,,Takeaway,2023-06-13
+TXN_7308222,Salad,2,ERROR,10.0,,Takeaway,2023-03-09
+TXN_5408625,Cookie,5,1.0,5.0,Cash,ERROR,2023-08-14
+TXN_5969754,Tea,4,1.5,6.0,,Takeaway,2023-01-29
+TXN_5740553,Salad,5,5.0,25.0,,In-store,2023-08-29
+TXN_4809497,Tea,4,1.5,6.0,Cash,In-store,
+TXN_2392934,UNKNOWN,2,2.0,4.0,,In-store,2023-11-25
+TXN_5728991,Salad,ERROR,5.0,10.0,,,2023-01-01
+TXN_7608816,,3,3.0,9.0,Digital Wallet,In-store,2023-11-07
+TXN_1046394,Smoothie,1,4.0,4.0,Cash,In-store,2023-04-29
+TXN_3228823,,5,1.5,7.5,,,2023-01-06
+TXN_2269396,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-10-26
+TXN_9263967,Cookie,3,1.0,3.0,Credit Card,In-store,2023-09-14
+TXN_6540946,Juice,4,3.0,12.0,Digital Wallet,,2023-10-08
+TXN_2914088,Salad,5,5.0,25.0,Cash,In-store,2023-03-22
+TXN_6571898,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-02-02
+TXN_7109358,Salad,,5.0,25.0,Digital Wallet,,2023-05-02
+TXN_4498370,Smoothie,4,4.0,16.0,ERROR,,2023-07-24
+TXN_4015710,Juice,4,UNKNOWN,12.0,Cash,UNKNOWN,2023-05-18
+TXN_4600048,Cookie,ERROR,1.0,2.0,Cash,,2023-10-30
+TXN_2108486,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-12-28
+TXN_7019782,Smoothie,ERROR,4.0,20.0,,,2023-10-16
+TXN_5228270,Juice,3,3.0,9.0,,Takeaway,2023-04-12
+TXN_4387303,Cookie,1,1.0,1.0,,,2023-06-27
+TXN_4637016,Salad,3,5.0,15.0,Credit Card,In-store,
+TXN_7786214,Smoothie,1,ERROR,4.0,Credit Card,,2023-11-25
+TXN_9587884,Tea,2,1.5,3.0,,,2023-01-05
+TXN_4625910,Juice,1,3.0,3.0,,,2023-01-17
+TXN_8250731,Cookie,2,1.0,2.0,Cash,,2023-08-24
+TXN_3605929,Smoothie,2,4.0,8.0,Credit Card,,2023-04-26
+TXN_4953450,Cookie,4,1.0,ERROR,ERROR,In-store,2023-03-10
+TXN_5315441,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-10-31
+TXN_9196322,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-08-12
+TXN_4009547,Juice,4,3.0,12.0,Credit Card,,2023-05-13
+TXN_3394710,Sandwich,,4.0,4.0,Digital Wallet,In-store,2023-10-22
+TXN_8354174,ERROR,3,2.0,,Credit Card,ERROR,2023-12-29
+TXN_5931292,ERROR,2,4.0,8.0,Credit Card,In-store,2023-12-18
+TXN_2109416,Sandwich,1,4.0,4.0,,In-store,2023-09-21
+TXN_8776606,UNKNOWN,4,5.0,20.0,Digital Wallet,Takeaway,2023-07-24
+TXN_1063366,Juice,3,3.0,9.0,,UNKNOWN,2023-03-20
+TXN_2393500,Juice,1,ERROR,3.0,Credit Card,In-store,2023-12-15
+TXN_9738758,Coffee,1,2.0,ERROR,Cash,In-store,2023-12-31
+TXN_7838465,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-06-15
+TXN_2447261,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-10-15
+TXN_6609947,ERROR,3,3.0,9.0,Digital Wallet,In-store,2023-05-29
+TXN_9036453,,1,4.0,4.0,Digital Wallet,Takeaway,2023-02-08
+TXN_2611990,Cookie,ERROR,1.0,3.0,Digital Wallet,Takeaway,2023-10-25
+TXN_1460963,Coffee,3,2.0,6.0,Cash,In-store,2023-02-10
+TXN_1713128,Smoothie,3,4.0,12.0,Credit Card,,2023-05-01
+TXN_4501168,ERROR,1,1.5,1.5,,In-store,2023-06-28
+TXN_2840323,Tea,4,1.5,6.0,Credit Card,ERROR,2023-05-07
+TXN_6691767,Salad,2,5.0,10.0,Cash,Takeaway,2023-02-05
+TXN_7280191,Coffee,3,2.0,6.0,ERROR,Takeaway,2023-08-23
+TXN_6932070,Tea,4,1.5,6.0,Credit Card,In-store,2023-06-10
+TXN_3502743,,5,4.0,20.0,,,2023-02-28
+TXN_2815335,Juice,5,3.0,15.0,Cash,,2023-03-30
+TXN_4916272,Tea,3,1.5,4.5,ERROR,,2023-03-03
+TXN_7940202,,1,,4.0,Digital Wallet,,2023-07-23
+TXN_5489408,Cookie,1,1.0,1.0,UNKNOWN,In-store,2023-05-02
+TXN_4640977,Cookie,3,1.0,3.0,Credit Card,In-store,2023-02-11
+TXN_8563346,UNKNOWN,3,2.0,6.0,Credit Card,,2023-10-24
+TXN_3172751,Juice,5,3.0,15.0,Credit Card,,ERROR
+TXN_7896721,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-04-22
+TXN_8973563,Coffee,1,2.0,2.0,,,2023-10-08
+TXN_4827371,Salad,2,5.0,10.0,,Takeaway,2023-06-20
+TXN_1559313,Smoothie,2,4.0,8.0,Credit Card,,2023-12-02
+TXN_7384923,Sandwich,2,4.0,UNKNOWN,,Takeaway,2023-01-24
+TXN_7906197,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-01-02
+TXN_9018535,Cookie,2,,2.0,Digital Wallet,Takeaway,2023-05-05
+TXN_9103318,Sandwich,2,4.0,8.0,,ERROR,2023-11-13
+TXN_8066743,Tea,3,1.5,4.5,Cash,Takeaway,2023-11-13
+TXN_9658677,Cake,ERROR,3.0,12.0,Cash,Takeaway,UNKNOWN
+TXN_8647575,Tea,UNKNOWN,1.5,3.0,Cash,,2023-02-08
+TXN_6376175,Juice,4,UNKNOWN,12.0,Digital Wallet,Takeaway,2023-02-24
+TXN_9840274,Sandwich,5,4.0,20.0,,Takeaway,2023-02-25
+TXN_4912458,Cake,4,3.0,12.0,ERROR,Takeaway,2023-06-12
+TXN_7982985,Cookie,1,1.0,1.0,Credit Card,,2023-01-27
+TXN_2855581,Coffee,4,2.0,8.0,Credit Card,UNKNOWN,2023-10-23
+TXN_7585348,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-03-16
+TXN_8249251,Cake,ERROR,3.0,9.0,ERROR,In-store,2023-01-01
+TXN_4005014,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-07-10
+TXN_3106215,Smoothie,3,4.0,ERROR,ERROR,Takeaway,2023-04-15
+TXN_4478185,Cake,2,3.0,6.0,Cash,In-store,2023-08-25
+TXN_7815651,Salad,1,ERROR,5.0,Cash,In-store,2023-01-16
+TXN_3461209,Juice,4,3.0,12.0,Credit Card,In-store,2023-04-26
+TXN_9498325,Salad,1,5.0,5.0,,,2023-04-04
+TXN_1026827,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-01-02
+TXN_4479052,Salad,UNKNOWN,5.0,20.0,Digital Wallet,In-store,2023-12-05
+TXN_7269513,Salad,3,5.0,15.0,Cash,,2023-05-12
+TXN_5134545,Tea,5,1.5,7.5,Digital Wallet,,2023-10-17
+TXN_7997144,Juice,4,3.0,12.0,Credit Card,,2023-02-25
+TXN_7315198,Salad,2,UNKNOWN,10.0,,UNKNOWN,2023-09-23
+TXN_4339682,Salad,5,5.0,25.0,,In-store,2023-03-04
+TXN_3363831,Juice,3,3.0,9.0,Digital Wallet,,2023-05-10
+TXN_5369555,Juice,4,3.0,12.0,Cash,Takeaway,2023-02-24
+TXN_6208034,Cake,1,3.0,3.0,Digital Wallet,,2023-08-29
+TXN_8187656,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-05-01
+TXN_6463415,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-04-12
+TXN_1461895,Juice,5,3.0,15.0,ERROR,,2023-06-17
+TXN_3197752,Smoothie,2,4.0,8.0,,,2023-03-10
+TXN_3112175,Coffee,4,2.0,8.0,Cash,,2023-03-16
+TXN_6439579,Tea,5,1.5,7.5,Credit Card,,2023-03-23
+TXN_4944121,UNKNOWN,2,2.0,4.0,UNKNOWN,UNKNOWN,2023-05-29
+TXN_5590805,Cake,1,3.0,3.0,,Takeaway,2023-01-25
+TXN_4634772,Juice,3,3.0,9.0,Credit Card,In-store,2023-01-12
+TXN_3519066,Cake,1,3.0,3.0,,Takeaway,2023-11-08
+TXN_8034156,Sandwich,1,4.0,4.0,Cash,In-store,2023-07-22
+TXN_2163229,Cookie,4,1.0,4.0,Cash,Takeaway,2023-12-21
+TXN_4109764,Juice,3,3.0,ERROR,Credit Card,UNKNOWN,2023-07-12
+TXN_1343750,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-02-15
+TXN_6387964,Tea,5,1.5,7.5,Digital Wallet,,2023-08-07
+TXN_2743397,Cake,2,3.0,6.0,Digital Wallet,,2023-10-03
+TXN_8022689,Tea,1,1.5,1.5,Cash,Takeaway,2023-06-15
+TXN_9392028,Salad,5,ERROR,25.0,Credit Card,In-store,2023-01-13
+TXN_3547825,Cookie,3,1.0,3.0,,Takeaway,2023-09-04
+TXN_9101792,Coffee,5,2.0,10.0,Cash,,2023-06-13
+TXN_3463928,,4,1.5,6.0,Credit Card,In-store,2023-06-07
+TXN_8503406,Smoothie,2,4.0,8.0,Digital Wallet,UNKNOWN,2023-02-15
+TXN_1992966,Smoothie,5,4.0,20.0,,In-store,2023-08-09
+TXN_2179458,,1,3.0,3.0,Cash,In-store,2023-10-23
+TXN_5648512,UNKNOWN,4,3.0,12.0,,Takeaway,2023-01-30
+TXN_8689416,Juice,5,3.0,15.0,ERROR,,2023-03-19
+TXN_1964555,Smoothie,2,4.0,8.0,Digital Wallet,,2023-04-11
+TXN_9402247,Salad,3,UNKNOWN,15.0,Digital Wallet,ERROR,ERROR
+TXN_8868960,Salad,5,5.0,25.0,,,UNKNOWN
+TXN_1794862,Cake,2,3.0,6.0,Cash,,2023-07-16
+TXN_5780615,Smoothie,3,4.0,ERROR,Cash,,2023-12-24
+TXN_2416816,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-10-19
+TXN_8005682,Coffee,2,2.0,4.0,Credit Card,,2023-03-16
+TXN_1778707,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-03-26
+TXN_9959813,Sandwich,4,4.0,16.0,Digital Wallet,,2023-09-05
+TXN_7675823,Tea,5,1.5,7.5,,ERROR,UNKNOWN
+TXN_3110343,Tea,UNKNOWN,1.5,7.5,Digital Wallet,Takeaway,2023-06-24
+TXN_7913451,Sandwich,5,4.0,20.0,Credit Card,,2023-12-05
+TXN_1901729,Cake,2,3.0,6.0,,Takeaway,2023-03-18
+TXN_5934059,Juice,,3.0,12.0,,UNKNOWN,2023-09-26
+TXN_8717428,Salad,3,5.0,15.0,Digital Wallet,,UNKNOWN
+TXN_2098878,Juice,2,3.0,6.0,,Takeaway,2023-08-19
+TXN_9536472,Juice,5,3.0,15.0,,,2023-11-12
+TXN_6696913,Cake,4,3.0,12.0,,,2023-10-22
+TXN_9561832,,3,4.0,12.0,Digital Wallet,ERROR,2023-10-29
+TXN_8888153,Coffee,5,2.0,10.0,,ERROR,2023-12-16
+TXN_3790025,ERROR,1,4.0,4.0,Cash,,2023-10-07
+TXN_2820693,Salad,3,UNKNOWN,15.0,Cash,Takeaway,2023-05-05
+TXN_5661147,Cake,1,3.0,3.0,,Takeaway,2023-11-06
+TXN_3746260,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-08-26
+TXN_7805035,Smoothie,3,4.0,12.0,,In-store,2023-05-18
+TXN_2058243,Smoothie,5,4.0,20.0,,Takeaway,2023-03-19
+TXN_5710748,Salad,1,5.0,5.0,,,2023-10-31
+TXN_3725837,Coffee,5,2.0,10.0,Cash,In-store,2023-10-22
+TXN_5132327,Smoothie,ERROR,4.0,20.0,Cash,,2023-01-25
+TXN_1575608,Sandwich,,,20.0,ERROR,Takeaway,2023-01-05
+TXN_4594922,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-06-19
+TXN_5163686,Salad,5,5.0,25.0,Credit Card,In-store,2023-05-29
+TXN_5445318,Cookie,1,1.0,1.0,Digital Wallet,,2023-02-16
+TXN_2391446,Sandwich,3,4.0,12.0,,In-store,2023-12-06
+TXN_2826603,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-06-22
+TXN_3489940,ERROR,3,1.0,3.0,Credit Card,,2023-12-15
+TXN_2526667,ERROR,3,3.0,9.0,Digital Wallet,In-store,2023-06-10
+TXN_3760598,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-10-24
+TXN_7679707,Tea,1,1.5,1.5,Credit Card,In-store,2023-07-22
+TXN_3831364,Tea,1,1.5,1.5,Digital Wallet,UNKNOWN,2023-03-03
+TXN_5038513,Cookie,2,UNKNOWN,2.0,Digital Wallet,Takeaway,2023-10-24
+TXN_5007619,Cake,5,3.0,15.0,Credit Card,In-store,2023-07-05
+TXN_5124870,Tea,1,1.5,1.5,Digital Wallet,,2023-08-11
+TXN_8229546,Smoothie,2,4.0,8.0,Cash,,2023-10-16
+TXN_3173923,Cookie,2,1.0,2.0,Digital Wallet,,2023-06-29
+TXN_8460786,Coffee,1,2.0,2.0,Cash,ERROR,2023-05-17
+TXN_7078232,ERROR,5,3.0,15.0,Digital Wallet,Takeaway,2023-11-21
+TXN_7833800,Coffee,2,2.0,4.0,,Takeaway,
+TXN_9625287,Juice,2,3.0,6.0,Cash,In-store,2023-07-08
+TXN_3135132,Sandwich,4,4.0,16.0,Credit Card,Takeaway,
+TXN_4779440,Cookie,1,1.0,1.0,,,2023-07-12
+TXN_7337979,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-05-27
+TXN_1713098,Smoothie,4,4.0,16.0,ERROR,,2023-11-22
+TXN_5325729,Coffee,5,2.0,10.0,Digital Wallet,,2023-05-04
+TXN_5630457,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-03-01
+TXN_4167859,Coffee,5,2.0,10.0,,Takeaway,2023-08-17
+TXN_4487966,Juice,3,3.0,9.0,Cash,In-store,2023-08-10
+TXN_1122140,Sandwich,4,4.0,16.0,Cash,,2023-06-19
+TXN_7484682,Juice,1,3.0,3.0,Cash,,2023-12-28
+TXN_5182042,Sandwich,4,4.0,16.0,,Takeaway,2023-02-25
+TXN_4040989,Sandwich,1,4.0,4.0,,,2023-03-02
+TXN_2190793,UNKNOWN,4,1.0,4.0,Credit Card,Takeaway,2023-07-29
+TXN_3663712,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-09-22
+TXN_9140598,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-10
+TXN_5657259,,2,1.5,3.0,,In-store,2023-03-03
+TXN_4316299,Tea,2,1.5,3.0,Credit Card,In-store,UNKNOWN
+TXN_5601300,Coffee,2,2.0,4.0,Digital Wallet,,2023-02-24
+TXN_9904662,Smoothie,1,4.0,4.0,,In-store,2023-11-19
+TXN_3696194,Salad,2,5.0,10.0,Credit Card,In-store,2023-11-27
+TXN_2964638,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-09-28
+TXN_8336656,Salad,5,5.0,25.0,Cash,Takeaway,2023-12-02
+TXN_2024121,Juice,5,3.0,UNKNOWN,Digital Wallet,In-store,2023-11-06
+TXN_6287890,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-02-07
+TXN_4712887,Tea,5,1.5,7.5,Credit Card,ERROR,2023-01-04
+TXN_4336892,Cookie,2,1.0,2.0,,In-store,2023-06-04
+TXN_5447694,Smoothie,1,4.0,ERROR,Digital Wallet,In-store,2023-11-18
+TXN_2492058,Smoothie,5,4.0,20.0,Cash,,2023-09-22
+TXN_3439712,Juice,4,3.0,12.0,,In-store,2023-04-04
+TXN_5350401,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-10-28
+TXN_8999006,Smoothie,1,4.0,,Cash,,2023-02-07
+TXN_8514689,Juice,5,3.0,15.0,,,2023-04-15
+TXN_1866028,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-06-12
+TXN_8379141,Salad,1,5.0,5.0,ERROR,In-store,2023-10-01
+TXN_9152264,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-03-15
+TXN_2287941,ERROR,1,1.0,1.0,,ERROR,2023-09-22
+TXN_3794585,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-02-10
+TXN_3856427,Juice,4,3.0,ERROR,ERROR,In-store,2023-03-25
+TXN_9890874,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-02
+TXN_3945716,Tea,2,1.5,3.0,,,2023-09-17
+TXN_6254003,,2,5.0,10.0,,,2023-11-02
+TXN_3101575,Coffee,UNKNOWN,2.0,4.0,,Takeaway,2023-12-03
+TXN_4874685,Smoothie,UNKNOWN,4.0,4.0,Credit Card,In-store,UNKNOWN
+TXN_6269119,,2,3.0,6.0,Digital Wallet,Takeaway,2023-07-19
+TXN_6024625,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-09-13
+TXN_7470910,Salad,2,5.0,10.0,Cash,In-store,2023-11-22
+TXN_9911345,Cookie,UNKNOWN,1.0,1.0,Digital Wallet,UNKNOWN,2023-04-14
+TXN_1116119,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-08-07
+TXN_3471223,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-10-08
+TXN_4491072,Smoothie,4,4.0,16.0,Credit Card,,2023-12-03
+TXN_2053993,Tea,2,1.5,3.0,,Takeaway,2023-09-21
+TXN_9086709,Cake,1,ERROR,3.0,,In-store,2023-05-04
+TXN_1646009,ERROR,4,5.0,20.0,Credit Card,,2023-10-11
+TXN_8692653,Juice,ERROR,3.0,6.0,Cash,Takeaway,2023-11-01
+TXN_5021925,Tea,4,1.5,6.0,Cash,In-store,2023-05-07
+TXN_1104849,UNKNOWN,4,4.0,16.0,Digital Wallet,Takeaway,2023-07-05
+TXN_6358073,Sandwich,3,4.0,12.0,,,
+TXN_7764154,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-12-09
+TXN_5410185,,3,3.0,9.0,,In-store,2023-02-22
+TXN_5651348,,3,5.0,,Cash,Takeaway,2023-11-04
+TXN_2178735,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-07-24
+TXN_4125165,Coffee,5,2.0,10.0,Cash,,2023-04-16
+TXN_5014959,Cookie,2,1.0,2.0,Credit Card,In-store,2023-11-28
+TXN_8811565,Juice,5,3.0,15.0,Credit Card,,2023-10-01
+TXN_9868382,Coffee,2,2.0,4.0,Digital Wallet,,2023-06-02
+TXN_2924611,Juice,3,3.0,9.0,Cash,,2023-04-19
+TXN_7063124,Cake,1,,3.0,,Takeaway,2023-04-10
+TXN_2291079,Coffee,,2.0,2.0,Cash,,2023-10-07
+TXN_5348445,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-11-15
+TXN_8920751,Tea,2,1.5,3.0,,,2023-04-20
+TXN_7215985,Tea,4,1.5,6.0,Credit Card,In-store,2023-08-07
+TXN_7448296,Cookie,1,1.0,1.0,Credit Card,In-store,2023-11-15
+TXN_2625324,Coffee,1,2.0,2.0,,UNKNOWN,2023-09-02
+TXN_3542902,Smoothie,1,4.0,4.0,ERROR,In-store,2023-06-10
+TXN_1494608,Tea,3,1.5,4.5,Credit Card,In-store,2023-05-07
+TXN_7615147,Sandwich,4,4.0,16.0,Cash,In-store,2023-05-19
+TXN_7225428,Tea,ERROR,,3.0,Credit Card,Takeaway,2023-03-07
+TXN_3426892,Salad,4,5.0,20.0,Credit Card,,2023-05-23
+TXN_5892508,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-03-21
+TXN_5546684,Coffee,1,2.0,2.0,Credit Card,In-store,2023-10-02
+TXN_6846047,Salad,,5.0,5.0,Digital Wallet,ERROR,2023-04-02
+TXN_5373527,Sandwich,2,4.0,8.0,,ERROR,2023-06-26
+TXN_6402128,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-11-09
+TXN_5009706,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-09-20
+TXN_7223120,Juice,1,3.0,3.0,,,2023-03-13
+TXN_1991104,Juice,2,ERROR,6.0,Digital Wallet,Takeaway,2023-11-29
+TXN_3380698,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-12-15
+TXN_9084554,,4,4.0,16.0,Credit Card,In-store,2023-06-08
+TXN_2996948,Smoothie,3,4.0,UNKNOWN,,UNKNOWN,2023-06-25
+TXN_1148945,Coffee,1,2.0,2.0,,UNKNOWN,2023-09-05
+TXN_2078577,Tea,4,1.5,6.0,Credit Card,,2023-01-31
+TXN_4007285,Sandwich,5,4.0,20.0,Digital Wallet,,2023-01-16
+TXN_2336708,ERROR,2,3.0,6.0,Cash,In-store,2023-06-16
+TXN_1512118,Salad,4,5.0,20.0,Cash,In-store,2023-03-01
+TXN_6077816,Cake,3,3.0,9.0,Credit Card,UNKNOWN,2023-09-26
+TXN_5136936,Cake,3,3.0,9.0,Cash,,2023-08-24
+TXN_8623443,,3,5.0,15.0,Credit Card,In-store,2023-09-04
+TXN_5654490,Tea,4,1.5,6.0,Credit Card,,2023-05-22
+TXN_4033888,Sandwich,2,4.0,8.0,Cash,In-store,2023-02-04
+TXN_4591512,Tea,2,1.5,3.0,,,2023-08-11
+TXN_6886495,Cookie,4,1.0,4.0,Cash,,2023-08-07
+TXN_9218683,Cake,2,3.0,6.0,Digital Wallet,In-store,ERROR
+TXN_2153529,Cookie,1,1.0,1.0,Credit Card,UNKNOWN,2023-09-11
+TXN_7880148,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-12-12
+TXN_3688181,Cake,1,3.0,3.0,,Takeaway,2023-08-23
+TXN_2482129,Juice,1,3.0,3.0,Cash,ERROR,2023-12-12
+TXN_4187420,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-01-31
+TXN_4146452,Smoothie,1,4.0,4.0,,Takeaway,2023-05-31
+TXN_9553579,Cake,2,3.0,6.0,Credit Card,In-store,2023-10-03
+TXN_3854285,Salad,3,5.0,15.0,Cash,Takeaway,2023-07-18
+TXN_5614488,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-07-22
+TXN_6187083,Cake,5,3.0,15.0,UNKNOWN,In-store,2023-06-02
+TXN_1521486,Salad,4,5.0,20.0,,ERROR,2023-01-28
+TXN_6868182,UNKNOWN,5,4.0,20.0,Credit Card,UNKNOWN,2023-01-02
+TXN_6035534,Salad,4,5.0,20.0,Credit Card,In-store,2023-12-18
+TXN_8781128,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,ERROR
+TXN_7670743,Salad,4,5.0,20.0,,In-store,2023-04-28
+TXN_7201724,Salad,1,5.0,5.0,Cash,Takeaway,2023-03-20
+TXN_2881199,Smoothie,ERROR,4.0,4.0,Digital Wallet,,2023-03-05
+TXN_3616362,Smoothie,5,4.0,UNKNOWN,Digital Wallet,In-store,2023-12-02
+TXN_6113876,Cake,3,3.0,9.0,Cash,In-store,2023-03-01
+TXN_6007079,ERROR,2,1.0,2.0,Credit Card,In-store,2023-10-09
+TXN_3163383,Tea,2,1.5,3.0,ERROR,In-store,2023-10-24
+TXN_1413304,UNKNOWN,5,5.0,25.0,,Takeaway,2023-03-17
+TXN_4907812,Sandwich,UNKNOWN,4.0,8.0,Digital Wallet,In-store,2023-08-11
+TXN_7894514,Cake,1,3.0,3.0,,,2023-09-25
+TXN_6450138,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-04-13
+TXN_9874588,Sandwich,2,4.0,8.0,UNKNOWN,Takeaway,2023-06-04
+TXN_6732989,Salad,2,5.0,10.0,Credit Card,,2023-04-29
+TXN_5442610,Juice,2,3.0,6.0,ERROR,Takeaway,2023-12-10
+TXN_2155368,ERROR,2,1.0,2.0,Digital Wallet,Takeaway,2023-02-06
+TXN_5236892,ERROR,1,3.0,3.0,Digital Wallet,Takeaway,2023-03-09
+TXN_9328595,Tea,2,1.5,3.0,Cash,,2023-10-24
+TXN_1324930,Sandwich,5,4.0,UNKNOWN,Credit Card,Takeaway,2023-01-11
+TXN_6148397,Tea,4,1.5,6.0,,In-store,2023-03-20
+TXN_8298711,Coffee,3,2.0,6.0,,Takeaway,2023-01-26
+TXN_7085875,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-08-23
+TXN_3857768,Coffee,2,2.0,4.0,Credit Card,,2023-01-04
+TXN_5474440,Cake,2,3.0,6.0,Credit Card,,2023-11-08
+TXN_6057379,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-03-18
+TXN_4637070,Tea,3,1.5,4.5,Credit Card,,2023-06-13
+TXN_9313535,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-06-04
+TXN_8161873,UNKNOWN,1,1.5,1.5,Digital Wallet,,2023-02-08
+TXN_5441196,Tea,,1.5,1.5,Cash,,2023-05-24
+TXN_9626053,Salad,1,5.0,5.0,Cash,Takeaway,2023-08-11
+TXN_7026504,ERROR,5,4.0,20.0,,,2023-03-29
+TXN_4114843,Sandwich,ERROR,4.0,8.0,Cash,,2023-05-17
+TXN_6622954,Smoothie,2,4.0,8.0,,In-store,2023-01-13
+TXN_5509088,Sandwich,3,4.0,12.0,Digital Wallet,,2023-08-28
+TXN_5583534,Cookie,2,1.0,2.0,Cash,Takeaway,2023-10-31
+TXN_1438257,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-06-13
+TXN_6428593,Tea,5,1.5,ERROR,,,2023-09-06
+TXN_4257830,Cookie,5,1.0,5.0,UNKNOWN,In-store,2023-08-04
+TXN_8780340,Cake,5,3.0,15.0,Credit Card,,2023-08-29
+TXN_5801294,Salad,1,5.0,5.0,ERROR,,2023-10-20
+TXN_4315988,UNKNOWN,2,5.0,10.0,Cash,Takeaway,2023-04-12
+TXN_3963927,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-01-03
+TXN_2906443,Cake,4,3.0,12.0,,,2023-08-14
+TXN_2660295,Cookie,3,1.0,3.0,,UNKNOWN,2023-12-06
+TXN_7023528,Tea,5,1.5,7.5,Cash,In-store,2023-10-28
+TXN_5419862,Juice,5,3.0,15.0,Digital Wallet,,2023-05-29
+TXN_9124680,Cookie,2,1.0,2.0,Cash,Takeaway,2023-10-03
+TXN_7853635,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-02-16
+TXN_2009893,Smoothie,3,4.0,12.0,ERROR,,2023-12-06
+TXN_3516263,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-09-23
+TXN_1591640,Cake,2,3.0,6.0,Cash,In-store,2023-05-26
+TXN_9358958,Smoothie,1,4.0,4.0,,Takeaway,2023-05-08
+TXN_3008336,,5,4.0,20.0,Credit Card,,2023-07-27
+TXN_7401710,Sandwich,5,4.0,20.0,Cash,UNKNOWN,2023-10-24
+TXN_2176727,Tea,1,1.5,1.5,,Takeaway,2023-07-26
+TXN_5595717,Juice,2,3.0,6.0,,,2023-06-16
+TXN_1697018,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-07-02
+TXN_1910957,Tea,5,1.5,7.5,,Takeaway,2023-07-25
+TXN_2667225,Salad,2,5.0,10.0,Cash,In-store,2023-11-21
+TXN_3152531,Coffee,3,2.0,6.0,Credit Card,UNKNOWN,2023-11-24
+TXN_8605958,Sandwich,,4.0,20.0,Cash,,2023-06-09
+TXN_5033045,Salad,3,5.0,15.0,Digital Wallet,,2023-04-21
+TXN_7527249,Tea,3,1.5,4.5,UNKNOWN,Takeaway,2023-03-29
+TXN_9159212,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-01-12
+TXN_6881523,Juice,5,3.0,15.0,,Takeaway,2023-02-24
+TXN_9725369,Coffee,UNKNOWN,2.0,6.0,,Takeaway,2023-02-10
+TXN_3282436,Salad,5,5.0,25.0,Credit Card,In-store,2023-12-14
+TXN_4206256,Smoothie,3,4.0,12.0,,ERROR,2023-10-10
+TXN_8465274,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-02-01
+TXN_1286779,Smoothie,ERROR,4.0,16.0,Credit Card,,2023-04-13
+TXN_7216922,Juice,5,3.0,15.0,UNKNOWN,,2023-06-26
+TXN_8330446,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-08-06
+TXN_1282260,Sandwich,5,4.0,20.0,Digital Wallet,UNKNOWN,2023-07-21
+TXN_9582716,Cake,2,3.0,6.0,UNKNOWN,UNKNOWN,ERROR
+TXN_9769410,Salad,1,5.0,5.0,Cash,In-store,2023-07-22
+TXN_7482583,Tea,5,1.5,7.5,Credit Card,,
+TXN_3865224,Coffee,3,2.0,6.0,,,2023-07-25
+TXN_8135614,Juice,2,UNKNOWN,6.0,Digital Wallet,,2023-01-28
+TXN_9603131,Smoothie,5,4.0,20.0,ERROR,UNKNOWN,2023-08-19
+TXN_1437083,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-03-15
+TXN_2955040,ERROR,5,3.0,15.0,,,2023-03-21
+TXN_2413626,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-11-06
+TXN_1568657,Coffee,2,UNKNOWN,4.0,Cash,,
+TXN_3392848,Cake,2,3.0,6.0,Cash,In-store,2023-04-03
+TXN_7027905,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-07-17
+TXN_8808034,Smoothie,2,4.0,8.0,Cash,In-store,2023-08-09
+TXN_1663113,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-12-24
+TXN_1544070,Coffee,5,2.0,10.0,UNKNOWN,Takeaway,2023-09-05
+TXN_6189334,Sandwich,1,4.0,4.0,Cash,In-store,2023-01-12
+TXN_3412490,Cake,2,3.0,6.0,Cash,In-store,UNKNOWN
+TXN_1852586,Cake,5,3.0,15.0,,In-store,UNKNOWN
+TXN_3803732,Salad,4,,20.0,Digital Wallet,,2023-01-08
+TXN_3410971,Smoothie,1,4.0,4.0,,Takeaway,2023-01-02
+TXN_6467618,Tea,3,1.5,4.5,,Takeaway,2023-10-12
+TXN_6908287,Cookie,1,1.0,1.0,Cash,In-store,2023-08-04
+TXN_2726700,UNKNOWN,,1.5,3.0,Digital Wallet,,2023-04-10
+TXN_1803889,Salad,4,5.0,20.0,,,2023-06-23
+TXN_6829707,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-08-17
+TXN_7303706,Coffee,2,2.0,4.0,Cash,In-store,2023-12-14
+TXN_1730647,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-01-18
+TXN_9691018,Sandwich,2,4.0,8.0,Digital Wallet,UNKNOWN,2023-07-21
+TXN_5480564,Salad,3,ERROR,15.0,Digital Wallet,,2023-05-28
+TXN_4090904,,UNKNOWN,1.5,7.5,Digital Wallet,In-store,2023-08-04
+TXN_9138791,Cake,1,3.0,,Digital Wallet,In-store,2023-03-22
+TXN_2367947,Smoothie,5,4.0,20.0,,Takeaway,2023-05-13
+TXN_4936135,Coffee,4,2.0,8.0,Cash,In-store,2023-12-08
+TXN_5311015,Smoothie,3,4.0,12.0,ERROR,,2023-05-11
+TXN_2473090,UNKNOWN,2,,3.0,Credit Card,In-store,2023-03-03
+TXN_8808631,Sandwich,5,ERROR,20.0,ERROR,Takeaway,2023-03-26
+TXN_8703212,ERROR,2,2.0,4.0,Credit Card,Takeaway,2023-04-17
+TXN_7732920,Sandwich,5,4.0,20.0,Cash,,2023-02-11
+TXN_4496665,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-12-10
+TXN_5041555,UNKNOWN,4,1.5,6.0,Digital Wallet,,2023-08-26
+TXN_6816094,Tea,4,1.5,6.0,,In-store,2023-12-30
+TXN_8209794,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-10-25
+TXN_4135454,Sandwich,4,4.0,16.0,,In-store,2023-07-23
+TXN_3942164,Coffee,4,2.0,8.0,Credit Card,,
+TXN_2761542,Cookie,4,1.0,4.0,,,2023-10-15
+TXN_7948095,Salad,5,5.0,UNKNOWN,,Takeaway,2023-07-18
+TXN_3330687,Cake,5,3.0,15.0,Cash,In-store,2023-12-26
+TXN_9822317,UNKNOWN,3,1.5,4.5,Cash,In-store,2023-09-25
+TXN_6243479,Sandwich,5,4.0,20.0,,,2023-09-18
+TXN_9296807,Coffee,3,2.0,6.0,Credit Card,,2023-12-20
+TXN_7626939,Coffee,UNKNOWN,2.0,10.0,,,ERROR
+TXN_5354746,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-03-06
+TXN_1235969,Cookie,1,1.0,1.0,Digital Wallet,,2023-07-08
+TXN_4240796,Juice,4,3.0,12.0,,,2023-03-28
+TXN_3736798,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-07-01
+TXN_9102030,Smoothie,4,4.0,16.0,Digital Wallet,In-store,ERROR
+TXN_8118419,Cake,3,3.0,9.0,,UNKNOWN,2023-12-03
+TXN_3089814,Cake,5,3.0,15.0,Digital Wallet,,2023-03-25
+TXN_6719521,Salad,5,5.0,25.0,Cash,In-store,2023-08-03
+TXN_6530795,Cookie,1,1.0,1.0,Credit Card,,2023-04-30
+TXN_4176373,Cookie,3,1.0,3.0,Cash,,2023-03-28
+TXN_7230500,Juice,3,3.0,9.0,Credit Card,,2023-12-12
+TXN_7094898,Salad,4,5.0,20.0,,Takeaway,2023-06-20
+TXN_2400518,Juice,3,3.0,9.0,Credit Card,,2023-02-04
+TXN_5349288,Coffee,4,2.0,8.0,Digital Wallet,,2023-11-20
+TXN_6806290,Salad,3,5.0,15.0,UNKNOWN,,2023-05-02
+TXN_6191123,,2,1.0,ERROR,Digital Wallet,Takeaway,2023-03-01
+TXN_5386752,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-12-07
+TXN_1022523,Salad,4,5.0,20.0,Cash,In-store,2023-11-25
+TXN_3125997,Juice,4,3.0,12.0,,,2023-10-19
+TXN_9906002,Smoothie,UNKNOWN,4.0,12.0,Digital Wallet,In-store,2023-07-13
+TXN_6202015,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-08-22
+TXN_6928137,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-10-11
+TXN_3003809,Coffee,4,2.0,8.0,Cash,,2023-04-21
+TXN_5913013,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-11-29
+TXN_7433269,Tea,1,1.5,1.5,Cash,In-store,2023-05-18
+TXN_3103972,Cake,1,3.0,3.0,ERROR,,2023-03-01
+TXN_9081115,Juice,3,3.0,ERROR,,,2023-12-04
+TXN_1054915,,5,1.0,5.0,,In-store,2023-01-22
+TXN_2633600,Salad,5,5.0,UNKNOWN,Cash,Takeaway,2023-11-28
+TXN_4631695,Cookie,5,1.0,5.0,UNKNOWN,In-store,2023-11-18
+TXN_3121271,Smoothie,2,4.0,8.0,Credit Card,,2023-08-13
+TXN_4613883,Tea,1,1.5,1.5,Cash,,2023-05-21
+TXN_2766651,Cake,ERROR,3.0,9.0,,,2023-05-11
+TXN_2166064,Coffee,4,2.0,8.0,,In-store,2023-02-08
+TXN_4617771,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-09-10
+TXN_9444461,Sandwich,2,4.0,8.0,,ERROR,2023-05-28
+TXN_4723978,ERROR,2,1.0,2.0,,,2023-04-20
+TXN_1741325,Tea,2,1.5,3.0,Credit Card,In-store,2023-03-31
+TXN_9370294,Cake,2,3.0,6.0,Credit Card,,2023-04-23
+TXN_9983356,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-09-20
+TXN_8964527,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-02-22
+TXN_7696120,Cookie,1,,1.0,UNKNOWN,In-store,
+TXN_3331437,,1,2.0,2.0,Cash,Takeaway,2023-02-26
+TXN_6313325,Cookie,5,1.0,5.0,ERROR,,2023-07-07
+TXN_9497634,Juice,3,3.0,9.0,Cash,,2023-07-20
+TXN_9408993,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-08-19
+TXN_7810285,Cake,4,3.0,12.0,Cash,Takeaway,2023-10-25
+TXN_5322809,Cake,2,3.0,6.0,,ERROR,2023-04-30
+TXN_1961595,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-07-02
+TXN_1200795,Sandwich,1,4.0,4.0,,In-store,2023-08-18
+TXN_8958073,Smoothie,1,4.0,4.0,,,2023-03-31
+TXN_4114503,Salad,5,5.0,25.0,,Takeaway,2023-11-07
+TXN_4179561,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-11-12
+TXN_5669113,Sandwich,2,4.0,UNKNOWN,,Takeaway,2023-03-19
+TXN_7574828,Coffee,2,2.0,4.0,,In-store,2023-09-24
+TXN_9056301,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-03-02
+TXN_8530924,Sandwich,2,4.0,8.0,Credit Card,ERROR,2023-08-05
+TXN_1505947,UNKNOWN,3,1.0,3.0,Cash,,2023-11-21
+TXN_2114258,,1,1.0,1.0,Digital Wallet,In-store,2023-12-04
+TXN_5965422,Coffee,2,2.0,4.0,Credit Card,,2023-06-20
+TXN_6910030,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-07-09
+TXN_3713626,Sandwich,2,4.0,8.0,Cash,,2023-12-24
+TXN_5753095,Sandwich,4,4.0,16.0,,,2023-06-25
+TXN_5538503,Smoothie,2,4.0,8.0,,In-store,2023-09-05
+TXN_7609781,Smoothie,3,4.0,12.0,Cash,In-store,2023-03-13
+TXN_8398059,Cake,1,3.0,3.0,Cash,Takeaway,2023-10-15
+TXN_3755379,Cookie,2,ERROR,2.0,Digital Wallet,In-store,2023-11-19
+TXN_6565955,,3,2.0,6.0,Digital Wallet,In-store,2023-12-29
+TXN_1792573,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-12-07
+TXN_4812472,Cake,2,3.0,6.0,Cash,,2023-09-16
+TXN_2923987,UNKNOWN,4,2.0,8.0,Cash,Takeaway,2023-03-28
+TXN_1789644,Coffee,4,2.0,8.0,Credit Card,In-store,ERROR
+TXN_5050993,Cookie,4,1.0,4.0,,ERROR,2023-02-06
+TXN_9991225,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-02-03
+TXN_8734476,Tea,1,1.5,1.5,Cash,Takeaway,2023-09-12
+TXN_6471962,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-09-21
+TXN_1981602,Sandwich,4,4.0,16.0,Cash,,2023-09-04
+TXN_4792702,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-06-28
+TXN_3572190,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-03-05
+TXN_6791398,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-12-17
+TXN_8361255,Cake,3,3.0,9.0,Cash,Takeaway,2023-07-29
+TXN_1096690,Smoothie,5,4.0,ERROR,Credit Card,,2023-10-09
+TXN_1371554,Sandwich,2,4.0,,,,2023-05-19
+TXN_5080213,UNKNOWN,1,2.0,,Digital Wallet,,2023-07-18
+TXN_5102956,Cake,5,3.0,15.0,,,
+TXN_5858988,Juice,1,ERROR,3.0,Credit Card,Takeaway,2023-06-24
+TXN_1476066,Smoothie,2,4.0,8.0,ERROR,Takeaway,2023-10-19
+TXN_6078834,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-04-28
+TXN_7812601,Tea,2,1.5,3.0,Credit Card,,2023-11-15
+TXN_8186625,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-07-21
+TXN_3713976,Juice,2,3.0,6.0,,Takeaway,2023-11-06
+TXN_2946829,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-02-08
+TXN_8645889,Salad,4,,20.0,Cash,,
+TXN_8750849,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-03-03
+TXN_2889344,Sandwich,3,4.0,12.0,,In-store,2023-05-21
+TXN_4067814,Tea,5,1.5,7.5,Cash,,2023-12-20
+TXN_2018654,Salad,1,ERROR,5.0,,,2023-10-23
+TXN_1973716,Salad,4,5.0,20.0,Credit Card,In-store,2023-01-21
+TXN_1105589,Coffee,5,2.0,10.0,Cash,Takeaway,2023-07-04
+TXN_3727374,Cake,2,3.0,6.0,,In-store,2023-04-10
+TXN_9155299,Juice,3,3.0,9.0,,Takeaway,2023-02-09
+TXN_1346936,Cookie,5,1.0,5.0,ERROR,,2023-10-10
+TXN_2089778,Cake,1,3.0,3.0,,In-store,2023-06-12
+TXN_4896948,Cake,,3.0,12.0,UNKNOWN,,2023-10-11
+TXN_5375349,Coffee,1,2.0,2.0,,Takeaway,2023-11-13
+TXN_6206171,Cake,1,3.0,3.0,Digital Wallet,,2023-03-19
+TXN_9256387,Tea,5,1.5,7.5,,,2023-05-31
+TXN_6915192,Coffee,4,2.0,8.0,UNKNOWN,In-store,2023-12-09
+TXN_8908224,Coffee,4,2.0,8.0,,,2023-08-21
+TXN_4988665,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-12-16
+TXN_7740907,Smoothie,5,4.0,UNKNOWN,,In-store,2023-02-11
+TXN_9596100,,4,3.0,12.0,Cash,Takeaway,2023-05-04
+TXN_5019407,Juice,4,3.0,12.0,Credit Card,,2023-04-17
+TXN_2482363,Tea,3,1.5,4.5,Cash,UNKNOWN,2023-08-06
+TXN_5412834,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-07-13
+TXN_1389258,Salad,1,5.0,5.0,Cash,Takeaway,2023-12-31
+TXN_3223187,Coffee,2,2.0,4.0,Credit Card,,2023-08-21
+TXN_9288207,Cake,4,3.0,12.0,,Takeaway,2023-05-16
+TXN_8300706,Salad,2,5.0,10.0,Digital Wallet,UNKNOWN,2023-12-23
+TXN_8076559,Cake,5,3.0,15.0,Cash,Takeaway,2023-11-02
+TXN_2749266,Sandwich,ERROR,4.0,12.0,,Takeaway,2023-02-06
+TXN_4310310,Cake,3,3.0,9.0,Cash,Takeaway,2023-03-08
+TXN_5301689,Cake,5,3.0,15.0,,In-store,2023-04-11
+TXN_9971927,Smoothie,3,4.0,12.0,,Takeaway,2023-08-07
+TXN_9143440,Coffee,4,2.0,8.0,Digital Wallet,,2023-03-31
+TXN_6359777,,5,4.0,20.0,,,2023-01-13
+TXN_2916209,Cake,2,3.0,6.0,ERROR,In-store,2023-04-15
+TXN_6411716,Cake,4,3.0,12.0,Credit Card,In-store,2023-02-25
+TXN_7759607,Sandwich,1,4.0,4.0,Digital Wallet,,2023-08-11
+TXN_8441057,Cake,4,3.0,12.0,Credit Card,,2023-11-04
+TXN_8283691,Juice,3,3.0,9.0,,,2023-01-25
+TXN_1154979,Coffee,3,2.0,6.0,Credit Card,In-store,2023-12-11
+TXN_4258949,Cake,2,3.0,6.0,,,2023-03-07
+TXN_6129205,Sandwich,5,4.0,20.0,Cash,In-store,2023-07-20
+TXN_3444519,Cookie,4,1.0,4.0,,Takeaway,2023-03-10
+TXN_6813508,Salad,1,5.0,5.0,Cash,,2023-10-26
+TXN_5540986,Cake,3,3.0,9.0,,UNKNOWN,2023-05-12
+TXN_4832513,Cookie,5,1.0,5.0,Credit Card,In-store,2023-06-05
+TXN_6202035,Tea,2,1.5,3.0,,In-store,2023-09-06
+TXN_4108120,Coffee,2,2.0,4.0,,In-store,2023-06-14
+TXN_8466519,UNKNOWN,1,1.0,1.0,,Takeaway,2023-08-31
+TXN_5379385,Coffee,5,2.0,10.0,Credit Card,,2023-02-21
+TXN_6782228,Coffee,4,2.0,8.0,Credit Card,,2023-08-18
+TXN_7268366,Juice,5,3.0,15.0,,In-store,2023-12-14
+TXN_1180969,Cookie,1,1.0,ERROR,Digital Wallet,In-store,2023-01-06
+TXN_3815345,,5,1.0,5.0,Cash,In-store,2023-09-16
+TXN_7453213,Coffee,UNKNOWN,2.0,6.0,,In-store,2023-10-27
+TXN_9469533,Cookie,4,ERROR,4.0,Cash,,2023-05-22
+TXN_6492919,Juice,3,3.0,9.0,Digital Wallet,,2023-09-24
+TXN_4356223,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-11-23
+TXN_7515082,Coffee,2,2.0,4.0,,In-store,2023-10-21
+TXN_7216161,Tea,4,1.5,6.0,Credit Card,UNKNOWN,2023-07-06
+TXN_2426782,Coffee,2,UNKNOWN,4.0,Credit Card,In-store,2023-11-04
+TXN_3484520,Juice,3,3.0,9.0,Credit Card,,2023-08-15
+TXN_2806515,Smoothie,4,4.0,UNKNOWN,,In-store,2023-12-31
+TXN_7198128,Cake,2,3.0,ERROR,,In-store,2023-09-07
+TXN_6717061,Salad,3,5.0,15.0,Credit Card,,2023-08-07
+TXN_3562350,Coffee,2,2.0,4.0,ERROR,,2023-02-04
+TXN_1987977,UNKNOWN,2,4.0,8.0,,,2023-11-16
+TXN_4250492,Salad,5,UNKNOWN,25.0,,Takeaway,2023-09-29
+TXN_2471972,Cookie,1,1.0,1.0,Cash,Takeaway,2023-04-08
+TXN_3060152,Juice,5,3.0,15.0,Digital Wallet,,2023-02-07
+TXN_4651514,Tea,2,1.5,ERROR,Digital Wallet,In-store,2023-03-28
+TXN_6555617,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-12-27
+TXN_7033977,Sandwich,4,4.0,16.0,,Takeaway,2023-05-04
+TXN_6899834,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-01-27
+TXN_5031214,ERROR,5,UNKNOWN,5.0,,Takeaway,2023-07-29
+TXN_3427950,Smoothie,5,4.0,20.0,,In-store,2023-02-23
+TXN_8817239,ERROR,5,4.0,20.0,Cash,In-store,2023-01-29
+TXN_8543211,Juice,3,3.0,9.0,,Takeaway,2023-11-30
+TXN_7538570,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-04-18
+TXN_8789116,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-01-13
+TXN_8930109,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-05-17
+TXN_9799798,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-05-23
+TXN_8551432,UNKNOWN,,1.5,6.0,,Takeaway,2023-01-12
+TXN_8831813,Smoothie,5,4.0,20.0,,,2023-11-23
+TXN_5067373,Cookie,3,1.0,3.0,Cash,ERROR,2023-10-18
+TXN_5755839,Sandwich,3,4.0,12.0,Credit Card,UNKNOWN,2023-12-19
+TXN_1681153,Juice,3,3.0,9.0,Cash,Takeaway,2023-02-09
+TXN_4255503,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-11-19
+TXN_6086709,ERROR,5,3.0,15.0,,ERROR,2023-07-07
+TXN_2385697,Coffee,1,2.0,2.0,Cash,Takeaway,2023-09-10
+TXN_9151321,Sandwich,4,4.0,16.0,Cash,In-store,2023-01-05
+TXN_7369807,Coffee,4,2.0,8.0,,In-store,2023-02-22
+TXN_1602799,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-03-23
+TXN_3336502,Sandwich,3,4.0,12.0,Credit Card,,2023-05-04
+TXN_9579181,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-05-24
+TXN_7391267,Cake,3,UNKNOWN,9.0,Digital Wallet,In-store,2023-12-07
+TXN_1388606,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-08-31
+TXN_2336857,Cake,3,3.0,9.0,Cash,In-store,2023-08-02
+TXN_9526867,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-10-21
+TXN_4427348,Cake,5,3.0,15.0,Cash,UNKNOWN,2023-12-22
+TXN_5901180,Cookie,3,1.0,3.0,Digital Wallet,,2023-12-20
+TXN_4932018,,4,4.0,16.0,Digital Wallet,Takeaway,2023-08-23
+TXN_3224921,Sandwich,5,4.0,20.0,,In-store,2023-04-06
+TXN_5792655,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-12-21
+TXN_5566652,Juice,5,3.0,15.0,Credit Card,,2023-09-16
+TXN_7782538,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-08-15
+TXN_7478389,Cookie,5,1.0,5.0,Digital Wallet,,2023-10-13
+TXN_6108428,Cake,3,3.0,9.0,Digital Wallet,,2023-05-08
+TXN_3615483,Sandwich,2,4.0,8.0,Digital Wallet,,2023-09-08
+TXN_6404763,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-11-13
+TXN_6060764,Smoothie,3,,12.0,,In-store,ERROR
+TXN_2269497,Coffee,5,2.0,10.0,ERROR,,2023-08-14
+TXN_8205107,UNKNOWN,4,4.0,16.0,,Takeaway,2023-04-19
+TXN_5290522,ERROR,2,2.0,4.0,Credit Card,Takeaway,2023-02-16
+TXN_8396271,ERROR,2,,2.0,,,2023-09-12
+TXN_5153686,Coffee,5,2.0,10.0,,Takeaway,2023-04-05
+TXN_5237569,Tea,3,,4.5,,,
+TXN_4915908,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-06-06
+TXN_7146613,Smoothie,1,4.0,4.0,Cash,ERROR,2023-08-01
+TXN_8219519,Tea,5,1.5,7.5,,,2023-11-29
+TXN_7867311,Smoothie,2,4.0,8.0,,,2023-07-17
+TXN_4798534,,5,5.0,25.0,Digital Wallet,Takeaway,2023-07-23
+TXN_9844703,UNKNOWN,2,1.5,3.0,,,2023-05-18
+TXN_4147073,,4,3.0,12.0,Cash,Takeaway,2023-06-16
+TXN_4203585,Cake,2,3.0,6.0,,,2023-09-03
+TXN_7222483,Sandwich,5,4.0,20.0,,Takeaway,2023-05-02
+TXN_9996968,Sandwich,1,ERROR,4.0,Cash,In-store,2023-10-14
+TXN_4472156,Cookie,1,1.0,1.0,,In-store,2023-11-03
+TXN_9121852,Cookie,1,1.0,1.0,Credit Card,,ERROR
+TXN_7043825,Juice,2,3.0,6.0,Cash,Takeaway,2023-02-07
+TXN_2195630,Sandwich,5,ERROR,20.0,Credit Card,Takeaway,2023-03-09
+TXN_2539318,Sandwich,4,4.0,16.0,Digital Wallet,UNKNOWN,2023-01-15
+TXN_5788769,Juice,1,3.0,3.0,Cash,In-store,2023-07-19
+TXN_3628056,Cake,4,ERROR,12.0,Cash,In-store,2023-07-09
+TXN_5735731,Smoothie,2,UNKNOWN,8.0,Credit Card,,2023-01-22
+TXN_2424930,Tea,5,1.5,7.5,Digital Wallet,,2023-01-20
+TXN_5856820,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-07-18
+TXN_3753993,Sandwich,5,4.0,20.0,Credit Card,,2023-04-01
+TXN_3001647,,1,5.0,5.0,,,2023-07-01
+TXN_9354616,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-01-27
+TXN_3749365,Cookie,3,1.0,3.0,Cash,,2023-01-19
+TXN_6900785,Juice,1,3.0,3.0,,Takeaway,2023-09-25
+TXN_5775113,Salad,1,5.0,5.0,Digital Wallet,,2023-10-23
+TXN_5268203,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-03-04
+TXN_3483570,Sandwich,2,4.0,8.0,ERROR,Takeaway,2023-03-21
+TXN_7406393,ERROR,5,1.5,7.5,Credit Card,Takeaway,2023-06-18
+TXN_5226635,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-02-01
+TXN_5469063,Coffee,2,2.0,4.0,,Takeaway,2023-02-24
+TXN_9278992,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-12-15
+TXN_4369292,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-10-09
+TXN_6011884,Tea,5,1.5,7.5,UNKNOWN,,2023-12-25
+TXN_2952715,Smoothie,3,4.0,12.0,Cash,In-store,ERROR
+TXN_3912727,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-04-13
+TXN_1951569,Salad,2,5.0,10.0,Digital Wallet,,2023-02-27
+TXN_6983139,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-12-18
+TXN_6787560,Cake,3,3.0,9.0,,,2023-07-13
+TXN_5977414,Cake,2,3.0,6.0,Credit Card,In-store,2023-08-06
+TXN_8517379,ERROR,4,3.0,12.0,Digital Wallet,Takeaway,2023-09-23
+TXN_5485384,Sandwich,5,4.0,20.0,,,2023-03-04
+TXN_9285663,Cookie,4,1.0,4.0,,ERROR,2023-11-18
+TXN_9074075,Juice,5,3.0,15.0,Credit Card,ERROR,2023-08-14
+TXN_8050034,Cookie,4,1.0,4.0,,In-store,2023-07-29
+TXN_8842223,Sandwich,5,,20.0,Digital Wallet,In-store,2023-01-01
+TXN_5121322,Sandwich,3,4.0,12.0,UNKNOWN,In-store,2023-12-17
+TXN_3091582,Sandwich,5,4.0,20.0,,,2023-11-28
+TXN_8550184,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-04-05
+TXN_7604352,Coffee,,2.0,6.0,,Takeaway,2023-12-19
+TXN_6899248,ERROR,5,3.0,15.0,,,2023-12-13
+TXN_2773491,Salad,5,5.0,25.0,Cash,,2023-11-14
+TXN_3071617,UNKNOWN,4,1.0,4.0,Credit Card,,2023-12-15
+TXN_3712466,Cake,5,3.0,UNKNOWN,Digital Wallet,ERROR,2023-04-10
+TXN_3670298,,4,1.0,4.0,Credit Card,Takeaway,2023-02-04
+TXN_4901854,Cookie,5,1.0,5.0,ERROR,,2023-04-23
+TXN_7590801,Tea,UNKNOWN,UNKNOWN,6.0,Cash,Takeaway,ERROR
+TXN_6962242,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-06-30
+TXN_5780931,Tea,4,1.5,6.0,Digital Wallet,ERROR,2023-10-06
+TXN_4563679,Coffee,4,2.0,8.0,,In-store,2023-09-11
+TXN_6290642,Coffee,4,2.0,,UNKNOWN,Takeaway,2023-12-23
+TXN_6177865,Juice,5,3.0,15.0,Digital Wallet,ERROR,2023-01-30
+TXN_8115752,Smoothie,2,4.0,8.0,Digital Wallet,ERROR,2023-06-27
+TXN_9253398,Sandwich,2,4.0,8.0,,Takeaway,2023-12-14
+TXN_3116227,Cake,1,3.0,3.0,Digital Wallet,,2023-05-30
+TXN_2494138,Cookie,3,1.0,3.0,Cash,,2023-01-10
+TXN_4889269,Cake,2,3.0,UNKNOWN,Cash,UNKNOWN,2023-02-19
+TXN_9503369,Cookie,UNKNOWN,1.0,1.0,,Takeaway,
+TXN_6105240,Juice,5,3.0,UNKNOWN,,In-store,2023-11-27
+TXN_8808162,Smoothie,4,4.0,16.0,Digital Wallet,ERROR,2023-05-07
+TXN_4548466,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-11-30
+TXN_3195257,,,5.0,5.0,Cash,,2023-10-09
+TXN_9835676,Cookie,2,1.0,2.0,Digital Wallet,,2023-03-30
+TXN_9728454,Juice,4,3.0,ERROR,Digital Wallet,Takeaway,2023-01-03
+TXN_5907854,Juice,3,3.0,9.0,,In-store,2023-11-11
+TXN_8685846,Tea,5,1.5,7.5,Credit Card,,2023-12-27
+TXN_1726774,Salad,3,5.0,15.0,,,2023-11-16
+TXN_2594430,Coffee,1,2.0,2.0,ERROR,,2023-05-18
+TXN_5750278,Salad,ERROR,5.0,15.0,Cash,Takeaway,2023-06-08
+TXN_6714931,Juice,3,3.0,9.0,,,2023-07-02
+TXN_5537740,Cake,,3.0,9.0,Credit Card,Takeaway,2023-04-30
+TXN_9433769,Cake,4,ERROR,12.0,Digital Wallet,,2023-08-13
+TXN_5944206,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-05-12
+TXN_9212178,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-11-18
+TXN_2915856,Tea,1,1.5,1.5,,In-store,2023-06-19
+TXN_4376214,Salad,5,5.0,25.0,,ERROR,2023-04-26
+TXN_9201212,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-06-08
+TXN_7752454,Cake,3,3.0,9.0,,,ERROR
+TXN_7055260,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-06-20
+TXN_4773465,Coffee,5,2.0,ERROR,Digital Wallet,Takeaway,2023-11-28
+TXN_9087344,Tea,5,1.5,UNKNOWN,Cash,UNKNOWN,2023-07-29
+TXN_1757340,Cake,2,3.0,6.0,Credit Card,In-store,2023-12-29
+TXN_9975321,Salad,2,5.0,10.0,Digital Wallet,ERROR,2023-03-25
+TXN_8148137,Tea,1,1.5,1.5,,In-store,UNKNOWN
+TXN_1681216,Cake,3,3.0,9.0,UNKNOWN,,2023-03-23
+TXN_3835043,Juice,2,3.0,6.0,Cash,,2023-12-29
+TXN_8366002,Sandwich,2,4.0,8.0,Credit Card,,2023-12-26
+TXN_9390740,Cake,2,3.0,6.0,Cash,In-store,2023-12-06
+TXN_4928254,Cake,1,3.0,3.0,Credit Card,UNKNOWN,2023-12-22
+TXN_5191642,Salad,ERROR,5.0,25.0,Cash,ERROR,2023-04-15
+TXN_9117434,Cake,1,3.0,3.0,UNKNOWN,In-store,2023-07-18
+TXN_2820788,UNKNOWN,5,1.0,5.0,ERROR,,2023-09-25
+TXN_3593060,Smoothie,UNKNOWN,,16.0,Cash,,2023-03-05
+TXN_7531745,Cake,2,3.0,6.0,Cash,,2023-06-23
+TXN_1082421,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-12-19
+TXN_2148444,Juice,2,3.0,6.0,Cash,,2023-11-27
+TXN_5402385,ERROR,2,3.0,6.0,Cash,In-store,2023-06-18
+TXN_1494502,Salad,5,5.0,25.0,Digital Wallet,ERROR,ERROR
+TXN_9277146,Cake,5,3.0,15.0,Credit Card,,2023-07-11
+TXN_9333347,Smoothie,5,4.0,20.0,Cash,UNKNOWN,2023-09-10
+TXN_9127105,Juice,3,3.0,9.0,Cash,,2023-03-04
+TXN_1417724,Sandwich,2,4.0,8.0,Digital Wallet,,2023-06-07
+TXN_6451377,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-03-19
+TXN_2142961,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-09-21
+TXN_5927884,Coffee,4,2.0,8.0,,ERROR,2023-12-21
+TXN_8588335,Salad,4,5.0,20.0,Credit Card,,2023-09-04
+TXN_6738350,Juice,2,3.0,6.0,Digital Wallet,,2023-11-02
+TXN_5575561,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-02-13
+TXN_1007347,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-08-28
+TXN_8933459,Juice,1,3.0,3.0,,,2023-12-31
+TXN_3678091,Juice,ERROR,3.0,9.0,Cash,,2023-09-07
+TXN_7692628,Tea,2,1.5,3.0,Cash,,2023-05-01
+TXN_6731518,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-12-04
+TXN_3455702,Salad,1,5.0,5.0,Cash,Takeaway,2023-03-23
+TXN_7794561,Juice,4,3.0,12.0,Credit Card,In-store,2023-05-18
+TXN_8908193,Smoothie,5,4.0,20.0,Cash,UNKNOWN,2023-04-02
+TXN_7688625,Coffee,1,2.0,2.0,Credit Card,In-store,2023-12-15
+TXN_7012065,Coffee,3,2.0,6.0,ERROR,,2023-08-05
+TXN_4323570,ERROR,1,1.0,1.0,Cash,UNKNOWN,2023-03-04
+TXN_8831924,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-07-12
+TXN_2865104,Cake,5,3.0,15.0,,In-store,2023-03-12
+TXN_1360998,Cookie,2,1.0,2.0,Cash,Takeaway,2023-07-30
+TXN_4125921,Juice,5,3.0,15.0,Credit Card,,2023-01-26
+TXN_4657842,ERROR,ERROR,1.0,5.0,Cash,Takeaway,2023-09-29
+TXN_8149585,Juice,1,3.0,3.0,Credit Card,ERROR,2023-02-21
+TXN_9047278,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-06-20
+TXN_8666003,Smoothie,4,4.0,16.0,,Takeaway,2023-06-09
+TXN_7606512,Cookie,5,1.0,5.0,Cash,,2023-12-03
+TXN_1819615,Coffee,4,2.0,8.0,,,2023-06-03
+TXN_1931404,Cake,5,3.0,15.0,ERROR,In-store,2023-10-01
+TXN_4516901,Tea,2,1.5,3.0,Credit Card,In-store,2023-09-05
+TXN_6817795,Tea,1,1.5,1.5,Cash,Takeaway,2023-09-12
+TXN_4643515,,1,4.0,4.0,Digital Wallet,In-store,2023-10-03
+TXN_9762385,Tea,3,1.5,4.5,,,2023-05-19
+TXN_6809170,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-08-10
+TXN_7365744,Cookie,4,1.0,4.0,Cash,In-store,2023-08-20
+TXN_9847116,Salad,3,5.0,15.0,Cash,Takeaway,2023-07-28
+TXN_8356338,Salad,5,5.0,25.0,Credit Card,In-store,2023-08-06
+TXN_4413506,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-10-29
+TXN_1057209,UNKNOWN,5,1.0,5.0,Credit Card,In-store,2023-09-17
+TXN_9534685,Salad,1,5.0,5.0,UNKNOWN,Takeaway,2023-04-27
+TXN_4893692,Salad,2,5.0,10.0,,,2023-01-02
+TXN_5680629,Cake,2,3.0,6.0,,Takeaway,2023-04-30
+TXN_2494194,Salad,5,5.0,25.0,Digital Wallet,,2023-02-11
+TXN_4549825,Salad,2,5.0,10.0,Digital Wallet,,
+TXN_4737392,Sandwich,2,4.0,8.0,Cash,In-store,2023-02-17
+TXN_9538738,Coffee,4,2.0,8.0,Cash,In-store,2023-09-25
+TXN_1854102,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-07-18
+TXN_3109692,Juice,4,3.0,,Credit Card,In-store,2023-06-21
+TXN_5395229,Coffee,5,2.0,10.0,Cash,,2023-11-29
+TXN_8918902,Coffee,5,2.0,10.0,,,2023-05-22
+TXN_8837375,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-11-21
+TXN_3952218,Salad,5,5.0,UNKNOWN,,,2023-04-07
+TXN_3225552,Salad,1,5.0,5.0,,In-store,2023-05-16
+TXN_7950226,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-10-13
+TXN_9086541,Salad,3,5.0,15.0,Cash,In-store,2023-02-15
+TXN_1817596,Tea,2,1.5,3.0,UNKNOWN,In-store,2023-11-04
+TXN_7644786,Cookie,3,1.0,,Credit Card,Takeaway,2023-01-20
+TXN_8017969,Juice,1,3.0,3.0,Cash,Takeaway,2023-03-26
+TXN_6667388,Cake,3,3.0,9.0,Cash,In-store,2023-08-14
+TXN_3488611,Tea,1,1.5,,Cash,,2023-02-13
+TXN_3165950,UNKNOWN,1,2.0,2.0,Digital Wallet,,ERROR
+TXN_3109334,Smoothie,3,4.0,12.0,,In-store,2023-04-06
+TXN_9425645,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-03-19
+TXN_2461238,Coffee,1,2.0,2.0,,Takeaway,2023-01-29
+TXN_4692976,Juice,1,3.0,3.0,Digital Wallet,UNKNOWN,2023-11-06
+TXN_6747376,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-11-20
+TXN_3689335,Juice,1,3.0,3.0,,Takeaway,2023-12-11
+TXN_9662568,Tea,5,1.5,7.5,Cash,ERROR,2023-10-30
+TXN_9817681,UNKNOWN,4,1.5,6.0,,Takeaway,
+TXN_5470087,Salad,2,5.0,10.0,,Takeaway,2023-10-11
+TXN_3717372,Juice,2,3.0,6.0,Credit Card,ERROR,2023-02-15
+TXN_6727985,Salad,5,5.0,,Credit Card,In-store,2023-06-16
+TXN_1755661,Salad,5,5.0,25.0,,In-store,2023-07-14
+TXN_9899571,ERROR,2,5.0,10.0,Credit Card,Takeaway,2023-02-18
+TXN_5692316,Smoothie,1,4.0,4.0,Digital Wallet,UNKNOWN,2023-06-22
+TXN_2062269,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-09-08
+TXN_2160316,Sandwich,1,4.0,4.0,,In-store,2023-10-24
+TXN_4220743,Sandwich,4,4.0,16.0,,In-store,2023-10-22
+TXN_2726843,Sandwich,1,4.0,4.0,,In-store,2023-05-31
+TXN_9969283,Sandwich,3,4.0,12.0,Digital Wallet,,2023-10-26
+TXN_8540115,,2,1.5,3.0,UNKNOWN,,2023-06-26
+TXN_8313892,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-11-29
+TXN_3131761,Smoothie,1,4.0,4.0,,Takeaway,2023-10-18
+TXN_1243964,,3,1.5,4.5,,Takeaway,2023-12-01
+TXN_1856112,Salad,3,5.0,15.0,Credit Card,,2023-06-08
+TXN_4532651,Coffee,2,2.0,4.0,,In-store,2023-09-13
+TXN_4083736,Coffee,1,2.0,2.0,ERROR,In-store,2023-08-21
+TXN_4493176,Tea,3,1.5,4.5,,,2023-10-14
+TXN_6712994,Coffee,3,2.0,6.0,Cash,Takeaway,2023-10-02
+TXN_1840566,Coffee,4,2.0,8.0,,ERROR,2023-01-05
+TXN_6257776,Juice,5,3.0,15.0,Cash,In-store,2023-10-28
+TXN_9039165,Sandwich,4,4.0,16.0,,Takeaway,2023-03-10
+TXN_7056051,Cake,2,3.0,6.0,,,UNKNOWN
+TXN_3869150,Cookie,3,1.0,3.0,Cash,,2023-03-26
+TXN_3604156,Coffee,,2.0,10.0,Credit Card,Takeaway,2023-11-08
+TXN_2018236,Coffee,5,2.0,10.0,Cash,,2023-04-19
+TXN_4430176,Sandwich,4,UNKNOWN,16.0,Credit Card,Takeaway,2023-08-27
+TXN_6073195,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-09-13
+TXN_5245399,,5,UNKNOWN,10.0,,,2023-12-25
+TXN_4178872,Tea,1,1.5,1.5,Credit Card,,2023-01-25
+TXN_8836650,Smoothie,5,4.0,20.0,,ERROR,2023-05-22
+TXN_5882584,Cake,5,3.0,15.0,,In-store,2023-09-16
+TXN_4291132,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-08-07
+TXN_1622123,Cookie,2,1.0,2.0,Cash,Takeaway,2023-01-05
+TXN_2878078,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-12-15
+TXN_7134579,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-06-06
+TXN_6921057,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-07-10
+TXN_2335088,Salad,4,5.0,20.0,Cash,In-store,2023-10-27
+TXN_9778859,Cookie,3,1.0,3.0,Cash,Takeaway,2023-06-05
+TXN_3850274,Juice,5,3.0,15.0,,,2023-09-08
+TXN_4428448,Cookie,4,1.0,4.0,,,2023-02-04
+TXN_1062822,Juice,UNKNOWN,3.0,6.0,Credit Card,,2023-06-28
+TXN_6386662,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-12-04
+TXN_5491825,Cake,4,3.0,12.0,Cash,In-store,2023-06-09
+TXN_5330930,Cake,1,3.0,3.0,,In-store,2023-07-12
+TXN_5580933,Smoothie,3,4.0,,Cash,Takeaway,2023-10-19
+TXN_3326110,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-08-13
+TXN_5455079,Salad,2,5.0,10.0,Cash,In-store,2023-11-30
+TXN_5526475,Tea,4,1.5,6.0,Cash,In-store,2023-05-06
+TXN_3800253,Cake,2,3.0,6.0,Cash,Takeaway,2023-01-15
+TXN_2091128,Cake,1,3.0,3.0,Credit Card,UNKNOWN,UNKNOWN
+TXN_9169782,Juice,5,3.0,15.0,Credit Card,,2023-09-18
+TXN_4639621,Coffee,2,ERROR,4.0,,In-store,2023-10-12
+TXN_4432823,,5,4.0,20.0,,In-store,2023-02-10
+TXN_8138157,,2,4.0,8.0,Cash,Takeaway,2023-05-07
+TXN_4134478,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-06-25
+TXN_6298532,Smoothie,4,4.0,16.0,Digital Wallet,,
+TXN_4997327,Coffee,2,2.0,4.0,,In-store,2023-03-19
+TXN_9522899,Smoothie,5,4.0,UNKNOWN,Credit Card,Takeaway,ERROR
+TXN_4049949,Cookie,1,1.0,1.0,,Takeaway,2023-11-06
+TXN_7296498,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-05-19
+TXN_4706042,Salad,5,5.0,25.0,,In-store,2023-12-01
+TXN_2488987,Tea,5,1.5,7.5,Cash,In-store,2023-06-12
+TXN_6708156,Tea,5,1.5,7.5,Credit Card,,2023-11-26
+TXN_7616002,Tea,2,1.5,3.0,,In-store,2023-11-08
+TXN_1865735,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-09-22
+TXN_5396450,Juice,3,3.0,9.0,Digital Wallet,,2023-12-09
+TXN_5881757,Sandwich,3,4.0,12.0,Credit Card,,2023-08-15
+TXN_3404479,ERROR,4,4.0,16.0,Credit Card,,2023-08-23
+TXN_5342589,Tea,2,1.5,3.0,Digital Wallet,ERROR,2023-04-06
+TXN_1987212,Smoothie,5,4.0,ERROR,Credit Card,Takeaway,2023-04-07
+TXN_5303275,Cookie,4,1.0,4.0,Cash,Takeaway,2023-09-18
+TXN_9193760,Salad,5,5.0,25.0,ERROR,,2023-01-20
+TXN_8541074,Salad,4,5.0,20.0,,In-store,2023-11-08
+TXN_1075183,Tea,2,1.5,3.0,Credit Card,,2023-01-09
+TXN_9316158,Sandwich,5,4.0,20.0,Cash,In-store,2023-10-31
+TXN_8207244,Tea,5,1.5,7.5,Cash,Takeaway,2023-05-04
+TXN_2346001,UNKNOWN,2,5.0,10.0,Digital Wallet,Takeaway,2023-08-21
+TXN_2814866,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-07-29
+TXN_8454044,Coffee,5,2.0,10.0,Credit Card,,2023-05-27
+TXN_8321092,,2,3.0,6.0,Credit Card,,2023-09-28
+TXN_2560137,Cake,1,3.0,3.0,Cash,Takeaway,2023-10-13
+TXN_7350571,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-02-19
+TXN_3915802,Coffee,3,2.0,6.0,Cash,Takeaway,2023-12-16
+TXN_5019143,Coffee,5,2.0,10.0,Cash,,2023-02-21
+TXN_1785371,Coffee,1,2.0,2.0,UNKNOWN,Takeaway,2023-01-16
+TXN_6441650,Cake,5,3.0,15.0,UNKNOWN,Takeaway,2023-09-06
+TXN_2493262,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-01-03
+TXN_3257591,Sandwich,1,4.0,4.0,Credit Card,In-store,UNKNOWN
+TXN_6038791,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-03-06
+TXN_1335337,Tea,3,1.5,4.5,Credit Card,In-store,2023-09-06
+TXN_2275914,Sandwich,2,4.0,8.0,UNKNOWN,Takeaway,2023-10-24
+TXN_6258276,Sandwich,5,4.0,20.0,Credit Card,UNKNOWN,2023-01-29
+TXN_2340312,Cake,4,3.0,12.0,UNKNOWN,Takeaway,2023-07-30
+TXN_6066433,Tea,2,1.5,,Cash,,2023-06-17
+TXN_1872922,Sandwich,5,4.0,20.0,,In-store,2023-07-16
+TXN_7730388,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-09-09
+TXN_3330377,ERROR,5,2.0,10.0,,,2023-05-08
+TXN_3147198,Smoothie,2,4.0,8.0,Digital Wallet,,2023-02-04
+TXN_6363897,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-11-26
+TXN_1893222,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-12-20
+TXN_9262803,Juice,5,3.0,15.0,Digital Wallet,,2023-10-04
+TXN_9491912,Tea,4,1.5,6.0,Cash,In-store,ERROR
+TXN_6992164,Sandwich,2,4.0,8.0,Cash,Takeaway,ERROR
+TXN_6577035,Smoothie,2,4.0,8.0,,In-store,2023-05-20
+TXN_9970966,Coffee,5,2.0,10.0,,In-store,2023-09-09
+TXN_5624179,Cookie,1,1.0,1.0,Cash,Takeaway,2023-10-26
+TXN_3450160,Cake,4,3.0,12.0,Credit Card,In-store,2023-10-23
+TXN_4075432,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-12
+TXN_2023802,Cake,2,3.0,6.0,Cash,In-store,2023-02-28
+TXN_5130399,Cookie,3,1.0,,,,2023-10-21
+TXN_6745832,Coffee,2,2.0,4.0,Credit Card,UNKNOWN,2023-10-02
+TXN_7560989,Sandwich,3,4.0,12.0,Digital Wallet,,2023-06-16
+TXN_9367492,Tea,2,,,Cash,In-store,2023-06-19
+TXN_3115258,Salad,1,5.0,5.0,,Takeaway,2023-12-06
+TXN_8182245,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-10-24
+TXN_3970335,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-09-01
+TXN_6376630,,2,3.0,6.0,Cash,In-store,2023-01-24
+TXN_7100596,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-09-14
+TXN_1481116,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-02-26
+TXN_9454212,Juice,5,3.0,15.0,Cash,In-store,2023-11-19
+TXN_3648327,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-08-17
+TXN_6188394,Juice,5,3.0,15.0,Credit Card,In-store,2023-10-05
+TXN_2553803,Juice,1,3.0,3.0,Cash,In-store,2023-12-29
+TXN_5700545,Salad,2,5.0,10.0,Credit Card,,2023-05-25
+TXN_8018479,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-09-15
+TXN_9465300,Tea,2,1.5,3.0,Credit Card,UNKNOWN,2023-09-01
+TXN_3046108,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-01-15
+TXN_5998419,Juice,4,3.0,12.0,,Takeaway,2023-09-26
+TXN_4454198,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-08-22
+TXN_5855756,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-08-29
+TXN_5182399,UNKNOWN,3,2.0,ERROR,Digital Wallet,Takeaway,2023-09-08
+TXN_6758675,Juice,1,3.0,3.0,Credit Card,In-store,2023-11-05
+TXN_1962275,Coffee,5,ERROR,10.0,Credit Card,Takeaway,2023-05-26
+TXN_9530003,Salad,1,5.0,5.0,Digital Wallet,,2023-08-24
+TXN_2347596,Juice,4,3.0,12.0,Credit Card,,2023-12-27
+TXN_6215303,Salad,4,5.0,20.0,,Takeaway,2023-08-20
+TXN_5524352,Sandwich,1,4.0,4.0,,,2023-01-05
+TXN_6668414,Cake,1,3.0,UNKNOWN,ERROR,In-store,2023-12-29
+TXN_8715122,Cake,2,3.0,6.0,Cash,Takeaway,ERROR
+TXN_1525046,Smoothie,2,4.0,8.0,Cash,,2023-12-02
+TXN_9867948,Smoothie,2,4.0,8.0,Digital Wallet,,2023-10-07
+TXN_8512466,UNKNOWN,5,3.0,15.0,,,2023-02-10
+TXN_9663990,Juice,1,3.0,3.0,,,2023-01-06
+TXN_7681072,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-07-07
+TXN_3099191,Salad,ERROR,5.0,10.0,ERROR,,2023-05-19
+TXN_8789986,Cake,2,3.0,6.0,Cash,Takeaway,2023-09-21
+TXN_8382825,Coffee,5,2.0,10.0,Cash,In-store,2023-01-20
+TXN_4486700,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-02-08
+TXN_2668108,Cookie,5,1.0,5.0,Cash,,2023-09-23
+TXN_5085328,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-02-03
+TXN_6023823,Cookie,2,1.0,2.0,Digital Wallet,,2023-04-20
+TXN_6541659,Sandwich,3,4.0,12.0,,Takeaway,2023-01-29
+TXN_3203928,Coffee,3,2.0,6.0,,In-store,2023-12-04
+TXN_3443235,Sandwich,5,4.0,20.0,,UNKNOWN,2023-10-11
+TXN_6191769,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-05-17
+TXN_6110386,Smoothie,1,4.0,4.0,Cash,In-store,2023-03-17
+TXN_7355635,Juice,3,3.0,9.0,,In-store,2023-12-21
+TXN_2944518,UNKNOWN,3,3.0,9.0,,Takeaway,2023-09-14
+TXN_9169536,Cake,5,3.0,UNKNOWN,Cash,In-store,2023-06-10
+TXN_8257774,Cookie,5,1.0,5.0,Cash,Takeaway,2023-03-04
+TXN_3873718,ERROR,1,5.0,5.0,Cash,In-store,2023-03-07
+TXN_8767676,Smoothie,1,4.0,4.0,,,2023-11-30
+TXN_1225638,Cake,4,3.0,12.0,Cash,Takeaway,2023-05-28
+TXN_5050111,,3,5.0,15.0,Cash,In-store,2023-06-13
+TXN_5508620,Sandwich,2,4.0,8.0,Cash,In-store,2023-08-26
+TXN_7864080,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-11-12
+TXN_6066883,Cake,2,3.0,6.0,Credit Card,,2023-12-21
+TXN_6034785,Coffee,3,2.0,6.0,Digital Wallet,,2023-06-17
+TXN_7818024,Cake,3,3.0,9.0,,,2023-08-16
+TXN_2463115,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-09-12
+TXN_9948425,Cake,3,3.0,9.0,UNKNOWN,Takeaway,2023-11-21
+TXN_2540440,,2,1.5,3.0,Digital Wallet,,2023-12-30
+TXN_2006923,Salad,5,5.0,25.0,Digital Wallet,,2023-05-31
+TXN_6762172,Coffee,5,2.0,10.0,Cash,Takeaway,2023-01-19
+TXN_6638051,Smoothie,2,4.0,8.0,Cash,,2023-11-05
+TXN_9834329,Smoothie,ERROR,4.0,4.0,Cash,,2023-09-17
+TXN_9172616,UNKNOWN,4,2.0,8.0,,Takeaway,2023-11-21
+TXN_8867300,Smoothie,4,4.0,16.0,,In-store,2023-05-06
+TXN_6987950,Cake,4,3.0,12.0,Credit Card,,2023-05-04
+TXN_9967728,Coffee,4,2.0,8.0,,,2023-01-30
+TXN_5591967,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-04-08
+TXN_5861158,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-11-21
+TXN_7501002,Coffee,1,2.0,2.0,Digital Wallet,UNKNOWN,2023-08-23
+TXN_2848654,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-03-15
+TXN_2406254,UNKNOWN,5,3.0,15.0,,Takeaway,2023-11-12
+TXN_3034652,Juice,5,3.0,15.0,Credit Card,In-store,2023-11-04
+TXN_2710779,Sandwich,5,4.0,UNKNOWN,Digital Wallet,In-store,2023-09-30
+TXN_2333576,Tea,2,ERROR,3.0,Digital Wallet,Takeaway,2023-11-22
+TXN_6330369,Juice,1,3.0,3.0,UNKNOWN,,2023-01-25
+TXN_7852032,Sandwich,1,4.0,4.0,Cash,,2023-03-19
+TXN_7189368,Sandwich,2,4.0,8.0,Credit Card,,2023-01-22
+TXN_6306655,,4,1.0,ERROR,Digital Wallet,Takeaway,2023-01-22
+TXN_7169320,Coffee,3,2.0,6.0,Credit Card,,ERROR
+TXN_6607568,Coffee,2,2.0,4.0,Cash,In-store,2023-03-24
+TXN_8245906,Cake,1,ERROR,3.0,Digital Wallet,,2023-02-08
+TXN_9837568,Salad,5,5.0,25.0,Cash,In-store,2023-04-17
+TXN_9603263,Cookie,5,1.0,5.0,Cash,ERROR,2023-05-02
+TXN_9425610,Sandwich,3,4.0,12.0,Cash,In-store,2023-01-08
+TXN_8092496,Juice,4,3.0,12.0,,In-store,2023-03-11
+TXN_3611851,,4,ERROR,ERROR,Credit Card,,2023-02-09
+TXN_9749333,Cookie,5,1.0,5.0,Cash,In-store,2023-02-27
+TXN_2771364,Coffee,1,2.0,2.0,Digital Wallet,,2023-01-23
+TXN_5180326,Juice,,3.0,12.0,,,2023-04-26
+TXN_7376092,Cookie,4,1.0,4.0,Cash,In-store,2023-11-07
+TXN_9279347,Sandwich,,4.0,20.0,Credit Card,,2023-02-27
+TXN_8278982,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-09-06
+TXN_7686476,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-01-03
+TXN_4283563,ERROR,2,1.5,3.0,Cash,UNKNOWN,2023-05-04
+TXN_1926278,Cookie,1,1.0,1.0,Credit Card,,2023-07-29
+TXN_3981000,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-05-24
+TXN_6167259,Juice,2,3.0,6.0,Digital Wallet,,2023-04-14
+TXN_7068653,Cookie,2,UNKNOWN,2.0,Cash,In-store,2023-06-05
+TXN_1572930,Coffee,3,2.0,6.0,,In-store,2023-07-17
+TXN_2788797,Tea,2,1.5,3.0,,,2023-03-23
+TXN_4255767,Juice,1,3.0,3.0,,,2023-05-25
+TXN_7367474,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-01-01
+TXN_7551097,Cake,2,3.0,6.0,Digital Wallet,ERROR,2023-06-12
+TXN_1546695,Coffee,5,2.0,,,Takeaway,2023-03-06
+TXN_4030010,Sandwich,5,4.0,20.0,,Takeaway,
+TXN_4567455,Coffee,3,2.0,6.0,,In-store,2023-02-01
+TXN_7958487,Cookie,5,1.0,5.0,,,2023-01-20
+TXN_2864420,Sandwich,1,4.0,4.0,,,2023-07-12
+TXN_1498343,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-03-31
+TXN_3107619,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-05-31
+TXN_1923349,ERROR,4,ERROR,6.0,,,2023-07-06
+TXN_7380217,Tea,1,1.5,1.5,Digital Wallet,,2023-09-10
+TXN_3195132,Salad,4,5.0,,Credit Card,,2023-08-26
+TXN_9001088,Coffee,2,,4.0,Credit Card,,2023-08-19
+TXN_2101437,,2,4.0,8.0,Cash,In-store,2023-08-27
+TXN_7411993,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-02-11
+TXN_2879092,ERROR,3,1.5,4.5,Cash,,2023-05-22
+TXN_8791641,Tea,5,1.5,7.5,,In-store,2023-01-25
+TXN_4679593,Juice,1,3.0,3.0,Cash,In-store,2023-01-10
+TXN_1907250,Cookie,1,1.0,1.0,Credit Card,,2023-11-15
+TXN_8504764,,2,4.0,8.0,Digital Wallet,Takeaway,2023-02-19
+TXN_1630051,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-03-17
+TXN_2566258,Cookie,4,1.0,4.0,Cash,Takeaway,2023-06-08
+TXN_5785600,Salad,5,5.0,ERROR,Cash,In-store,2023-12-10
+TXN_4864206,Cookie,5,1.0,5.0,Cash,In-store,2023-03-18
+TXN_4360040,Salad,1,5.0,5.0,Credit Card,,2023-11-15
+TXN_9490163,Salad,4,5.0,20.0,Credit Card,,2023-02-23
+TXN_2640727,ERROR,3,3.0,9.0,Digital Wallet,Takeaway,2023-03-05
+TXN_9927061,Cookie,2,1.0,2.0,,,2023-10-17
+TXN_5113993,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-02-10
+TXN_2192787,Sandwich,5,4.0,20.0,Cash,In-store,2023-01-01
+TXN_2127588,Cake,4,3.0,12.0,Cash,In-store,2023-07-17
+TXN_5284338,,4,2.0,8.0,Cash,Takeaway,2023-03-30
+TXN_8108748,Sandwich,1,4.0,4.0,Cash,UNKNOWN,2023-06-19
+TXN_5538713,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-09-20
+TXN_5949811,Tea,UNKNOWN,1.5,3.0,Digital Wallet,In-store,2023-02-21
+TXN_2565449,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-10-04
+TXN_7264039,Cake,5,3.0,15.0,Cash,,2023-09-19
+TXN_9224501,Salad,5,5.0,25.0,Credit Card,In-store,2023-12-08
+TXN_5767393,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-09-11
+TXN_2628024,Smoothie,1,4.0,4.0,,In-store,2023-05-02
+TXN_4638629,Smoothie,4,4.0,,Credit Card,,2023-02-10
+TXN_9287133,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-04-20
+TXN_6223786,Cake,5,3.0,15.0,Cash,,2023-07-05
+TXN_5460750,Juice,3,3.0,9.0,Credit Card,,2023-07-31
+TXN_6792445,Cake,,3.0,9.0,Cash,ERROR,2023-12-03
+TXN_2543138,Sandwich,1,4.0,4.0,Credit Card,,2023-05-20
+TXN_7134064,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-04-04
+TXN_8616163,Smoothie,ERROR,4.0,8.0,,Takeaway,UNKNOWN
+TXN_9201988,Coffee,3,2.0,6.0,,,2023-05-14
+TXN_5486063,Smoothie,3,4.0,12.0,Cash,In-store,2023-05-21
+TXN_2285849,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-09-10
+TXN_9577271,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-30
+TXN_6568536,Cake,1,3.0,3.0,Cash,,2023-12-29
+TXN_6802372,Juice,3,3.0,9.0,,In-store,2023-07-20
+TXN_2624121,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-01-28
+TXN_8994477,Coffee,3,,6.0,,In-store,2023-04-19
+TXN_7868879,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-05-02
+TXN_8321225,ERROR,4,1.5,6.0,Credit Card,Takeaway,2023-08-20
+TXN_1439390,Juice,4,3.0,12.0,,In-store,2023-02-14
+TXN_9373436,Salad,4,5.0,20.0,Digital Wallet,,2023-04-06
+TXN_6243519,Coffee,3,2.0,6.0,Cash,Takeaway,2023-03-03
+TXN_8668901,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-06-30
+TXN_4903004,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-12-03
+TXN_2195218,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-09-10
+TXN_9678108,Salad,3,5.0,15.0,ERROR,Takeaway,2023-10-10
+TXN_3206876,Salad,4,5.0,20.0,,In-store,2023-11-07
+TXN_3064922,UNKNOWN,ERROR,5.0,10.0,Cash,,2023-11-12
+TXN_7362525,Cake,5,3.0,15.0,Cash,Takeaway,2023-06-09
+TXN_2161341,Salad,5,5.0,25.0,Digital Wallet,ERROR,2023-03-12
+TXN_8753888,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-12-25
+TXN_3265596,Tea,1,1.5,1.5,Cash,,2023-12-28
+TXN_2815691,Juice,5,3.0,15.0,Digital Wallet,ERROR,2023-02-06
+TXN_8956534,Coffee,5,2.0,10.0,Cash,Takeaway,2023-06-05
+TXN_7957208,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-04-14
+TXN_6851213,Juice,1,3.0,3.0,Digital Wallet,,2023-05-19
+TXN_7127903,Coffee,5,2.0,10.0,,In-store,2023-11-27
+TXN_7543722,Cookie,3,1.0,3.0,Digital Wallet,,2023-08-26
+TXN_7952680,ERROR,1,5.0,5.0,ERROR,,2023-06-09
+TXN_8556062,Sandwich,5,4.0,20.0,,,2023-08-07
+TXN_8429412,Smoothie,4,4.0,16.0,,,2023-06-23
+TXN_3817784,Salad,,5.0,5.0,,,2023-11-25
+TXN_1749105,Sandwich,5,4.0,20.0,Cash,In-store,2023-10-17
+TXN_9731530,Tea,UNKNOWN,1.5,6.0,Credit Card,,2023-06-23
+TXN_1248266,Salad,3,5.0,15.0,Credit Card,In-store,2023-10-14
+TXN_5400273,Smoothie,4,4.0,16.0,Credit Card,,2023-05-24
+TXN_2255634,Salad,4,5.0,20.0,,,2023-04-09
+TXN_3312002,Smoothie,4,4.0,16.0,Digital Wallet,,2023-04-30
+TXN_5331122,Salad,4,5.0,20.0,Credit Card,In-store,2023-09-26
+TXN_1227800,Juice,3,3.0,9.0,Cash,Takeaway,2023-02-19
+TXN_1867836,Juice,1,3.0,3.0,Credit Card,,2023-03-21
+TXN_3051509,Cookie,ERROR,1.0,5.0,,In-store,2023-03-07
+TXN_5108804,Juice,1,,3.0,Digital Wallet,In-store,2023-09-26
+TXN_2699583,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-07-26
+TXN_1622577,Juice,1,3.0,3.0,Cash,,2023-03-14
+TXN_9508880,Coffee,4,2.0,8.0,,In-store,2023-10-26
+TXN_2156218,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-07-24
+TXN_8271025,Juice,5,3.0,15.0,Credit Card,,2023-03-09
+TXN_4894699,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-02-20
+TXN_5427338,Cake,ERROR,3.0,6.0,Digital Wallet,In-store,2023-04-27
+TXN_8631468,Cake,1,3.0,3.0,Credit Card,In-store,2023-10-10
+TXN_6315590,Tea,5,1.5,7.5,,In-store,2023-10-04
+TXN_7825457,Cake,5,3.0,15.0,Cash,ERROR,2023-09-15
+TXN_7468777,Salad,1,5.0,5.0,Digital Wallet,In-store,
+TXN_2378096,Tea,3,1.5,4.5,Cash,Takeaway,2023-09-22
+TXN_2627056,Sandwich,4,4.0,16.0,Digital Wallet,,2023-04-22
+TXN_5062280,Smoothie,4,4.0,16.0,Credit Card,,2023-07-05
+TXN_3620110,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-06-01
+TXN_7290923,Salad,3,5.0,15.0,UNKNOWN,,2023-02-09
+TXN_7844687,Cake,1,3.0,3.0,,In-store,ERROR
+TXN_1005331,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-11-04
+TXN_1579182,Juice,5,3.0,15.0,Cash,In-store,2023-02-20
+TXN_7311097,Coffee,5,2.0,10.0,,In-store,2023-08-05
+TXN_1185118,UNKNOWN,5,3.0,,,,UNKNOWN
+TXN_4836614,ERROR,4,1.5,6.0,Digital Wallet,,2023-04-03
+TXN_7477271,Tea,5,1.5,7.5,,Takeaway,2023-07-12
+TXN_6503052,Juice,4,3.0,12.0,,,2023-04-21
+TXN_6471268,Smoothie,5,4.0,20.0,Digital Wallet,,2023-02-10
+TXN_3985301,Smoothie,2,4.0,8.0,,In-store,ERROR
+TXN_6843517,Sandwich,5,4.0,ERROR,Credit Card,In-store,2023-01-02
+TXN_9370304,Smoothie,4,,16.0,,Takeaway,2023-09-01
+TXN_9298053,Juice,5,3.0,15.0,Cash,In-store,2023-06-29
+TXN_1446862,Cake,3,3.0,9.0,,Takeaway,2023-09-26
+TXN_4987246,Cookie,3,1.0,UNKNOWN,Digital Wallet,Takeaway,2023-11-24
+TXN_6271219,Sandwich,3,4.0,12.0,Cash,,2023-06-07
+TXN_2614545,Tea,1,1.5,1.5,UNKNOWN,In-store,2023-08-10
+TXN_4917580,ERROR,3,2.0,6.0,,In-store,2023-03-08
+TXN_6236864,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-08-17
+TXN_7825648,Coffee,1,2.0,2.0,,Takeaway,2023-05-18
+TXN_1853196,Sandwich,1,4.0,4.0,Credit Card,,2023-08-28
+TXN_7201361,Smoothie,3,4.0,12.0,Cash,In-store,2023-05-26
+TXN_6902481,Juice,3,3.0,9.0,Cash,,2023-09-03
+TXN_4041845,Juice,5,3.0,15.0,,,2023-12-01
+TXN_8861272,Coffee,1,2.0,2.0,Digital Wallet,,2023-03-27
+TXN_7527954,Cake,4,3.0,12.0,,UNKNOWN,2023-12-09
+TXN_2229365,Sandwich,2,4.0,8.0,Cash,In-store,2023-09-07
+TXN_5563675,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-01-01
+TXN_7416770,,3,3.0,9.0,,Takeaway,2023-04-08
+TXN_6594187,Tea,5,1.5,7.5,UNKNOWN,,UNKNOWN
+TXN_8632098,Salad,2,UNKNOWN,10.0,,,2023-01-06
+TXN_3520908,Sandwich,3,UNKNOWN,12.0,Digital Wallet,ERROR,2023-08-01
+TXN_7907499,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-04-18
+TXN_8360073,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-06-15
+TXN_4840295,,4,4.0,16.0,Digital Wallet,Takeaway,2023-02-02
+TXN_4140167,Coffee,2,2.0,4.0,Cash,UNKNOWN,2023-06-29
+TXN_2690515,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-09-06
+TXN_2080682,Coffee,3,2.0,6.0,Credit Card,In-store,2023-05-02
+TXN_8399341,Tea,5,1.5,7.5,Cash,,2023-03-22
+TXN_5661891,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-10-28
+TXN_3164212,Smoothie,4,4.0,16.0,,In-store,2023-11-14
+TXN_1834831,ERROR,5,5.0,25.0,Digital Wallet,In-store,2023-02-16
+TXN_3360401,UNKNOWN,2,1.5,3.0,,Takeaway,2023-02-05
+TXN_6036520,Coffee,5,2.0,10.0,Cash,,2023-09-15
+TXN_1582958,Coffee,2,2.0,4.0,Cash,,2023-12-08
+TXN_9834415,Cookie,2,1.0,2.0,Credit Card,In-store,2023-12-28
+TXN_7325430,Coffee,2,2.0,4.0,Cash,,2023-04-17
+TXN_6440365,Smoothie,2,4.0,8.0,Cash,,2023-05-14
+TXN_4002629,Cake,5,3.0,15.0,Credit Card,In-store,2023-06-15
+TXN_4244830,Coffee,5,2.0,10.0,,In-store,2023-04-24
+TXN_2217038,Tea,5,1.5,7.5,ERROR,,2023-06-12
+TXN_6259827,Cake,2,,6.0,Credit Card,Takeaway,2023-06-14
+TXN_6551087,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-05-02
+TXN_1643039,Cookie,3,1.0,3.0,,,2023-02-17
+TXN_3683787,Tea,5,ERROR,7.5,Credit Card,,2023-09-16
+TXN_5765576,Sandwich,5,4.0,20.0,,In-store,2023-11-22
+TXN_4155134,Cookie,1,1.0,1.0,,Takeaway,2023-05-07
+TXN_1795044,Coffee,2,2.0,4.0,Digital Wallet,UNKNOWN,2023-08-15
+TXN_3328393,ERROR,3,3.0,9.0,,,2023-04-16
+TXN_2399870,Salad,4,5.0,20.0,,,2023-04-08
+TXN_8898121,Tea,4,1.5,6.0,Digital Wallet,,2023-03-26
+TXN_4735392,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-04-04
+TXN_3244935,Salad,5,5.0,25.0,,Takeaway,2023-11-24
+TXN_8410712,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-10-23
+TXN_8997048,Juice,1,3.0,3.0,,In-store,2023-12-05
+TXN_6009395,Sandwich,4,4.0,16.0,Cash,In-store,2023-07-20
+TXN_3733753,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-03-10
+TXN_4084548,Salad,2,5.0,10.0,Cash,In-store,2023-07-21
+TXN_7125945,Cake,3,3.0,9.0,Credit Card,In-store,2023-01-30
+TXN_6746140,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,ERROR
+TXN_8103439,Smoothie,1,4.0,4.0,,Takeaway,2023-11-30
+TXN_9474082,UNKNOWN,3,5.0,15.0,Digital Wallet,In-store,2023-03-22
+TXN_2623927,Sandwich,2,4.0,8.0,UNKNOWN,,2023-01-27
+TXN_8707598,Juice,4,,12.0,Credit Card,,2023-10-22
+TXN_2810554,UNKNOWN,1,3.0,3.0,Credit Card,Takeaway,2023-02-18
+TXN_5435751,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-05-24
+TXN_9991468,Juice,4,3.0,12.0,Credit Card,,2023-11-30
+TXN_1339457,ERROR,3,4.0,ERROR,Digital Wallet,In-store,2023-05-23
+TXN_5186460,Juice,3,3.0,9.0,Credit Card,UNKNOWN,2023-11-07
+TXN_8936782,Juice,5,3.0,UNKNOWN,,In-store,2023-04-01
+TXN_6885561,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-06-24
+TXN_4089089,Smoothie,5,4.0,20.0,,,2023-10-26
+TXN_6304285,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-11-16
+TXN_7792996,Salad,4,5.0,20.0,Cash,,2023-12-20
+TXN_3653328,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-06-27
+TXN_3003876,Cookie,3,1.0,3.0,Cash,ERROR,2023-08-27
+TXN_4015634,Tea,2,1.5,3.0,,,2023-06-28
+TXN_8166394,Juice,4,3.0,12.0,Credit Card,,2023-12-22
+TXN_1270603,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-12-03
+TXN_8837886,Smoothie,3,4.0,ERROR,,,2023-04-20
+TXN_1437275,Coffee,3,2.0,6.0,Credit Card,,2023-07-22
+TXN_5791605,Smoothie,3,4.0,12.0,,Takeaway,2023-05-17
+TXN_5836079,Coffee,1,2.0,2.0,Digital Wallet,,2023-07-14
+TXN_2897115,UNKNOWN,3,2.0,6.0,Digital Wallet,In-store,2023-06-23
+TXN_8916613,Salad,4,5.0,20.0,ERROR,Takeaway,2023-06-19
+TXN_9251292,Tea,2,1.5,3.0,Cash,UNKNOWN,2023-01-20
+TXN_9639025,Coffee,5,2.0,10.0,,,2023-12-06
+TXN_7770253,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-01-06
+TXN_9196116,Cake,2,ERROR,6.0,,In-store,2023-07-06
+TXN_5405799,Coffee,3,2.0,6.0,Cash,ERROR,2023-08-13
+TXN_1701500,Smoothie,1,4.0,4.0,ERROR,Takeaway,2023-01-05
+TXN_6669163,Cookie,ERROR,1.0,1.0,Credit Card,Takeaway,2023-07-26
+TXN_9695128,Cake,1,3.0,3.0,Cash,In-store,2023-12-21
+TXN_8700156,Tea,4,ERROR,6.0,Credit Card,In-store,2023-12-25
+TXN_7192920,Smoothie,4,4.0,16.0,Digital Wallet,ERROR,2023-02-28
+TXN_1866816,Juice,3,3.0,9.0,,In-store,2023-08-21
+TXN_2423762,Coffee,1,2.0,2.0,,,2023-08-12
+TXN_4007506,Salad,1,5.0,5.0,,,2023-01-19
+TXN_4371760,Smoothie,2,4.0,8.0,Cash,In-store,2023-01-12
+TXN_4468830,Smoothie,4,4.0,ERROR,Digital Wallet,In-store,2023-11-10
+TXN_1908100,Juice,2,3.0,6.0,,In-store,2023-04-17
+TXN_3892344,Cookie,2,1.0,2.0,,,2023-07-28
+TXN_3023841,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-04-29
+TXN_8793244,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-05-08
+TXN_5764993,Salad,3,5.0,,ERROR,Takeaway,2023-04-26
+TXN_2376525,Sandwich,5,4.0,20.0,ERROR,,
+TXN_2628941,Smoothie,1,4.0,4.0,,In-store,2023-12-27
+TXN_5206049,,3,UNKNOWN,3.0,Digital Wallet,,2023-06-24
+TXN_5448602,Juice,3,3.0,9.0,Credit Card,In-store,2023-01-17
+TXN_1346517,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-03-20
+TXN_9277534,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-04-25
+TXN_4946991,Cake,1,ERROR,3.0,UNKNOWN,UNKNOWN,2023-04-17
+TXN_9663098,Juice,2,3.0,6.0,Cash,,2023-06-10
+TXN_2492586,Salad,3,ERROR,15.0,Cash,,2023-05-17
+TXN_2450799,Tea,5,UNKNOWN,7.5,ERROR,UNKNOWN,2023-11-26
+TXN_6145837,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-08-27
+TXN_3665727,Cookie,1,1.0,1.0,,In-store,2023-10-13
+TXN_5067056,Sandwich,1,4.0,4.0,Cash,In-store,2023-08-13
+TXN_8453110,Smoothie,3,4.0,12.0,Digital Wallet,UNKNOWN,2023-06-24
+TXN_4954887,Cookie,3,1.0,3.0,,In-store,2023-06-11
+TXN_4449173,,ERROR,2.0,2.0,Digital Wallet,Takeaway,2023-04-05
+TXN_6641409,UNKNOWN,5,4.0,20.0,Digital Wallet,ERROR,2023-11-21
+TXN_6132959,Salad,5,5.0,25.0,Digital Wallet,,2023-07-01
+TXN_8626161,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-11-23
+TXN_7099050,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-01-18
+TXN_8938663,Coffee,1,2.0,2.0,Digital Wallet,,2023-09-09
+TXN_5039624,Cookie,4,1.0,4.0,,Takeaway,2023-04-27
+TXN_9565465,Tea,3,1.5,4.5,Credit Card,In-store,2023-12-26
+TXN_6301600,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-02-28
+TXN_1529904,Coffee,1,2.0,2.0,Credit Card,In-store,
+TXN_4784128,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-08-27
+TXN_5807634,Sandwich,5,4.0,20.0,Digital Wallet,,2023-05-23
+TXN_5560205,Coffee,3,2.0,6.0,Cash,In-store,2023-12-22
+TXN_2193092,Juice,4,ERROR,12.0,,Takeaway,2023-10-30
+TXN_8191921,Salad,3,5.0,15.0,Digital Wallet,,
+TXN_1833277,Tea,2,1.5,3.0,,Takeaway,2023-10-19
+TXN_6346774,Juice,3,3.0,9.0,Cash,In-store,UNKNOWN
+TXN_6119798,Salad,1,5.0,5.0,Credit Card,In-store,2023-09-19
+TXN_9793353,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-08-21
+TXN_5017895,Salad,4,5.0,20.0,Cash,,2023-09-25
+TXN_4547995,Cake,3,3.0,9.0,Digital Wallet,,2023-11-30
+TXN_7032256,Sandwich,5,4.0,20.0,Credit Card,,2023-03-13
+TXN_2578309,Smoothie,3,4.0,12.0,,ERROR,2023-05-05
+TXN_2064360,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-08-30
+TXN_5508573,Cake,1,3.0,3.0,,Takeaway,2023-12-17
+TXN_7125392,Cookie,4,UNKNOWN,4.0,Digital Wallet,Takeaway,2023-07-05
+TXN_2564219,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-07-18
+TXN_1203954,Sandwich,1,4.0,4.0,Digital Wallet,,2023-08-12
+TXN_4671054,UNKNOWN,,5.0,20.0,Cash,,2023-06-20
+TXN_4488222,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-03-13
+TXN_3103967,Juice,2,3.0,6.0,Credit Card,ERROR,2023-11-12
+TXN_9853577,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-04-30
+TXN_4349597,Juice,4,3.0,12.0,Credit Card,ERROR,2023-08-21
+TXN_3353214,Smoothie,5,4.0,20.0,Credit Card,,2023-08-12
+TXN_7122708,Sandwich,5,,20.0,,Takeaway,2023-06-23
+TXN_8788437,Coffee,1,2.0,2.0,,UNKNOWN,2023-11-19
+TXN_1672443,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-10-03
+TXN_6277500,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-01-09
+TXN_6671827,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-08-09
+TXN_4647042,Sandwich,5,4.0,20.0,,Takeaway,2023-04-25
+TXN_1183212,Juice,4,3.0,12.0,,In-store,2023-06-30
+TXN_8426712,Cookie,3,1.0,3.0,,In-store,2023-05-22
+TXN_5894676,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-06-17
+TXN_1411744,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-09-17
+TXN_6610554,Coffee,5,2.0,10.0,Digital Wallet,,2023-10-28
+TXN_6169248,Juice,5,3.0,15.0,Credit Card,,2023-08-12
+TXN_1581997,Salad,4,5.0,20.0,Digital Wallet,,2023-08-26
+TXN_4868913,Cake,4,3.0,12.0,Cash,,2023-06-30
+TXN_8277553,Tea,3,1.5,4.5,Cash,,2023-09-26
+TXN_4030197,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-03-05
+TXN_7276927,Coffee,5,ERROR,10.0,Cash,Takeaway,2023-07-06
+TXN_3912836,Salad,1,5.0,5.0,Credit Card,In-store,2023-11-23
+TXN_3833729,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-11-13
+TXN_7054393,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-05-30
+TXN_1395083,Juice,1,3.0,3.0,Cash,In-store,2023-07-08
+TXN_8784653,Smoothie,1,4.0,4.0,Cash,In-store,2023-09-12
+TXN_3943666,Juice,4,3.0,12.0,,Takeaway,2023-03-15
+TXN_8308672,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-01-01
+TXN_3190959,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-12-16
+TXN_6199016,Juice,1,3.0,3.0,Digital Wallet,,2023-02-14
+TXN_9301279,Smoothie,1,UNKNOWN,4.0,Credit Card,UNKNOWN,2023-05-27
+TXN_8900751,Sandwich,1,4.0,ERROR,UNKNOWN,Takeaway,2023-01-30
+TXN_6542877,Juice,1,3.0,3.0,,In-store,2023-12-06
+TXN_5516804,Sandwich,,4.0,20.0,Credit Card,Takeaway,2023-09-26
+TXN_6345733,Coffee,1,2.0,2.0,,In-store,2023-11-26
+TXN_5834491,Tea,3,1.5,4.5,,,2023-08-13
+TXN_1667192,Cake,4,3.0,12.0,UNKNOWN,Takeaway,2023-07-17
+TXN_1454730,Coffee,5,2.0,10.0,,Takeaway,2023-07-21
+TXN_3243832,Cake,2,3.0,6.0,,,2023-08-10
+TXN_7501717,Sandwich,1,4.0,4.0,Credit Card,,2023-08-03
+TXN_1351151,Smoothie,ERROR,4.0,4.0,Credit Card,,2023-10-03
+TXN_6117497,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-02-13
+TXN_6018740,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,
+TXN_3818464,Cake,2,3.0,6.0,Cash,In-store,2023-03-02
+TXN_2093816,Sandwich,ERROR,4.0,12.0,Cash,Takeaway,2023-04-06
+TXN_7694020,Cookie,2,,2.0,Digital Wallet,Takeaway,2023-08-06
+TXN_4215488,Salad,5,5.0,25.0,,In-store,2023-10-07
+TXN_5167425,Juice,UNKNOWN,3.0,15.0,Digital Wallet,,2023-08-04
+TXN_7075261,Juice,1,3.0,3.0,,,2023-07-29
+TXN_2694724,Sandwich,2,4.0,8.0,Digital Wallet,,2023-06-26
+TXN_8285304,Cookie,1,1.0,1.0,Cash,,2023-07-09
+TXN_7415686,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-04-13
+TXN_8877644,Cookie,2,1.0,2.0,,Takeaway,2023-09-01
+TXN_7231548,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-11-06
+TXN_2879361,Juice,3,3.0,9.0,,Takeaway,2023-11-22
+TXN_5956755,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-03-05
+TXN_6124342,Cake,3,3.0,9.0,,Takeaway,2023-09-14
+TXN_3824443,Smoothie,3,4.0,12.0,UNKNOWN,In-store,2023-10-08
+TXN_6778177,Cookie,4,1.0,4.0,,Takeaway,2023-10-12
+TXN_2634410,Smoothie,3,4.0,12.0,,ERROR,2023-07-15
+TXN_6975750,Juice,5,3.0,15.0,,ERROR,2023-01-08
+TXN_9293417,Tea,3,1.5,,Digital Wallet,Takeaway,
+TXN_7741256,,5,3.0,15.0,Digital Wallet,Takeaway,2023-04-24
+TXN_3484190,Coffee,5,2.0,10.0,Digital Wallet,,2023-12-27
+TXN_2621008,UNKNOWN,2,1.0,2.0,Digital Wallet,Takeaway,2023-10-21
+TXN_5429861,Cake,1,3.0,3.0,Digital Wallet,,2023-03-20
+TXN_2828596,Coffee,,2.0,4.0,,,2023-11-25
+TXN_6348290,ERROR,4,2.0,8.0,,In-store,2023-01-24
+TXN_9813943,Salad,2,5.0,10.0,Cash,,2023-04-06
+TXN_2364171,Juice,4,3.0,12.0,Cash,,2023-05-18
+TXN_8002886,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-05-28
+TXN_9956671,Cake,3,UNKNOWN,9.0,Credit Card,,2023-05-05
+TXN_7694491,Salad,3,5.0,15.0,Cash,In-store,2023-09-01
+TXN_7517996,Cake,2,3.0,6.0,Cash,ERROR,2023-10-22
+TXN_1655827,Cake,1,3.0,3.0,,In-store,2023-09-06
+TXN_6047026,Smoothie,2,4.0,8.0,ERROR,UNKNOWN,2023-03-24
+TXN_4225300,Sandwich,1,4.0,4.0,Cash,Takeaway,
+TXN_2764962,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-08-13
+TXN_5396727,Juice,2,UNKNOWN,6.0,Credit Card,Takeaway,2023-10-13
+TXN_5198827,Tea,5,1.5,7.5,,,2023-02-15
+TXN_8023817,Juice,4,3.0,12.0,,Takeaway,2023-05-08
+TXN_3413185,Cake,ERROR,3.0,12.0,Credit Card,In-store,2023-03-03
+TXN_9783452,Juice,3,3.0,9.0,Cash,UNKNOWN,2023-04-11
+TXN_4171507,Tea,1,1.5,1.5,,In-store,2023-10-26
+TXN_1491299,Juice,2,3.0,6.0,Credit Card,In-store,2023-02-27
+TXN_4187327,Tea,2,1.5,3.0,,Takeaway,2023-04-01
+TXN_3277379,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-01-06
+TXN_2568101,Salad,5,5.0,25.0,Cash,Takeaway,2023-08-03
+TXN_3247340,Tea,3,1.5,4.5,Cash,Takeaway,2023-12-25
+TXN_7797321,Sandwich,5,4.0,20.0,,,2023-11-26
+TXN_7512574,Tea,1,1.5,1.5,,Takeaway,
+TXN_3044825,ERROR,1,1.5,1.5,Credit Card,In-store,2023-08-14
+TXN_9019429,Smoothie,2,4.0,8.0,Digital Wallet,,2023-05-11
+TXN_9744862,Juice,4,3.0,,Cash,In-store,2023-09-19
+TXN_6365371,UNKNOWN,2,4.0,ERROR,Credit Card,,2023-06-16
+TXN_4543880,Salad,3,5.0,15.0,Cash,,2023-07-18
+TXN_4064245,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-02-20
+TXN_8777692,Coffee,4,2.0,8.0,Credit Card,In-store,2023-12-06
+TXN_9126502,Smoothie,5,4.0,20.0,Credit Card,,2023-09-22
+TXN_6626427,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-02-13
+TXN_4507755,Cake,2,3.0,6.0,Digital Wallet,,2023-05-10
+TXN_3928766,Juice,5,3.0,15.0,,Takeaway,2023-01-14
+TXN_9104535,Cake,4,3.0,,,,2023-04-13
+TXN_4914535,ERROR,2,1.0,2.0,Cash,UNKNOWN,
+TXN_4824773,Salad,5,5.0,25.0,Cash,Takeaway,2023-06-06
+TXN_9981953,,3,4.0,12.0,,,2023-02-03
+TXN_6627338,Juice,5,3.0,15.0,,Takeaway,2023-12-03
+TXN_3555821,Sandwich,3,4.0,12.0,,In-store,2023-07-12
+TXN_1372991,Coffee,4,2.0,8.0,,In-store,2023-11-17
+TXN_6364938,Coffee,3,ERROR,6.0,Digital Wallet,In-store,2023-07-16
+TXN_3040823,Smoothie,1,4.0,4.0,,In-store,2023-10-06
+TXN_6755757,UNKNOWN,4,4.0,16.0,Credit Card,In-store,2023-04-05
+TXN_4563646,Juice,5,3.0,15.0,Cash,Takeaway,2023-10-10
+TXN_3596456,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,ERROR
+TXN_2130415,,,2.0,2.0,Digital Wallet,Takeaway,2023-12-08
+TXN_9617421,Tea,1,1.5,,,In-store,2023-08-21
+TXN_1738607,Juice,2,3.0,6.0,Credit Card,In-store,2023-01-17
+TXN_3832513,Salad,1,5.0,5.0,,Takeaway,2023-02-13
+TXN_4128086,Tea,4,1.5,6.0,,,2023-05-29
+TXN_3927733,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-01-20
+TXN_2518917,Cookie,1,1.0,1.0,UNKNOWN,In-store,2023-05-21
+TXN_9489176,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-01-10
+TXN_2004781,Sandwich,5,ERROR,20.0,,Takeaway,2023-04-20
+TXN_3061266,Cookie,4,1.0,4.0,Credit Card,In-store,2023-12-06
+TXN_2036482,Cake,1,3.0,3.0,Cash,,2023-06-04
+TXN_7217284,Salad,3,5.0,15.0,Cash,In-store,2023-12-29
+TXN_5055872,Sandwich,,4.0,12.0,Credit Card,,2023-02-05
+TXN_1386024,Cake,4,3.0,12.0,Credit Card,,2023-05-21
+TXN_8397155,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-08-16
+TXN_9491244,ERROR,5,3.0,15.0,,,2023-04-19
+TXN_4301188,Smoothie,4,4.0,16.0,Credit Card,In-store,2023-12-23
+TXN_4522012,Coffee,2,2.0,ERROR,,In-store,2023-04-13
+TXN_4650044,Cookie,4,1.0,4.0,Cash,,2023-06-21
+TXN_5721215,Tea,2,1.5,3.0,,Takeaway,2023-05-17
+TXN_7865220,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-06-28
+TXN_1869147,Smoothie,4,4.0,16.0,Digital Wallet,,2023-11-21
+TXN_3377885,Sandwich,3,4.0,12.0,Cash,,2023-05-08
+TXN_9270865,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-11-06
+TXN_7373126,Smoothie,2,4.0,8.0,Credit Card,,2023-11-18
+TXN_8097899,Coffee,4,2.0,8.0,Digital Wallet,UNKNOWN,2023-09-05
+TXN_6131415,UNKNOWN,5,1.5,7.5,Digital Wallet,UNKNOWN,2023-11-24
+TXN_1248436,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-08-14
+TXN_1718733,UNKNOWN,3,2.0,6.0,Cash,,2023-05-31
+TXN_9063887,Cake,5,3.0,15.0,ERROR,Takeaway,2023-07-15
+TXN_5932169,Salad,5,ERROR,25.0,Credit Card,ERROR,2023-11-06
+TXN_6064282,Smoothie,4,4.0,16.0,Credit Card,,2023-10-18
+TXN_9309509,Tea,5,ERROR,7.5,,,2023-11-15
+TXN_5413274,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-02-10
+TXN_5902629,Cookie,3,1.0,3.0,Cash,Takeaway,2023-01-26
+TXN_2461859,Sandwich,2,4.0,8.0,Digital Wallet,ERROR,2023-09-23
+TXN_6629689,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-05-29
+TXN_2806206,Sandwich,3,4.0,12.0,Cash,,2023-01-25
+TXN_8900579,Sandwich,3,4.0,12.0,Credit Card,,2023-11-01
+TXN_5406758,ERROR,5,5.0,25.0,,Takeaway,2023-07-06
+TXN_2982163,Coffee,4,2.0,,,,2023-03-22
+TXN_3225132,Sandwich,3,4.0,12.0,Credit Card,,2023-06-26
+TXN_6522252,Tea,2,1.5,3.0,Digital Wallet,,2023-01-14
+TXN_5855981,Juice,2,3.0,6.0,Cash,,2023-11-09
+TXN_4802389,Cake,2,3.0,6.0,,,2023-12-14
+TXN_7516790,Cake,2,3.0,6.0,ERROR,,2023-01-08
+TXN_2631671,Cookie,1,1.0,,Credit Card,,ERROR
+TXN_2345373,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-02-20
+TXN_9372046,UNKNOWN,3,2.0,6.0,Credit Card,In-store,2023-04-10
+TXN_9402270,Coffee,3,2.0,6.0,,In-store,2023-02-09
+TXN_9306229,Smoothie,2,4.0,8.0,,,2023-09-08
+TXN_5379179,Cookie,2,1.0,2.0,Digital Wallet,,2023-07-08
+TXN_1996318,Cake,5,3.0,ERROR,Digital Wallet,,2023-09-04
+TXN_2135613,Smoothie,3,4.0,12.0,Digital Wallet,,2023-04-06
+TXN_1461246,Smoothie,1,4.0,4.0,,,2023-06-01
+TXN_2452624,Juice,1,3.0,3.0,Cash,,2023-11-10
+TXN_1108663,Juice,3,3.0,9.0,Cash,Takeaway,2023-08-16
+TXN_5319247,Sandwich,5,4.0,20.0,,In-store,2023-03-02
+TXN_3599473,Coffee,2,2.0,ERROR,Cash,,2023-08-29
+TXN_4959129,,2,3.0,6.0,Credit Card,In-store,2023-06-24
+TXN_5591145,Sandwich,3,4.0,12.0,,Takeaway,2023-08-22
+TXN_9587015,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-06-25
+TXN_7997641,Smoothie,2,4.0,8.0,ERROR,In-store,2023-12-20
+TXN_7943598,UNKNOWN,4,4.0,16.0,Credit Card,,
+TXN_6845472,Smoothie,5,4.0,20.0,Digital Wallet,,2023-12-11
+TXN_2861396,Salad,5,5.0,25.0,Credit Card,UNKNOWN,2023-01-04
+TXN_6915899,Salad,3,5.0,15.0,Credit Card,In-store,2023-05-29
+TXN_6211466,,2,1.5,3.0,Cash,In-store,2023-09-12
+TXN_3200203,ERROR,2,UNKNOWN,8.0,,UNKNOWN,2023-12-04
+TXN_5198524,Cake,1,3.0,3.0,Credit Card,In-store,2023-06-14
+TXN_8498613,Sandwich,2,UNKNOWN,,,,2023-11-08
+TXN_3432879,Cake,5,3.0,15.0,Credit Card,,2023-02-05
+TXN_6786340,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-04-18
+TXN_8689246,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-05-16
+TXN_4536553,Tea,2,1.5,3.0,Cash,,2023-08-17
+TXN_9036067,Cookie,5,1.0,5.0,Credit Card,,2023-10-06
+TXN_4201578,Salad,5,5.0,25.0,,In-store,2023-01-23
+TXN_1249069,Coffee,2,2.0,4.0,,ERROR,2023-01-22
+TXN_4068183,Smoothie,4,4.0,16.0,Digital Wallet,,2023-08-01
+TXN_7206160,Sandwich,ERROR,4.0,8.0,,,2023-09-07
+TXN_7903841,UNKNOWN,2,3.0,6.0,Digital Wallet,,2023-06-24
+TXN_8936663,Cookie,4,1.0,4.0,Credit Card,,2023-11-12
+TXN_7771434,Coffee,4,2.0,8.0,Credit Card,,2023-03-26
+TXN_6087494,Juice,5,3.0,15.0,Credit Card,,2023-07-05
+TXN_2252121,Smoothie,3,4.0,12.0,ERROR,ERROR,2023-02-01
+TXN_5358805,Coffee,5,2.0,10.0,Digital Wallet,ERROR,2023-01-01
+TXN_2490759,Smoothie,3,4.0,12.0,Cash,,2023-11-19
+TXN_2605566,Cake,2,,6.0,,,2023-12-01
+TXN_6691781,Coffee,4,2.0,8.0,Credit Card,UNKNOWN,2023-09-07
+TXN_1730850,Juice,2,3.0,6.0,Cash,Takeaway,2023-12-15
+TXN_7051359,Coffee,5,2.0,10.0,UNKNOWN,,2023-10-30
+TXN_2202863,Salad,5,5.0,25.0,,,2023-07-28
+TXN_7145672,Sandwich,1,4.0,4.0,Credit Card,,2023-10-11
+TXN_5974123,Sandwich,2,4.0,8.0,Digital Wallet,UNKNOWN,2023-06-25
+TXN_9833245,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-04-30
+TXN_1515059,ERROR,4,3.0,12.0,,In-store,2023-10-25
+TXN_9690114,Coffee,,2.0,4.0,Credit Card,Takeaway,2023-12-01
+TXN_7944534,Tea,2,UNKNOWN,3.0,Digital Wallet,In-store,2023-10-13
+TXN_6337312,Salad,1,5.0,5.0,,In-store,2023-01-11
+TXN_5239202,Cake,1,3.0,3.0,,,2023-09-14
+TXN_1512184,Coffee,3,2.0,6.0,,Takeaway,2023-01-28
+TXN_9864212,Smoothie,5,4.0,20.0,,ERROR,
+TXN_6811368,Coffee,4,2.0,8.0,,Takeaway,2023-02-18
+TXN_3854036,Juice,3,ERROR,9.0,Cash,,2023-11-07
+TXN_3873656,Coffee,3,2.0,6.0,,Takeaway,2023-09-30
+TXN_8792638,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-07-02
+TXN_7397665,Salad,5,,25.0,Credit Card,Takeaway,2023-11-11
+TXN_3493951,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-08-20
+TXN_1480967,Tea,2,1.5,3.0,Cash,Takeaway,
+TXN_1510315,ERROR,3,2.0,6.0,Cash,,2023-02-28
+TXN_7763592,Smoothie,1,4.0,4.0,,In-store,2023-02-17
+TXN_9710307,ERROR,ERROR,1.5,3.0,UNKNOWN,Takeaway,2023-01-24
+TXN_1860406,Coffee,2,2.0,4.0,,Takeaway,2023-06-17
+TXN_1663257,Juice,3,3.0,9.0,Credit Card,ERROR,2023-04-23
+TXN_2743696,Cookie,1,1.0,1.0,,,2023-04-28
+TXN_7640700,Juice,2,3.0,6.0,ERROR,,2023-01-15
+TXN_3227186,Salad,2,5.0,10.0,Digital Wallet,,2023-05-05
+TXN_7917193,Cookie,3,1.0,3.0,Cash,ERROR,2023-05-18
+TXN_2490435,Cookie,1,1.0,1.0,,,2023-03-13
+TXN_4698656,Smoothie,4,4.0,16.0,,,2023-12-07
+TXN_3507334,Juice,4,3.0,12.0,UNKNOWN,,2023-05-05
+TXN_5255023,ERROR,2,4.0,8.0,Credit Card,In-store,2023-11-15
+TXN_8669012,UNKNOWN,3,1.5,UNKNOWN,Digital Wallet,,2023-07-26
+TXN_1299959,Smoothie,5,4.0,20.0,Cash,,2023-06-23
+TXN_3680047,Salad,5,5.0,25.0,,,2023-07-16
+TXN_8379880,Juice,UNKNOWN,3.0,9.0,,Takeaway,2023-05-24
+TXN_4801832,Salad,2,5.0,10.0,,Takeaway,2023-08-05
+TXN_3425783,Juice,2,3.0,6.0,,,2023-06-15
+TXN_4099487,ERROR,5,4.0,20.0,Digital Wallet,,2023-01-25
+TXN_8878830,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-10-11
+TXN_7524977,UNKNOWN,4,UNKNOWN,,ERROR,,2023-12-09
+TXN_8295101,Tea,4,1.5,6.0,,,2023-10-23
+TXN_3303114,Salad,4,5.0,20.0,Credit Card,In-store,2023-06-18
+TXN_2106437,Tea,1,1.5,1.5,Cash,Takeaway,2023-08-01
+TXN_2291713,Salad,4,5.0,20.0,Cash,In-store,2023-08-06
+TXN_7552449,Cake,3,3.0,9.0,Cash,ERROR,2023-05-26
+TXN_9021000,Coffee,3,2.0,6.0,,,2023-01-20
+TXN_4205369,Salad,5,5.0,25.0,,Takeaway,2023-07-16
+TXN_4551806,Tea,1,1.5,1.5,ERROR,,2023-01-09
+TXN_5313211,Smoothie,5,4.0,20.0,Credit Card,ERROR,2023-05-04
+TXN_2282283,Cookie,2,1.0,2.0,Digital Wallet,,2023-02-23
+TXN_3193321,Smoothie,3,4.0,12.0,ERROR,Takeaway,2023-08-15
+TXN_7211769,Juice,1,3.0,3.0,Credit Card,UNKNOWN,2023-09-11
+TXN_6643951,UNKNOWN,1,4.0,4.0,Credit Card,In-store,2023-01-07
+TXN_1653570,Coffee,5,2.0,10.0,UNKNOWN,Takeaway,2023-10-10
+TXN_3722720,Salad,2,5.0,10.0,,In-store,2023-06-27
+TXN_7624646,Smoothie,2,4.0,8.0,,,2023-03-24
+TXN_6725579,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-02-21
+TXN_4015101,Sandwich,1,4.0,4.0,Credit Card,,2023-01-18
+TXN_6037712,Salad,,5.0,15.0,Credit Card,In-store,2023-08-10
+TXN_6845225,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-02-21
+TXN_5214219,Salad,4,5.0,20.0,Credit Card,,2023-03-22
+TXN_3388054,Coffee,5,2.0,10.0,Cash,,2023-11-13
+TXN_5817991,Smoothie,4,4.0,16.0,Cash,,2023-05-24
+TXN_2916247,Salad,3,UNKNOWN,15.0,,In-store,2023-09-03
+TXN_9798525,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-11-05
+TXN_4974012,Sandwich,5,,20.0,Cash,Takeaway,2023-05-17
+TXN_7644000,Cake,2,3.0,6.0,,Takeaway,2023-02-07
+TXN_1482123,Coffee,1,2.0,2.0,Cash,In-store,2023-06-17
+TXN_5622313,Salad,2,5.0,10.0,Credit Card,In-store,2023-01-07
+TXN_5737831,Juice,4,UNKNOWN,12.0,ERROR,Takeaway,2023-05-15
+TXN_3446033,Cookie,3,1.0,3.0,Credit Card,,2023-02-15
+TXN_6249754,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-10-21
+TXN_9729280,Tea,3,1.5,4.5,Credit Card,In-store,2023-11-06
+TXN_9551638,Salad,3,5.0,15.0,Cash,,2023-06-25
+TXN_5158607,Smoothie,4,,16.0,Credit Card,,2023-03-24
+TXN_1045022,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-10-13
+TXN_5818032,UNKNOWN,1,1.0,1.0,ERROR,,2023-04-19
+TXN_5404249,ERROR,1,4.0,4.0,,ERROR,2023-10-04
+TXN_5484423,,2,2.0,4.0,,,2023-08-26
+TXN_4598397,Coffee,4,2.0,8.0,Cash,Takeaway,2023-09-13
+TXN_3849488,Salad,UNKNOWN,UNKNOWN,5.0,,In-store,2023-03-01
+TXN_9186913,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-10-16
+TXN_9507002,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-05-08
+TXN_4423218,Cookie,3,1.0,3.0,Cash,In-store,2023-05-29
+TXN_4851339,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-02-01
+TXN_3274105,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-07-28
+TXN_2810280,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-06-25
+TXN_9901424,Cookie,3,1.0,3.0,Digital Wallet,,2023-05-30
+TXN_3880417,Cookie,1,1.0,1.0,,In-store,2023-06-27
+TXN_3756680,Tea,2,1.5,3.0,Credit Card,ERROR,2023-08-30
+TXN_2334523,Coffee,,2.0,10.0,Digital Wallet,Takeaway,2023-08-17
+TXN_8611913,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-07-16
+TXN_7387701,Coffee,1,2.0,2.0,Cash,Takeaway,UNKNOWN
+TXN_9904091,Salad,4,5.0,20.0,,,2023-05-20
+TXN_4953063,Tea,5,,7.5,Credit Card,UNKNOWN,ERROR
+TXN_5908857,Smoothie,5,4.0,20.0,,In-store,2023-06-04
+TXN_4411172,Smoothie,4,4.0,16.0,Cash,,2023-07-09
+TXN_6841805,Cake,2,3.0,6.0,,,2023-02-14
+TXN_7800236,Salad,3,5.0,15.0,Digital Wallet,UNKNOWN,2023-07-19
+TXN_2413026,Coffee,1,ERROR,2.0,,Takeaway,2023-04-26
+TXN_9947479,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-09-27
+TXN_6403859,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-03-06
+TXN_6828371,Smoothie,4,4.0,16.0,,,2023-10-20
+TXN_8335965,Tea,5,1.5,7.5,Credit Card,,2023-03-21
+TXN_9747008,Tea,4,1.5,6.0,Cash,Takeaway,ERROR
+TXN_9703722,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-01-11
+TXN_6259001,Tea,4,1.5,,Digital Wallet,In-store,2023-01-30
+TXN_6119081,Coffee,2,2.0,4.0,Cash,In-store,2023-09-27
+TXN_4811887,Cake,2,3.0,6.0,Cash,In-store,2023-02-11
+TXN_9587814,Juice,3,3.0,9.0,Cash,In-store,2023-01-25
+TXN_7682605,Tea,5,1.5,7.5,Digital Wallet,UNKNOWN,2023-10-19
+TXN_4690415,Sandwich,2,ERROR,8.0,Digital Wallet,,
+TXN_7946450,Smoothie,1,ERROR,4.0,Credit Card,In-store,2023-07-15
+TXN_2611393,Smoothie,3,4.0,12.0,,UNKNOWN,2023-04-25
+TXN_2122597,Cake,3,3.0,9.0,Credit Card,,2023-05-11
+TXN_7510217,Tea,ERROR,1.5,7.5,Credit Card,In-store,2023-10-24
+TXN_3267783,Cake,3,3.0,9.0,,In-store,2023-10-30
+TXN_7852397,Tea,3,1.5,4.5,Cash,In-store,2023-08-10
+TXN_8459594,Sandwich,1,4.0,4.0,Credit Card,ERROR,2023-11-07
+TXN_9190969,Coffee,1,2.0,2.0,,In-store,2023-10-06
+TXN_2982995,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-04-06
+TXN_9181144,,3,3.0,UNKNOWN,,Takeaway,2023-10-25
+TXN_6490609,Salad,4,5.0,UNKNOWN,,In-store,2023-03-03
+TXN_9938260,Smoothie,4,4.0,16.0,,In-store,2023-03-03
+TXN_5486398,Cookie,4,1.0,4.0,Cash,,2023-05-13
+TXN_5875661,Sandwich,3,4.0,,Credit Card,,2023-08-12
+TXN_2555823,Cake,4,3.0,12.0,Digital Wallet,,2023-06-21
+TXN_4223265,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-06-06
+TXN_3390072,Tea,1,1.5,1.5,Credit Card,,2023-05-03
+TXN_6491662,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-10-06
+TXN_1248167,UNKNOWN,1,4.0,4.0,Cash,,2023-03-05
+TXN_9500986,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-05-10
+TXN_2147453,,4,1.0,4.0,Credit Card,ERROR,2023-04-27
+TXN_9137801,,5,4.0,20.0,Credit Card,In-store,2023-06-10
+TXN_4892303,Sandwich,4,4.0,16.0,,ERROR,2023-07-16
+TXN_5985451,Sandwich,2,4.0,8.0,,,2023-07-24
+TXN_6092344,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-12-04
+TXN_1218016,Tea,3,1.5,4.5,Digital Wallet,,2023-11-26
+TXN_8110646,,2,3.0,6.0,Credit Card,Takeaway,2023-06-07
+TXN_1221777,Coffee,3,2.0,6.0,ERROR,In-store,2023-01-29
+TXN_3691087,Cookie,4,1.0,4.0,,,2023-07-11
+TXN_5571026,,1,5.0,5.0,Cash,Takeaway,2023-09-08
+TXN_6336973,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-03-21
+TXN_5609260,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-05-02
+TXN_4242676,Coffee,5,2.0,UNKNOWN,Credit Card,Takeaway,2023-11-26
+TXN_6835777,Juice,5,3.0,15.0,Digital Wallet,,2023-05-11
+TXN_6097706,Sandwich,4,UNKNOWN,16.0,Cash,Takeaway,2023-02-15
+TXN_5496581,Juice,1,3.0,3.0,Credit Card,,2023-08-11
+TXN_2897468,Salad,2,5.0,10.0,Cash,,2023-10-10
+TXN_3260087,Salad,5,5.0,25.0,,,2023-04-20
+TXN_2047672,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-01-25
+TXN_6893490,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-03-17
+TXN_3743336,Salad,2,5.0,10.0,Digital Wallet,,2023-02-21
+TXN_6851654,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-01-25
+TXN_8510511,Coffee,4,2.0,8.0,,,2023-10-06
+TXN_2092306,Juice,4,3.0,ERROR,ERROR,In-store,2023-04-01
+TXN_7345190,Smoothie,4,4.0,16.0,Digital Wallet,ERROR,2023-02-20
+TXN_6647319,Juice,5,3.0,15.0,Credit Card,,2023-10-23
+TXN_5889912,Salad,1,5.0,5.0,Cash,In-store,2023-09-26
+TXN_4483304,Smoothie,4,4.0,ERROR,Credit Card,Takeaway,2023-11-08
+TXN_3720223,Cake,4,3.0,12.0,Cash,Takeaway,2023-10-22
+TXN_4506778,Cake,3,3.0,9.0,Digital Wallet,,2023-04-21
+TXN_8226226,Sandwich,1,4.0,4.0,,In-store,2023-07-30
+TXN_9723120,Tea,5,1.5,7.5,Credit Card,UNKNOWN,2023-01-26
+TXN_2726676,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-08-10
+TXN_4011694,,1,2.0,2.0,Credit Card,In-store,2023-09-02
+TXN_3327212,Tea,2,1.5,3.0,Credit Card,,2023-12-20
+TXN_3558795,Smoothie,1,4.0,4.0,Cash,In-store,2023-05-30
+TXN_9989242,Sandwich,4,4.0,16.0,,,2023-09-12
+TXN_2035772,Cookie,2,ERROR,2.0,Cash,,2023-01-17
+TXN_2711627,Smoothie,5,4.0,20.0,Cash,ERROR,2023-11-09
+TXN_2804828,Cake,3,3.0,9.0,Cash,,2023-02-25
+TXN_3869958,Cake,1,3.0,3.0,Digital Wallet,ERROR,2023-01-11
+TXN_9684465,Cake,5,3.0,15.0,,Takeaway,2023-02-15
+TXN_7570308,Tea,4,1.5,6.0,Cash,,
+TXN_6476304,Sandwich,2,4.0,8.0,Credit Card,,2023-03-17
+TXN_3893927,Salad,4,5.0,20.0,,In-store,2023-09-14
+TXN_5947976,Coffee,3,2.0,6.0,,In-store,2023-05-21
+TXN_4139983,Tea,5,1.5,7.5,Cash,Takeaway,2023-10-16
+TXN_4571222,Cookie,2,1.0,2.0,Credit Card,UNKNOWN,2023-03-21
+TXN_6484542,Salad,5,5.0,25.0,Credit Card,,2023-05-18
+TXN_5183630,Coffee,4,2.0,8.0,,In-store,2023-02-15
+TXN_5562799,Cookie,5,1.0,5.0,,,2023-10-25
+TXN_9601220,,3,1.0,,Digital Wallet,Takeaway,2023-04-20
+TXN_6404625,Cake,5,3.0,15.0,Credit Card,ERROR,2023-04-24
+TXN_5327102,Cookie,2,1.0,2.0,,,2023-07-16
+TXN_5741619,Smoothie,ERROR,4.0,20.0,Cash,,2023-01-02
+TXN_4452589,Tea,UNKNOWN,1.5,1.5,UNKNOWN,Takeaway,2023-08-22
+TXN_6540284,Juice,1,3.0,3.0,,,2023-04-24
+TXN_9657957,Smoothie,UNKNOWN,4.0,8.0,,,2023-11-27
+TXN_3670939,Tea,3,1.5,4.5,Cash,,2023-07-13
+TXN_2935871,Cookie,4,1.0,4.0,Cash,Takeaway,2023-07-07
+TXN_1610204,Cake,1,3.0,3.0,,Takeaway,2023-02-19
+TXN_8372268,Salad,2,ERROR,10.0,,Takeaway,2023-06-15
+TXN_1239021,Sandwich,5,UNKNOWN,20.0,Credit Card,UNKNOWN,2023-09-15
+TXN_1863866,Smoothie,1,4.0,4.0,Cash,,2023-10-03
+TXN_4630854,Tea,1,1.5,1.5,Digital Wallet,,2023-02-10
+TXN_6183842,Tea,3,1.5,4.5,UNKNOWN,UNKNOWN,2023-09-15
+TXN_5355693,Smoothie,1,4.0,4.0,,,2023-12-03
+TXN_8284910,Smoothie,1,4.0,4.0,Cash,In-store,2023-07-19
+TXN_4408913,Salad,2,5.0,10.0,Cash,,2023-08-24
+TXN_2123573,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-01-09
+TXN_8036176,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-06-20
+TXN_9107676,Sandwich,UNKNOWN,4.0,8.0,Cash,UNKNOWN,2023-02-12
+TXN_2490185,Salad,4,5.0,20.0,Credit Card,In-store,2023-12-18
+TXN_6295420,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-09-27
+TXN_1542042,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-07-26
+TXN_7716125,Cookie,2,1.0,2.0,Digital Wallet,,2023-05-17
+TXN_6579109,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-02-22
+TXN_5577030,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-02-15
+TXN_3910230,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-01-05
+TXN_8031804,Coffee,4,2.0,8.0,Credit Card,,2023-07-01
+TXN_6928775,,2,1.0,2.0,Cash,In-store,2023-03-25
+TXN_6755107,Smoothie,2,4.0,8.0,Digital Wallet,,2023-11-14
+TXN_5153899,Tea,3,1.5,4.5,,Takeaway,2023-03-01
+TXN_5632156,Sandwich,4,4.0,16.0,Digital Wallet,,2023-08-02
+TXN_9861782,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-07-15
+TXN_8861275,Smoothie,2,4.0,8.0,,In-store,2023-10-31
+TXN_8961155,Cake,5,3.0,,Cash,Takeaway,2023-09-06
+TXN_6112765,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-07-21
+TXN_7090563,Smoothie,3,4.0,12.0,,In-store,2023-08-17
+TXN_9737090,Sandwich,3,4.0,12.0,,In-store,2023-06-01
+TXN_2847831,Coffee,1,2.0,2.0,Cash,In-store,2023-02-19
+TXN_3385167,Tea,3,1.5,4.5,Cash,In-store,2023-04-26
+TXN_1938071,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-12-25
+TXN_8774692,Tea,5,1.5,7.5,Digital Wallet,,2023-07-12
+TXN_4887268,Salad,1,5.0,5.0,Credit Card,In-store,2023-10-16
+TXN_9506372,Cake,4,3.0,12.0,,,2023-11-06
+TXN_6651961,Salad,4,5.0,20.0,Credit Card,In-store,2023-02-08
+TXN_2537138,Cake,3,3.0,9.0,,UNKNOWN,2023-10-24
+TXN_2015313,Salad,5,5.0,25.0,Cash,,2023-10-18
+TXN_5604797,Coffee,1,2.0,2.0,Cash,In-store,2023-10-13
+TXN_6303383,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-09-22
+TXN_5203710,,ERROR,5.0,20.0,Digital Wallet,,2023-04-22
+TXN_7059722,Sandwich,5,4.0,20.0,Digital Wallet,In-store,ERROR
+TXN_5403707,Smoothie,3,4.0,12.0,Cash,In-store,2023-03-20
+TXN_4084052,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-06-30
+TXN_3843541,,3,5.0,15.0,Credit Card,In-store,2023-03-06
+TXN_4000025,Tea,5,,7.5,UNKNOWN,Takeaway,2023-06-12
+TXN_7113656,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-01-22
+TXN_6039235,Juice,2,3.0,6.0,Digital Wallet,,2023-06-25
+TXN_6621756,Cookie,1,1.0,1.0,,,2023-11-14
+TXN_3923847,Cake,2,3.0,6.0,Credit Card,,2023-09-12
+TXN_3226989,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-04-17
+TXN_1523567,Salad,3,5.0,UNKNOWN,Digital Wallet,Takeaway,2023-11-22
+TXN_8751289,Tea,2,1.5,3.0,Cash,In-store,2023-09-10
+TXN_9996195,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-03-16
+TXN_2151688,Cake,5,3.0,15.0,,,2023-09-29
+TXN_4243591,Cake,4,3.0,12.0,Credit Card,In-store,2023-10-11
+TXN_4138399,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-07-03
+TXN_1724233,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-02-01
+TXN_1564506,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-02-01
+TXN_3520982,Salad,5,5.0,25.0,,,2023-10-26
+TXN_6130455,Tea,2,1.5,3.0,Digital Wallet,UNKNOWN,ERROR
+TXN_8936591,Cookie,5,1.0,5.0,,In-store,2023-03-22
+TXN_7622389,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-02-26
+TXN_2896048,Tea,4,,6.0,Cash,,2023-05-17
+TXN_2204457,Coffee,4,2.0,8.0,Cash,Takeaway,2023-01-06
+TXN_1319834,Cookie,1,1.0,1.0,,,2023-03-31
+TXN_9042043,Cookie,4,1.0,4.0,Cash,Takeaway,ERROR
+TXN_7503593,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-04-19
+TXN_4076463,Cookie,3,1.0,3.0,Digital Wallet,,2023-06-25
+TXN_1901704,Salad,5,5.0,25.0,Cash,,2023-11-17
+TXN_5589433,Cake,2,3.0,6.0,Cash,In-store,2023-03-13
+TXN_4386732,Smoothie,4,4.0,16.0,Cash,,2023-08-01
+TXN_3174336,Cookie,UNKNOWN,1.0,1.0,,,2023-07-17
+TXN_4983903,ERROR,5,4.0,20.0,,,2023-09-18
+TXN_8043642,Salad,4,5.0,20.0,Cash,In-store,2023-06-12
+TXN_1223805,Juice,3,3.0,9.0,UNKNOWN,In-store,2023-07-04
+TXN_3879110,ERROR,4,1.0,UNKNOWN,Credit Card,Takeaway,2023-03-18
+TXN_9551491,Salad,1,5.0,5.0,,,2023-07-13
+TXN_3033987,Cake,4,3.0,12.0,Cash,ERROR,2023-03-13
+TXN_2732570,Cookie,3,1.0,3.0,Digital Wallet,,2023-06-23
+TXN_9104781,Sandwich,2,4.0,8.0,UNKNOWN,ERROR,2023-07-03
+TXN_7876775,Coffee,5,2.0,10.0,,Takeaway,2023-02-09
+TXN_7566250,Salad,3,5.0,15.0,,Takeaway,2023-06-04
+TXN_3365018,Juice,5,3.0,15.0,Cash,Takeaway,2023-02-06
+TXN_1487762,Tea,3,1.5,4.5,,,2023-02-07
+TXN_4592205,Cookie,3,1.0,3.0,Credit Card,In-store,2023-12-30
+TXN_6660755,Cookie,2,1.0,2.0,Credit Card,In-store,2023-05-16
+TXN_3750900,Tea,2,,3.0,Credit Card,In-store,2023-04-03
+TXN_3290872,Cake,2,3.0,6.0,Credit Card,In-store,2023-06-13
+TXN_6378158,Salad,5,,25.0,Credit Card,In-store,2023-06-17
+TXN_8800818,Cake,2,3.0,ERROR,Digital Wallet,,2023-09-28
+TXN_5707386,Tea,5,1.5,7.5,,Takeaway,2023-06-28
+TXN_1145592,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-09-11
+TXN_2670487,Coffee,3,2.0,6.0,Digital Wallet,,2023-10-20
+TXN_9485101,Cookie,2,1.0,2.0,Cash,Takeaway,2023-11-01
+TXN_9667219,Juice,4,3.0,12.0,Cash,In-store,2023-10-09
+TXN_3119835,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-03-01
+TXN_2454046,Juice,2,3.0,6.0,,Takeaway,UNKNOWN
+TXN_7014091,Coffee,5,2.0,10.0,Cash,In-store,2023-11-26
+TXN_7107807,Cookie,1,1.0,1.0,Digital Wallet,,2023-11-01
+TXN_5698925,Juice,2,3.0,6.0,,In-store,2023-04-08
+TXN_6662213,Sandwich,4,4.0,16.0,Digital Wallet,,2023-01-18
+TXN_1336900,Coffee,5,2.0,10.0,Credit Card,ERROR,2023-01-16
+TXN_2250785,Cake,1,3.0,3.0,Cash,,2023-03-19
+TXN_8122340,Coffee,4,2.0,,Credit Card,,2023-06-09
+TXN_9911498,Coffee,4,2.0,8.0,Cash,In-store,2023-03-27
+TXN_4130861,Salad,2,5.0,10.0,Credit Card,UNKNOWN,
+TXN_3741325,Sandwich,5,4.0,20.0,Digital Wallet,,2023-07-04
+TXN_8658970,Salad,3,5.0,15.0,Credit Card,,2023-09-03
+TXN_2887971,Smoothie,2,4.0,8.0,Digital Wallet,UNKNOWN,2023-06-26
+TXN_9865855,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-04-18
+TXN_2217295,Juice,4,ERROR,12.0,Credit Card,In-store,2023-11-22
+TXN_8913492,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-12-25
+TXN_5625086,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-06-17
+TXN_2690222,ERROR,4,3.0,12.0,,,2023-01-01
+TXN_5767429,Cake,2,3.0,6.0,UNKNOWN,UNKNOWN,2023-03-19
+TXN_5910541,Cake,ERROR,3.0,15.0,Cash,In-store,2023-09-08
+TXN_4435352,Salad,2,5.0,10.0,Credit Card,,2023-05-03
+TXN_1009421,Cookie,4,1.0,4.0,Cash,Takeaway,2023-02-21
+TXN_5369243,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-11-16
+TXN_2939667,,1,3.0,3.0,,In-store,2023-12-21
+TXN_5734395,Sandwich,UNKNOWN,4.0,20.0,Cash,Takeaway,2023-05-17
+TXN_2966262,Tea,ERROR,1.5,4.5,Cash,,2023-11-19
+TXN_7293241,ERROR,1,2.0,2.0,Digital Wallet,,2023-08-27
+TXN_1827212,Sandwich,5,4.0,20.0,ERROR,,2023-12-22
+TXN_4809548,Smoothie,3,4.0,12.0,,Takeaway,2023-11-04
+TXN_2224935,Coffee,1,2.0,2.0,Digital Wallet,,2023-04-15
+TXN_7580441,Coffee,1,UNKNOWN,2.0,Cash,,2023-08-09
+TXN_4897993,Sandwich,4,,16.0,,In-store,2023-12-07
+TXN_9522045,Coffee,3,2.0,6.0,,,2023-05-30
+TXN_6128966,Sandwich,3,4.0,12.0,,,2023-12-18
+TXN_5475746,Cake,3,3.0,9.0,Credit Card,In-store,2023-08-20
+TXN_6071339,Coffee,5,2.0,10.0,Cash,Takeaway,2023-10-17
+TXN_9540864,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-08-07
+TXN_6389404,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-11-20
+TXN_8724474,ERROR,5,5.0,25.0,Cash,,2023-08-04
+TXN_8199524,Cake,5,3.0,15.0,Cash,ERROR,2023-12-01
+TXN_1212652,Juice,3,3.0,9.0,Credit Card,UNKNOWN,2023-01-30
+TXN_1799247,Coffee,3,2.0,6.0,,,2023-01-25
+TXN_5745054,Smoothie,1,4.0,4.0,Credit Card,,2023-01-26
+TXN_4328090,,ERROR,4.0,4.0,Digital Wallet,In-store,2023-04-18
+TXN_3499226,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-09-08
+TXN_1259340,Tea,3,ERROR,UNKNOWN,Digital Wallet,,2023-02-24
+TXN_3893480,Cookie,3,1.0,3.0,,,2023-12-24
+TXN_2614271,UNKNOWN,2,4.0,8.0,Digital Wallet,ERROR,2023-08-03
+TXN_8295765,Cake,4,3.0,12.0,,Takeaway,2023-04-05
+TXN_1324760,Tea,4,1.5,6.0,Cash,In-store,2023-01-18
+TXN_8292441,Salad,1,5.0,5.0,Cash,Takeaway,2023-09-15
+TXN_6663486,Coffee,3,2.0,6.0,,,2023-11-02
+TXN_9423451,Coffee,1,UNKNOWN,2.0,,,2023-10-22
+TXN_3792125,Salad,5,5.0,25.0,Credit Card,In-store,2023-08-25
+TXN_7021504,Cookie,2,1.0,2.0,UNKNOWN,In-store,2023-05-31
+TXN_8608811,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-01-05
+TXN_4844386,,5,UNKNOWN,15.0,Credit Card,In-store,2023-10-28
+TXN_4368729,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-06-11
+TXN_5072156,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-07-24
+TXN_5763520,ERROR,1,5.0,5.0,ERROR,,2023-01-17
+TXN_4877933,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-01-12
+TXN_8854384,Juice,5,3.0,15.0,Cash,Takeaway,2023-08-12
+TXN_3308378,Cookie,4,1.0,4.0,Digital Wallet,,2023-04-28
+TXN_4355766,Cookie,5,1.0,UNKNOWN,Digital Wallet,,2023-11-07
+TXN_5644235,Salad,4,5.0,20.0,Cash,In-store,2023-03-25
+TXN_5331285,Sandwich,3,4.0,12.0,Digital Wallet,,2023-03-12
+TXN_7620397,Cookie,4,1.0,4.0,ERROR,,2023-12-24
+TXN_1214868,Juice,4,,12.0,Cash,In-store,2023-07-30
+TXN_5117595,Smoothie,4,4.0,16.0,Cash,In-store,2023-02-05
+TXN_9708144,Smoothie,3,4.0,12.0,Cash,ERROR,2023-04-18
+TXN_8266689,,5,ERROR,15.0,Cash,In-store,2023-12-03
+TXN_3589166,Tea,1,1.5,1.5,,,2023-02-02
+TXN_3943672,Sandwich,4,4.0,16.0,Credit Card,,2023-10-21
+TXN_8988279,Smoothie,2,4.0,8.0,,In-store,2023-08-08
+TXN_4269933,Smoothie,2,4.0,8.0,,Takeaway,2023-03-28
+TXN_2234460,Tea,2,1.5,3.0,,Takeaway,2023-08-15
+TXN_4356564,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-10-05
+TXN_2223047,UNKNOWN,2,2.0,4.0,,Takeaway,2023-06-14
+TXN_9469735,Cake,1,3.0,3.0,ERROR,In-store,2023-12-31
+TXN_6762250,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-06-17
+TXN_8553273,Juice,5,3.0,15.0,Cash,In-store,2023-01-15
+TXN_8713971,Tea,1,1.5,1.5,Cash,,2023-08-26
+TXN_4076575,Smoothie,3,4.0,12.0,,Takeaway,2023-01-18
+TXN_2432379,Coffee,1,2.0,2.0,Credit Card,In-store,2023-10-24
+TXN_3187634,UNKNOWN,5,2.0,10.0,Digital Wallet,Takeaway,2023-09-01
+TXN_1961943,Smoothie,UNKNOWN,4.0,12.0,Digital Wallet,In-store,2023-11-05
+TXN_5908104,Sandwich,2,4.0,8.0,Credit Card,,2023-05-12
+TXN_1355212,Coffee,2,2.0,4.0,,,2023-05-25
+TXN_2155393,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-07-12
+TXN_3485938,UNKNOWN,4,5.0,20.0,Cash,Takeaway,2023-05-28
+TXN_9449037,Coffee,4,2.0,8.0,,Takeaway,2023-04-30
+TXN_3114654,Juice,3,3.0,9.0,,In-store,2023-12-01
+TXN_5837801,Salad,1,5.0,,Credit Card,In-store,2023-01-25
+TXN_1336470,Tea,1,1.5,1.5,Cash,,2023-12-22
+TXN_2544724,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-12-28
+TXN_1035504,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-03-30
+TXN_2576799,Juice,1,3.0,3.0,Cash,,2023-03-12
+TXN_4659155,Juice,1,3.0,3.0,UNKNOWN,,2023-04-13
+TXN_9781961,Coffee,1,2.0,2.0,Credit Card,In-store,2023-12-01
+TXN_5313347,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-12-10
+TXN_7926510,Salad,4,5.0,20.0,Cash,,2023-10-03
+TXN_3477975,Sandwich,ERROR,4.0,16.0,,,2023-02-26
+TXN_6736084,Juice,1,3.0,3.0,,Takeaway,2023-04-19
+TXN_5573731,Sandwich,4,4.0,16.0,Cash,,2023-01-15
+TXN_2760327,Salad,1,5.0,5.0,ERROR,Takeaway,2023-02-16
+TXN_5540067,Tea,4,1.5,6.0,,ERROR,2023-08-24
+TXN_7585599,Cake,1,3.0,3.0,Credit Card,,2023-01-12
+TXN_6333241,Coffee,ERROR,2.0,4.0,Digital Wallet,,2023-09-15
+TXN_1635631,Cookie,4,1.0,4.0,Credit Card,,2023-07-04
+TXN_8907996,Sandwich,4,4.0,16.0,Cash,In-store,2023-02-19
+TXN_3206049,Coffee,4,2.0,8.0,,,2023-03-27
+TXN_4620647,Coffee,1,2.0,2.0,Digital Wallet,UNKNOWN,2023-07-15
+TXN_5348915,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-09
+TXN_4036214,Cake,2,,6.0,Credit Card,UNKNOWN,2023-10-17
+TXN_6323914,Juice,1,3.0,3.0,Credit Card,In-store,2023-03-19
+TXN_7804128,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-02-12
+TXN_6228313,ERROR,4,3.0,12.0,,,2023-01-24
+TXN_2930752,Cake,2,3.0,6.0,Credit Card,,2023-03-04
+TXN_3477101,Cookie,4,1.0,4.0,,Takeaway,2023-05-02
+TXN_2210265,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-06-14
+TXN_5534515,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-02-09
+TXN_9561380,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-11
+TXN_3038078,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-04-06
+TXN_5652473,Smoothie,4,4.0,16.0,,,2023-03-19
+TXN_5222822,Salad,1,5.0,5.0,,In-store,2023-11-20
+TXN_6238191,Smoothie,4,4.0,16.0,ERROR,In-store,2023-10-27
+TXN_1244593,Salad,5,5.0,25.0,,In-store,2023-04-11
+TXN_9749175,Cake,1,3.0,3.0,Credit Card,In-store,2023-09-07
+TXN_4502314,Cookie,3,1.0,3.0,Credit Card,,2023-06-02
+TXN_5476846,Tea,4,1.5,6.0,Credit Card,Takeaway,
+TXN_3703964,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-09-23
+TXN_1554195,Smoothie,2,4.0,8.0,Digital Wallet,,2023-10-22
+TXN_1025152,Cookie,4,1.0,4.0,,,2023-08-19
+TXN_3429942,Smoothie,3,4.0,ERROR,Digital Wallet,In-store,2023-04-24
+TXN_2134660,UNKNOWN,5,3.0,15.0,Credit Card,In-store,2023-11-08
+TXN_8944175,Salad,3,5.0,15.0,Digital Wallet,,2023-11-30
+TXN_4680399,Juice,5,3.0,15.0,Digital Wallet,,2023-04-07
+TXN_5328065,Cake,5,3.0,15.0,Cash,,2023-09-18
+TXN_9202496,Cake,5,3.0,15.0,Credit Card,In-store,2023-07-19
+TXN_2914953,Cake,2,3.0,6.0,Cash,In-store,2023-07-25
+TXN_6068148,Cake,3,3.0,9.0,ERROR,In-store,2023-08-11
+TXN_1216051,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-10-28
+TXN_3943327,Juice,1,3.0,3.0,,,2023-05-20
+TXN_5268025,Cookie,5,1.0,,Digital Wallet,In-store,2023-05-19
+TXN_9952441,Smoothie,1,4.0,UNKNOWN,Cash,In-store,2023-09-05
+TXN_7354271,Cookie,4,1.0,4.0,UNKNOWN,In-store,2023-04-12
+TXN_3358494,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-06-22
+TXN_2966507,Cookie,3,1.0,3.0,ERROR,In-store,2023-04-25
+TXN_9752586,Tea,2,1.5,3.0,Digital Wallet,,2023-06-14
+TXN_1324968,Cookie,3,1.0,3.0,Credit Card,In-store,2023-01-05
+TXN_8424417,Smoothie,2,,8.0,,Takeaway,2023-10-21
+TXN_3985920,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-03-29
+TXN_7335526,Sandwich,4,4.0,16.0,Cash,In-store,2023-06-03
+TXN_5989987,Smoothie,4,4.0,16.0,Cash,,2023-08-02
+TXN_8132632,Tea,3,1.5,4.5,,UNKNOWN,2023-07-26
+TXN_2408294,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-12-26
+TXN_7380756,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-10-16
+TXN_1145888,Coffee,4,2.0,8.0,,,2023-01-26
+TXN_3845754,Tea,4,1.5,6.0,,Takeaway,2023-11-25
+TXN_1315214,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-11-03
+TXN_7602467,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-10-17
+TXN_1672708,Salad,4,5.0,20.0,,,2023-04-04
+TXN_4979250,Tea,3,1.5,4.5,Cash,In-store,2023-11-01
+TXN_2809397,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-09-13
+TXN_8752130,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-10-23
+TXN_7326075,Cookie,1,UNKNOWN,1.0,Cash,,2023-06-12
+TXN_9134257,Coffee,,2.0,6.0,Digital Wallet,Takeaway,2023-05-19
+TXN_9944832,Coffee,3,2.0,6.0,,,2023-12-25
+TXN_8329302,Juice,UNKNOWN,3.0,9.0,,Takeaway,
+TXN_9639317,Cake,3,3.0,9.0,Cash,,2023-12-28
+TXN_7707761,Tea,3,1.5,4.5,Credit Card,,2023-03-08
+TXN_3177517,ERROR,1,1.5,1.5,Credit Card,In-store,2023-02-22
+TXN_5353855,,3,4.0,12.0,Credit Card,Takeaway,2023-12-24
+TXN_3106811,Juice,3,3.0,9.0,Cash,Takeaway,2023-09-27
+TXN_3475342,Juice,3,3.0,9.0,,In-store,2023-04-24
+TXN_8017663,Coffee,2,2.0,4.0,,,2023-05-18
+TXN_6309965,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-06-14
+TXN_7146871,Coffee,,2.0,4.0,,,2023-09-20
+TXN_2661443,Juice,2,3.0,6.0,Credit Card,,2023-06-30
+TXN_6954434,Juice,3,ERROR,9.0,Cash,Takeaway,2023-02-23
+TXN_3578712,Tea,5,UNKNOWN,7.5,Credit Card,,2023-08-15
+TXN_6131350,Sandwich,2,,8.0,Credit Card,,2023-09-28
+TXN_9207050,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-07-21
+TXN_5351656,Tea,1,1.5,1.5,,Takeaway,2023-03-02
+TXN_8905718,Tea,5,1.5,7.5,,In-store,2023-09-07
+TXN_1938148,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-06-07
+TXN_2024598,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-01-01
+TXN_7145872,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-04-15
+TXN_8140560,Cake,5,3.0,15.0,ERROR,Takeaway,2023-06-29
+TXN_6591756,Cookie,5,1.0,5.0,,,2023-03-09
+TXN_9004306,Coffee,4,2.0,8.0,Credit Card,In-store,2023-05-26
+TXN_7899686,UNKNOWN,1,4.0,4.0,Digital Wallet,Takeaway,2023-09-09
+TXN_7092761,Salad,4,5.0,20.0,UNKNOWN,,2023-05-11
+TXN_6360436,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-09-13
+TXN_3295247,Coffee,5,2.0,10.0,Digital Wallet,,2023-08-25
+TXN_5822344,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-27
+TXN_4266069,Coffee,1,2.0,2.0,,,2023-12-25
+TXN_9470768,Smoothie,5,4.0,20.0,Credit Card,,2023-09-27
+TXN_1540181,Tea,3,1.5,4.5,,Takeaway,2023-08-17
+TXN_6688020,Salad,5,5.0,25.0,UNKNOWN,,2023-09-05
+TXN_4181147,Coffee,4,2.0,8.0,,Takeaway,2023-02-18
+TXN_7211792,Tea,3,1.5,4.5,ERROR,Takeaway,2023-11-27
+TXN_6568978,Cake,3,3.0,9.0,Digital Wallet,,2023-03-12
+TXN_6670607,Juice,5,3.0,UNKNOWN,,Takeaway,2023-01-06
+TXN_9773606,Tea,2,1.5,3.0,Cash,Takeaway,2023-12-04
+TXN_9762035,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-08-21
+TXN_4493661,Sandwich,1,4.0,4.0,Cash,,2023-07-08
+TXN_4617139,Juice,4,,12.0,,,2023-04-12
+TXN_5339625,Smoothie,5,4.0,20.0,Digital Wallet,ERROR,2023-06-29
+TXN_9657636,Cake,1,3.0,3.0,Cash,Takeaway,2023-07-08
+TXN_1375992,Coffee,5,2.0,10.0,Credit Card,In-store,2023-03-23
+TXN_2077318,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-08-24
+TXN_8232653,Salad,5,5.0,25.0,Cash,,2023-04-21
+TXN_4624436,Sandwich,1,4.0,4.0,,,2023-05-22
+TXN_6158865,Cookie,1,1.0,1.0,Digital Wallet,,2023-11-27
+TXN_6148337,Cookie,2,1.0,2.0,,In-store,2023-09-27
+TXN_9096951,Smoothie,3,4.0,12.0,Cash,Takeaway,2023-06-28
+TXN_7080148,Cake,3,3.0,9.0,,,2023-12-30
+TXN_4275169,Salad,1,5.0,5.0,,Takeaway,2023-06-27
+TXN_9005396,Juice,4,3.0,12.0,Cash,,2023-08-10
+TXN_2466036,Coffee,5,2.0,10.0,,Takeaway,2023-08-31
+TXN_1533790,Cake,,3.0,12.0,Digital Wallet,Takeaway,2023-07-21
+TXN_7090165,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-08-30
+TXN_9533792,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-09-01
+TXN_4995910,Cake,5,3.0,UNKNOWN,ERROR,,2023-03-10
+TXN_9174916,Coffee,3,2.0,6.0,Credit Card,,2023-06-21
+TXN_8121601,Juice,4,3.0,UNKNOWN,ERROR,In-store,2023-07-02
+TXN_5882077,Sandwich,3,4.0,12.0,,Takeaway,2023-03-10
+TXN_3163681,Sandwich,2,4.0,8.0,,,2023-05-11
+TXN_2849719,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-06-23
+TXN_9623460,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-01-17
+TXN_3359704,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-07-23
+TXN_7093219,Smoothie,4,4.0,16.0,Credit Card,,2023-06-06
+TXN_2444408,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-05-11
+TXN_2475111,Cookie,3,1.0,3.0,,Takeaway,2023-03-31
+TXN_3296152,Salad,3,5.0,15.0,Credit Card,In-store,2023-10-20
+TXN_5157855,Salad,1,5.0,5.0,Digital Wallet,,2023-08-18
+TXN_2887411,Smoothie,2,4.0,8.0,Cash,In-store,2023-01-16
+TXN_7543369,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-11-18
+TXN_9561441,Tea,5,1.5,7.5,Cash,In-store,2023-11-11
+TXN_5595584,Smoothie,2,4.0,8.0,ERROR,In-store,2023-10-19
+TXN_1158197,Coffee,2,2.0,4.0,,Takeaway,2023-05-21
+TXN_3633955,Sandwich,4,4.0,16.0,Cash,In-store,2023-09-20
+TXN_2761949,Salad,3,5.0,15.0,Credit Card,In-store,2023-10-01
+TXN_4967355,Sandwich,2,4.0,8.0,,In-store,2023-04-25
+TXN_8062897,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-10-02
+TXN_4831426,Juice,4,3.0,12.0,Credit Card,,2023-02-27
+TXN_3995843,UNKNOWN,3,4.0,ERROR,,In-store,2023-12-31
+TXN_4284492,Juice,3,3.0,9.0,,Takeaway,2023-05-30
+TXN_9942634,Tea,5,1.5,7.5,,Takeaway,2023-01-17
+TXN_7104682,Cookie,5,1.0,5.0,,Takeaway,2023-08-31
+TXN_5745955,Smoothie,4,4.0,16.0,Credit Card,,UNKNOWN
+TXN_6866209,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-05-20
+TXN_7573801,Cake,2,3.0,6.0,ERROR,In-store,2023-12-14
+TXN_9681880,Coffee,3,2.0,6.0,Cash,In-store,2023-03-21
+TXN_2559288,Salad,4,5.0,20.0,Credit Card,,2023-12-27
+TXN_9188692,Cake,ERROR,3.0,UNKNOWN,Credit Card,,2023-12-01
+TXN_2936975,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-10-05
+TXN_5027125,Salad,3,5.0,15.0,Cash,In-store,2023-07-06
+TXN_7433758,Cookie,1,1.0,1.0,Cash,,2023-06-09
+TXN_2092288,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-03-30
+TXN_5701303,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-09-08
+TXN_7323833,ERROR,3,4.0,ERROR,Credit Card,,2023-04-09
+TXN_5161371,Cake,2,3.0,6.0,Credit Card,In-store,2023-01-17
+TXN_6228918,Cake,1,3.0,3.0,Digital Wallet,In-store,UNKNOWN
+TXN_1132566,Cake,3,3.0,9.0,Cash,,2023-02-27
+TXN_3713527,Cookie,4,1.0,4.0,ERROR,Takeaway,2023-03-08
+TXN_1719440,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-07-13
+TXN_6273703,Tea,2,1.5,3.0,Credit Card,,2023-12-24
+TXN_2050017,Sandwich,4,4.0,16.0,,Takeaway,2023-03-24
+TXN_6797827,Sandwich,1,4.0,4.0,Credit Card,,2023-06-16
+TXN_6885626,Cake,5,3.0,15.0,UNKNOWN,In-store,2023-08-06
+TXN_3729074,Salad,3,5.0,15.0,Credit Card,In-store,2023-04-15
+TXN_7418962,Smoothie,4,4.0,16.0,Cash,,2023-03-07
+TXN_7217537,Salad,3,5.0,15.0,Cash,In-store,2023-12-19
+TXN_7904970,Tea,ERROR,1.5,3.0,Credit Card,Takeaway,2023-05-23
+TXN_8845592,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-11-12
+TXN_2402637,,2,4.0,8.0,,Takeaway,2023-06-18
+TXN_2081985,Coffee,2,2.0,4.0,Digital Wallet,UNKNOWN,2023-03-24
+TXN_5664467,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-11-06
+TXN_2275523,Tea,4,1.5,6.0,Digital Wallet,UNKNOWN,2023-09-02
+TXN_7230977,ERROR,5,3.0,15.0,,Takeaway,2023-08-24
+TXN_6451747,Salad,4,5.0,20.0,Cash,,2023-05-23
+TXN_2680626,Cake,3,3.0,9.0,Cash,In-store,2023-01-08
+TXN_8668840,Cake,5,3.0,15.0,Digital Wallet,,2023-10-03
+TXN_5390428,Juice,2,3.0,6.0,,In-store,2023-11-25
+TXN_5009367,Juice,3,3.0,9.0,Credit Card,In-store,2023-04-19
+TXN_5930921,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,
+TXN_3067854,Cake,1,3.0,3.0,Credit Card,,2023-07-08
+TXN_6401072,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-07-28
+TXN_6377597,Cookie,1,1.0,1.0,UNKNOWN,In-store,
+TXN_6799966,Tea,4,1.5,6.0,Digital Wallet,,2023-03-03
+TXN_5080934,Juice,,3.0,9.0,Cash,Takeaway,2023-12-10
+TXN_8684125,Salad,2,5.0,10.0,Credit Card,In-store,2023-03-08
+TXN_1647077,Smoothie,2,4.0,8.0,UNKNOWN,,2023-08-19
+TXN_9769782,Smoothie,5,4.0,20.0,Cash,Takeaway,ERROR
+TXN_8167808,Cake,3,3.0,9.0,Cash,In-store,2023-02-03
+TXN_4541998,Sandwich,UNKNOWN,4.0,4.0,,Takeaway,2023-01-13
+TXN_3369789,Sandwich,5,4.0,20.0,,,2023-04-15
+TXN_7973461,Tea,3,1.5,4.5,UNKNOWN,In-store,2023-04-11
+TXN_7753587,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-03-28
+TXN_4490958,Coffee,2,2.0,4.0,,,2023-03-30
+TXN_8715515,ERROR,5,3.0,15.0,Credit Card,Takeaway,2023-07-23
+TXN_8242126,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-11-20
+TXN_2972659,Tea,3,1.5,4.5,,,2023-12-16
+TXN_5685028,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-08-12
+TXN_9835620,Juice,2,3.0,UNKNOWN,,,2023-06-09
+TXN_9245124,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-04-19
+TXN_8619762,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-08-05
+TXN_5983031,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-03-09
+TXN_8730549,Smoothie,4,4.0,16.0,,Takeaway,2023-02-04
+TXN_6889867,Sandwich,5,4.0,20.0,Cash,,2023-03-07
+TXN_9035484,Coffee,2,2.0,4.0,Cash,,2023-06-29
+TXN_2505327,Juice,2,3.0,,,,
+TXN_9972525,Coffee,4,2.0,8.0,,,2023-07-31
+TXN_3315026,Juice,5,3.0,15.0,Cash,,2023-11-06
+TXN_3613385,Cookie,3,1.0,3.0,,Takeaway,2023-05-26
+TXN_9629541,Sandwich,5,4.0,20.0,Digital Wallet,,2023-12-18
+TXN_7503640,Salad,3,5.0,15.0,Digital Wallet,,2023-11-04
+TXN_1135761,ERROR,3,3.0,9.0,Digital Wallet,,2023-01-30
+TXN_8558404,Salad,ERROR,5.0,20.0,Digital Wallet,In-store,2023-07-15
+TXN_8430735,Juice,2,3.0,6.0,,,2023-10-25
+TXN_8279865,Juice,1,ERROR,3.0,Cash,,2023-07-18
+TXN_5906520,Salad,2,5.0,10.0,ERROR,,2023-01-31
+TXN_8250427,Coffee,4,2.0,8.0,Credit Card,,2023-09-15
+TXN_9928337,Juice,1,3.0,3.0,ERROR,Takeaway,2023-11-05
+TXN_7008306,Salad,2,5.0,,UNKNOWN,,2023-04-11
+TXN_5603538,Juice,3,3.0,9.0,Cash,,2023-02-15
+TXN_7368648,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-03-09
+TXN_6220542,Juice,3,3.0,9.0,,Takeaway,2023-03-24
+TXN_3299535,Coffee,3,2.0,6.0,,Takeaway,2023-11-16
+TXN_1217959,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-07-28
+TXN_4390633,Tea,2,1.5,3.0,UNKNOWN,,2023-10-17
+TXN_5052998,Juice,3,3.0,9.0,Credit Card,,2023-10-07
+TXN_5171332,Tea,5,1.5,7.5,Cash,Takeaway,2023-02-05
+TXN_4798484,Juice,3,3.0,9.0,,In-store,2023-08-09
+TXN_7905741,Cookie,5,1.0,5.0,Credit Card,,2023-02-08
+TXN_6369875,Tea,5,1.5,7.5,Cash,,2023-10-04
+TXN_7840162,Cookie,5,,5.0,Cash,Takeaway,2023-02-27
+TXN_9069297,Cookie,4,1.0,4.0,Credit Card,In-store,2023-01-27
+TXN_5017038,Sandwich,3,4.0,12.0,,,2023-05-25
+TXN_6748453,Sandwich,5,4.0,20.0,,In-store,2023-05-08
+TXN_1678985,Juice,2,3.0,6.0,Cash,In-store,2023-07-16
+TXN_6697669,Cake,5,3.0,15.0,Cash,,2023-01-03
+TXN_3131555,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-12-04
+TXN_1617029,UNKNOWN,4,5.0,20.0,Cash,Takeaway,2023-05-15
+TXN_7785297,Cookie,3,1.0,3.0,Cash,,2023-12-06
+TXN_9432588,Coffee,5,2.0,10.0,,,2023-07-26
+TXN_3313000,Coffee,5,2.0,10.0,Credit Card,In-store,2023-01-08
+TXN_3120023,Cookie,3,1.0,3.0,Cash,In-store,2023-09-30
+TXN_7483257,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-06-05
+TXN_3430842,Cookie,2,1.0,2.0,Cash,Takeaway,2023-08-02
+TXN_9622300,Salad,UNKNOWN,5.0,5.0,Cash,Takeaway,2023-06-23
+TXN_8822610,Cake,4,3.0,12.0,,Takeaway,2023-08-05
+TXN_8005089,Salad,4,5.0,20.0,ERROR,,2023-06-10
+TXN_7009420,Sandwich,5,4.0,20.0,UNKNOWN,Takeaway,2023-07-07
+TXN_5118667,Coffee,4,2.0,8.0,Cash,In-store,2023-12-12
+TXN_6533180,Coffee,5,2.0,10.0,,Takeaway,2023-05-03
+TXN_6989438,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-12-17
+TXN_3894820,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_7003185,Tea,2,1.5,3.0,,,2023-06-03
+TXN_1139495,Salad,3,5.0,15.0,Digital Wallet,,2023-02-19
+TXN_1256536,Salad,1,5.0,5.0,ERROR,Takeaway,2023-12-16
+TXN_6437055,Cake,1,3.0,3.0,UNKNOWN,,2023-10-22
+TXN_6212975,,1,4.0,4.0,Credit Card,Takeaway,2023-06-08
+TXN_4223466,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-05-31
+TXN_6684202,Sandwich,1,4.0,4.0,,,2023-07-31
+TXN_7279066,UNKNOWN,5,3.0,15.0,Digital Wallet,Takeaway,2023-09-09
+TXN_5032114,Sandwich,2,4.0,8.0,,,2023-05-31
+TXN_3411281,Cake,2,3.0,6.0,UNKNOWN,,2023-09-29
+TXN_6608817,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-07-17
+TXN_4258943,Sandwich,2,4.0,ERROR,Credit Card,In-store,2023-01-02
+TXN_1897660,Tea,3,1.5,4.5,Digital Wallet,In-store,UNKNOWN
+TXN_9774691,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-04-11
+TXN_8556230,,5,1.0,5.0,Cash,In-store,2023-05-21
+TXN_1522430,Smoothie,3,4.0,12.0,Credit Card,,2023-12-06
+TXN_2797077,,2,5.0,10.0,,Takeaway,2023-07-04
+TXN_7666909,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-08-29
+TXN_9365558,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-02-12
+TXN_6837601,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-02-05
+TXN_1713983,Salad,2,5.0,10.0,Cash,In-store,2023-05-11
+TXN_4674417,Cookie,5,1.0,UNKNOWN,Digital Wallet,Takeaway,2023-07-03
+TXN_4641838,Cookie,5,1.0,5.0,Credit Card,,2023-04-30
+TXN_9315119,Salad,2,5.0,10.0,,Takeaway,2023-06-16
+TXN_2552405,Juice,5,3.0,15.0,Credit Card,,2023-06-22
+TXN_3465980,Cookie,4,1.0,4.0,Cash,Takeaway,2023-07-08
+TXN_4220189,Tea,1,1.5,1.5,,Takeaway,2023-08-16
+TXN_7343905,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-01-17
+TXN_9813938,Sandwich,5,4.0,20.0,Cash,,2023-06-30
+TXN_6129460,Juice,5,3.0,15.0,Cash,UNKNOWN,2023-11-19
+TXN_9470590,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-04-11
+TXN_7212607,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-08-06
+TXN_8384628,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-08-22
+TXN_4200340,Cake,5,3.0,15.0,Cash,Takeaway,2023-07-06
+TXN_9349052,,4,3.0,12.0,Cash,,2023-10-31
+TXN_9749434,Cake,5,3.0,15.0,Credit Card,Takeaway,ERROR
+TXN_2693584,Cookie,,1.0,3.0,,,2023-10-28
+TXN_4778105,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-10-08
+TXN_7804488,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-28
+TXN_4674667,Coffee,2,2.0,4.0,,Takeaway,2023-05-24
+TXN_8832852,Sandwich,5,4.0,20.0,UNKNOWN,Takeaway,ERROR
+TXN_4278785,Salad,3,5.0,15.0,Cash,In-store,2023-04-29
+TXN_4462052,Cookie,1,1.0,1.0,Cash,In-store,2023-10-12
+TXN_3379368,Cake,5,3.0,15.0,Credit Card,,2023-05-26
+TXN_7651864,Smoothie,4,4.0,16.0,Digital Wallet,UNKNOWN,2023-04-29
+TXN_7089173,Juice,1,3.0,3.0,Digital Wallet,,2023-01-14
+TXN_1906642,Cookie,4,1.0,4.0,,Takeaway,2023-06-06
+TXN_5410349,ERROR,5,3.0,15.0,Credit Card,Takeaway,2023-03-05
+TXN_5234368,Coffee,3,2.0,6.0,Digital Wallet,,2023-06-10
+TXN_5544904,Salad,5,5.0,25.0,,,2023-04-19
+TXN_3376958,Salad,4,5.0,20.0,,In-store,2023-10-31
+TXN_5446085,Coffee,3,2.0,6.0,Digital Wallet,,2023-09-16
+TXN_9676940,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-08-16
+TXN_2371941,Juice,2,3.0,6.0,Cash,,2023-01-26
+TXN_8980774,Tea,4,1.5,6.0,,In-store,UNKNOWN
+TXN_5708913,Cake,2,3.0,6.0,Cash,In-store,2023-04-29
+TXN_6310726,UNKNOWN,3,1.0,3.0,Credit Card,,2023-03-30
+TXN_4096816,ERROR,3,2.0,6.0,Digital Wallet,Takeaway,2023-11-02
+TXN_7451083,Coffee,1,2.0,2.0,Digital Wallet,,2023-06-24
+TXN_5132082,Salad,5,5.0,25.0,ERROR,,2023-10-08
+TXN_7323040,Cookie,3,1.0,3.0,,Takeaway,2023-11-09
+TXN_9176418,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-03-02
+TXN_9702662,UNKNOWN,4,,16.0,,Takeaway,2023-07-10
+TXN_7612618,Smoothie,4,4.0,16.0,Credit Card,ERROR,2023-04-12
+TXN_7321789,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-05-10
+TXN_3679126,Cookie,1,1.0,1.0,Cash,,2023-07-15
+TXN_2008137,Coffee,4,2.0,8.0,,ERROR,2023-10-07
+TXN_2622670,Cake,5,3.0,15.0,Digital Wallet,UNKNOWN,2023-01-28
+TXN_4791105,ERROR,3,4.0,,,Takeaway,2023-05-18
+TXN_6882819,UNKNOWN,1,3.0,3.0,Cash,ERROR,2023-08-21
+TXN_2152670,Tea,3,1.5,4.5,Credit Card,In-store,2023-12-24
+TXN_3482117,Sandwich,2,4.0,8.0,,,2023-07-18
+TXN_1843989,ERROR,5,1.0,5.0,,Takeaway,2023-07-19
+TXN_4943715,Coffee,5,2.0,10.0,Digital Wallet,,2023-10-06
+TXN_8571836,Juice,3,,9.0,Cash,ERROR,2023-12-27
+TXN_2544176,Tea,3,1.5,4.5,,Takeaway,2023-12-19
+TXN_1589264,,2,5.0,10.0,Cash,,2023-07-26
+TXN_1379209,Tea,5,1.5,7.5,,In-store,2023-02-06
+TXN_2515920,ERROR,3,3.0,9.0,Cash,In-store,2023-10-02
+TXN_6496099,Coffee,,2.0,10.0,Digital Wallet,,2023-07-21
+TXN_8696065,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-11-04
+TXN_4746320,Cookie,2,1.0,2.0,ERROR,Takeaway,2023-04-02
+TXN_1250407,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-11-21
+TXN_1617476,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-02-10
+TXN_4196578,Tea,2,1.5,3.0,Credit Card,,2023-06-26
+TXN_9725461,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-11-25
+TXN_2975443,Salad,5,5.0,25.0,,Takeaway,2023-12-31
+TXN_1000555,Tea,1,1.5,1.5,Credit Card,In-store,2023-10-19
+TXN_1622411,Salad,2,5.0,10.0,UNKNOWN,Takeaway,2023-07-23
+TXN_9429128,Coffee,,2.0,8.0,Credit Card,In-store,2023-12-19
+TXN_1056277,Cookie,UNKNOWN,1.0,5.0,,,2023-02-06
+TXN_4801617,Juice,5,3.0,15.0,,,2023-04-02
+TXN_1365285,Juice,5,3.0,15.0,Credit Card,,2023-06-11
+TXN_3189677,Smoothie,,4.0,4.0,,,2023-01-11
+TXN_3375399,Cookie,,1.0,1.0,Digital Wallet,Takeaway,2023-05-21
+TXN_9315755,Cake,5,3.0,15.0,Cash,Takeaway,2023-09-26
+TXN_6853678,Cookie,4,1.0,4.0,Digital Wallet,,2023-07-23
+TXN_6530886,Coffee,1,2.0,UNKNOWN,Credit Card,,2023-10-21
+TXN_3530720,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-10-18
+TXN_3716067,Tea,5,1.5,7.5,Credit Card,In-store,UNKNOWN
+TXN_1410102,Salad,1,5.0,5.0,Cash,In-store,2023-06-23
+TXN_6977098,Juice,5,3.0,15.0,Credit Card,In-store,2023-06-09
+TXN_7735237,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-01-13
+TXN_7510766,Coffee,3,2.0,6.0,,In-store,2023-07-24
+TXN_3352256,Sandwich,2,4.0,8.0,,Takeaway,2023-09-08
+TXN_8494538,Cake,4,3.0,12.0,,,2023-11-08
+TXN_8676769,Salad,UNKNOWN,5.0,15.0,Digital Wallet,In-store,2023-06-16
+TXN_5282529,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-04-13
+TXN_9495930,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-10-23
+TXN_3514492,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-02-23
+TXN_1349215,UNKNOWN,ERROR,4.0,4.0,Digital Wallet,,2023-02-06
+TXN_7223646,Cookie,UNKNOWN,1.0,5.0,Credit Card,,2023-09-19
+TXN_4033982,UNKNOWN,2,1.5,3.0,Credit Card,Takeaway,2023-01-04
+TXN_1842697,UNKNOWN,5,,15.0,,,2023-10-25
+TXN_4227337,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-12-15
+TXN_5790213,Juice,3,3.0,9.0,Cash,,2023-08-30
+TXN_3546261,Tea,3,1.5,4.5,,Takeaway,2023-03-20
+TXN_7119228,UNKNOWN,4,3.0,12.0,Digital Wallet,,2023-10-09
+TXN_3334257,Sandwich,2,4.0,8.0,Cash,UNKNOWN,2023-06-10
+TXN_5665767,Tea,4,1.5,6.0,,,2023-08-22
+TXN_4527464,Tea,4,1.5,6.0,,In-store,2023-08-09
+TXN_1011236,Cake,1,3.0,3.0,Cash,In-store,2023-02-08
+TXN_8293691,Coffee,4,2.0,8.0,,,2023-06-30
+TXN_7463011,Sandwich,2,4.0,8.0,,In-store,2023-01-22
+TXN_6872268,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-01-07
+TXN_3999554,Coffee,1,2.0,ERROR,Credit Card,Takeaway,2023-09-13
+TXN_9942247,Coffee,2,2.0,UNKNOWN,Cash,Takeaway,2023-10-15
+TXN_3687300,Cookie,2,1.0,2.0,Credit Card,In-store,ERROR
+TXN_6113452,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-09-21
+TXN_1752617,Tea,5,1.5,7.5,,Takeaway,2023-09-05
+TXN_1949789,Salad,2,5.0,10.0,,Takeaway,2023-11-07
+TXN_7386089,Sandwich,2,4.0,8.0,,In-store,2023-07-15
+TXN_6751134,Sandwich,3,,12.0,,UNKNOWN,2023-01-12
+TXN_2731270,Cake,1,3.0,3.0,,Takeaway,2023-05-31
+TXN_8830813,Coffee,UNKNOWN,2.0,2.0,Cash,In-store,2023-06-18
+TXN_2548248,Cake,4,3.0,12.0,ERROR,Takeaway,2023-06-28
+TXN_3026930,Cake,2,3.0,6.0,Cash,In-store,2023-03-23
+TXN_2824366,Sandwich,4,4.0,16.0,ERROR,In-store,2023-07-02
+TXN_2801651,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-07-10
+TXN_5005592,Coffee,1,2.0,2.0,Credit Card,In-store,2023-06-05
+TXN_8284313,Salad,5,5.0,25.0,,,2023-11-20
+TXN_8058026,Tea,1,1.5,1.5,ERROR,Takeaway,2023-05-19
+TXN_2182790,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-05-05
+TXN_7251929,ERROR,2,5.0,10.0,Digital Wallet,In-store,2023-01-31
+TXN_2145530,Sandwich,3,4.0,12.0,Digital Wallet,ERROR,2023-10-08
+TXN_4159861,Juice,1,3.0,3.0,Digital Wallet,,2023-03-20
+TXN_4600614,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-01-27
+TXN_1853298,Cookie,5,1.0,5.0,Credit Card,,2023-01-02
+TXN_6600858,Sandwich,3,4.0,12.0,Cash,ERROR,2023-03-27
+TXN_7494793,Smoothie,5,ERROR,20.0,,Takeaway,2023-12-29
+TXN_3968170,Salad,1,5.0,5.0,,In-store,2023-08-05
+TXN_4628310,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-04-20
+TXN_6110009,Juice,5,3.0,15.0,,Takeaway,2023-12-26
+TXN_8996187,Salad,2,,10.0,Credit Card,In-store,2023-09-28
+TXN_3544792,Sandwich,1,4.0,4.0,Digital Wallet,,2023-06-27
+TXN_2353057,Cake,3,3.0,9.0,UNKNOWN,Takeaway,2023-08-04
+TXN_6013295,Juice,2,3.0,6.0,Cash,Takeaway,2023-11-07
+TXN_3200195,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-05-04
+TXN_4860027,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-07-28
+TXN_3509437,,4,4.0,16.0,,In-store,2023-12-06
+TXN_5442505,Cake,4,ERROR,12.0,Digital Wallet,Takeaway,2023-09-07
+TXN_4708410,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-10-08
+TXN_4847617,Sandwich,4,4.0,UNKNOWN,Credit Card,,2023-08-04
+TXN_1898329,Cake,5,3.0,15.0,Cash,In-store,2023-04-12
+TXN_2508266,Cookie,1,1.0,1.0,ERROR,,2023-01-28
+TXN_1945918,Juice,2,3.0,6.0,,UNKNOWN,2023-09-12
+TXN_8147057,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-08-21
+TXN_9546556,,5,3.0,15.0,Cash,In-store,2023-08-18
+TXN_4935258,Cake,2,3.0,6.0,Credit Card,,2023-09-14
+TXN_5588239,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-03-31
+TXN_6575599,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-10-09
+TXN_9382156,Tea,5,1.5,7.5,ERROR,Takeaway,2023-06-02
+TXN_1229376,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-08-14
+TXN_1732216,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-08-30
+TXN_1756717,Smoothie,3,4.0,12.0,Credit Card,UNKNOWN,2023-01-22
+TXN_8188857,Cake,1,3.0,3.0,,,2023-12-21
+TXN_9783697,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-07-14
+TXN_6991253,Juice,3,3.0,9.0,,In-store,2023-12-13
+TXN_7177487,Tea,ERROR,1.5,6.0,Credit Card,,2023-09-07
+TXN_8444245,ERROR,1,3.0,3.0,Cash,,2023-01-30
+TXN_3224756,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-11-20
+TXN_3421456,Cake,UNKNOWN,3.0,3.0,UNKNOWN,,2023-09-05
+TXN_9421618,Cake,3,3.0,9.0,Cash,ERROR,2023-02-21
+TXN_9054741,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-06-24
+TXN_9063299,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-06-15
+TXN_4318159,Coffee,4,2.0,8.0,Digital Wallet,,2023-03-30
+TXN_8127390,Tea,3,1.5,4.5,,In-store,2023-01-19
+TXN_9682798,Cake,3,3.0,,Cash,In-store,2023-09-15
+TXN_9716971,Salad,4,5.0,20.0,Digital Wallet,UNKNOWN,2023-06-21
+TXN_7827797,Salad,3,5.0,,,Takeaway,2023-06-30
+TXN_4343391,Cookie,5,1.0,5.0,Cash,Takeaway,2023-06-01
+TXN_6877186,Cookie,2,1.0,2.0,Credit Card,In-store,2023-12-05
+TXN_8162049,Sandwich,1,4.0,4.0,Digital Wallet,,
+TXN_6559173,Smoothie,5,4.0,20.0,UNKNOWN,,2023-08-09
+TXN_9818498,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-09-01
+TXN_2520102,Coffee,1,2.0,2.0,Digital Wallet,,2023-03-08
+TXN_9155044,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-02-28
+TXN_5625110,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-11-07
+TXN_3923375,Cake,5,3.0,15.0,Credit Card,,ERROR
+TXN_8706498,Smoothie,5,4.0,20.0,,,2023-05-08
+TXN_1188596,Juice,1,3.0,3.0,Cash,,2023-10-24
+TXN_8085790,Cookie,4,1.0,4.0,Cash,Takeaway,2023-10-27
+TXN_3113823,Salad,5,ERROR,25.0,Digital Wallet,In-store,2023-03-01
+TXN_3423451,Salad,4,5.0,20.0,Cash,ERROR,2023-10-11
+TXN_8010863,Coffee,2,2.0,4.0,,,2023-06-30
+TXN_6154626,Smoothie,5,4.0,20.0,,Takeaway,2023-05-06
+TXN_5841004,Cookie,2,,2.0,Credit Card,In-store,2023-04-28
+TXN_2886223,Sandwich,5,4.0,20.0,Credit Card,,2023-07-24
+TXN_6047742,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-12-11
+TXN_5086795,Salad,1,5.0,5.0,Cash,In-store,2023-04-29
+TXN_1943186,Salad,2,5.0,10.0,Cash,In-store,2023-12-16
+TXN_9600016,Cookie,4,1.0,4.0,,Takeaway,2023-05-06
+TXN_7397017,Salad,3,5.0,15.0,Digital Wallet,Takeaway,ERROR
+TXN_4305997,Tea,3,1.5,4.5,,In-store,2023-11-22
+TXN_4364374,Sandwich,2,4.0,UNKNOWN,Cash,ERROR,2023-04-20
+TXN_7031347,UNKNOWN,4,3.0,12.0,Credit Card,Takeaway,2023-06-09
+TXN_9703331,Cake,2,3.0,6.0,Cash,,2023-09-09
+TXN_3851247,Cake,1,3.0,3.0,Credit Card,In-store,2023-11-23
+TXN_6666679,Juice,2,3.0,6.0,Digital Wallet,,2023-08-25
+TXN_5683213,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-10-30
+TXN_2052609,Cake,4,,12.0,Credit Card,Takeaway,2023-06-23
+TXN_6557825,Tea,UNKNOWN,1.5,4.5,ERROR,,2023-05-07
+TXN_6228999,Cookie,5,1.0,5.0,,,2023-02-07
+TXN_4226287,Cookie,1,1.0,1.0,,,2023-04-29
+TXN_9868053,Juice,3,3.0,9.0,Digital Wallet,In-store,UNKNOWN
+TXN_2570829,Juice,1,3.0,3.0,Cash,Takeaway,2023-03-31
+TXN_7433531,Sandwich,2,4.0,8.0,,Takeaway,2023-08-16
+TXN_5190685,Cookie,4,1.0,4.0,Cash,Takeaway,2023-11-12
+TXN_4526296,Smoothie,5,4.0,20.0,UNKNOWN,Takeaway,2023-11-23
+TXN_5137315,Salad,UNKNOWN,5.0,25.0,Credit Card,In-store,2023-01-05
+TXN_6513435,Juice,3,3.0,9.0,,Takeaway,2023-08-16
+TXN_8337899,Cookie,1,1.0,1.0,Digital Wallet,,2023-11-10
+TXN_2245787,Salad,4,5.0,20.0,,Takeaway,2023-10-29
+TXN_9203396,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-01-08
+TXN_9352671,Sandwich,2,4.0,UNKNOWN,Cash,Takeaway,2023-02-10
+TXN_6391414,Smoothie,4,4.0,16.0,Cash,In-store,2023-05-08
+TXN_2613440,Juice,3,3.0,9.0,Credit Card,In-store,2023-04-15
+TXN_5632564,Cookie,1,1.0,1.0,Credit Card,,2023-11-04
+TXN_4175122,UNKNOWN,4,2.0,8.0,Digital Wallet,In-store,2023-09-29
+TXN_3475075,Cake,3,,9.0,Cash,Takeaway,UNKNOWN
+TXN_4759797,Salad,3,5.0,15.0,UNKNOWN,In-store,ERROR
+TXN_4704439,Coffee,3,2.0,6.0,Cash,UNKNOWN,2023-06-14
+TXN_3292043,Cookie,5,UNKNOWN,5.0,,ERROR,ERROR
+TXN_2666340,Cake,2,3.0,6.0,Cash,Takeaway,2023-09-29
+TXN_8004162,Salad,5,5.0,25.0,ERROR,UNKNOWN,2023-11-04
+TXN_6539480,Cake,5,3.0,15.0,Cash,Takeaway,2023-08-25
+TXN_1993002,ERROR,4,3.0,12.0,,Takeaway,2023-03-30
+TXN_5024094,Tea,1,UNKNOWN,1.5,Credit Card,,2023-02-20
+TXN_7399898,Juice,3,3.0,9.0,,,2023-02-19
+TXN_7675213,ERROR,UNKNOWN,4.0,8.0,Digital Wallet,In-store,2023-03-08
+TXN_5180728,Tea,2,1.5,3.0,,In-store,2023-09-01
+TXN_1442791,Tea,1,1.5,1.5,UNKNOWN,,2023-03-23
+TXN_7169607,Cake,2,3.0,6.0,Credit Card,,2023-04-10
+TXN_8157817,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-08-30
+TXN_9105544,Tea,3,1.5,4.5,,In-store,2023-07-08
+TXN_7620529,Sandwich,2,4.0,8.0,Cash,In-store,2023-08-08
+TXN_1491670,Juice,5,3.0,15.0,Credit Card,Takeaway,2023-06-28
+TXN_8041777,Cake,1,3.0,3.0,Cash,,2023-11-23
+TXN_2366464,Juice,1,3.0,3.0,Cash,Takeaway,2023-06-05
+TXN_7994275,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-09-18
+TXN_6034920,Cookie,1,1.0,1.0,Credit Card,In-store,2023-09-09
+TXN_4673812,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-05-01
+TXN_3577949,Cake,3,,UNKNOWN,ERROR,Takeaway,2023-04-25
+TXN_4503560,Cake,5,3.0,15.0,Digital Wallet,,2023-02-21
+TXN_6543620,Cookie,2,1.0,2.0,Cash,Takeaway,2023-04-08
+TXN_5071222,Cookie,5,1.0,5.0,Digital Wallet,ERROR,2023-10-25
+TXN_1605048,Cake,4,3.0,12.0,Cash,Takeaway,2023-03-16
+TXN_9907306,ERROR,3,1.0,3.0,Digital Wallet,Takeaway,2023-09-06
+TXN_2401829,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-02-07
+TXN_8359674,Salad,3,5.0,15.0,,Takeaway,2023-10-16
+TXN_1937611,Tea,2,UNKNOWN,3.0,Credit Card,Takeaway,2023-11-02
+TXN_5438111,Smoothie,3,4.0,12.0,Cash,In-store,2023-01-06
+TXN_1442771,,1,3.0,3.0,,,2023-04-25
+TXN_5793057,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-02-25
+TXN_1778597,Cookie,3,1.0,UNKNOWN,Cash,,2023-09-28
+TXN_4076631,ERROR,4,3.0,12.0,Cash,In-store,2023-07-21
+TXN_1660757,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-11-08
+TXN_7540909,Tea,2,1.5,3.0,Digital Wallet,,2023-02-20
+TXN_1469462,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-09-05
+TXN_4745094,Tea,5,1.5,7.5,Credit Card,,2023-12-05
+TXN_3711712,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-08-20
+TXN_7909509,Smoothie,3,4.0,12.0,,Takeaway,2023-10-10
+TXN_8577850,Tea,UNKNOWN,1.5,4.5,,,2023-07-10
+TXN_1268480,Salad,5,5.0,25.0,Cash,In-store,2023-04-18
+TXN_6579974,Sandwich,5,4.0,20.0,Digital Wallet,,2023-05-10
+TXN_6957331,Juice,3,3.0,ERROR,Digital Wallet,,2023-01-23
+TXN_7796731,Juice,,3.0,6.0,,In-store,2023-06-09
+TXN_7218914,UNKNOWN,1,5.0,5.0,Digital Wallet,In-store,2023-01-11
+TXN_4869107,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-01-30
+TXN_2027203,Coffee,3,2.0,6.0,Credit Card,,2023-07-15
+TXN_6149748,Salad,3,5.0,15.0,Credit Card,,2023-07-06
+TXN_1633563,ERROR,4,4.0,16.0,Digital Wallet,In-store,2023-02-05
+TXN_3088330,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-12-08
+TXN_5001766,Smoothie,1,4.0,UNKNOWN,Digital Wallet,,2023-05-24
+TXN_5634960,Tea,2,1.5,3.0,,Takeaway,2023-09-06
+TXN_6280724,Coffee,3,2.0,6.0,Credit Card,,2023-05-02
+TXN_7650834,Salad,2,5.0,10.0,Cash,Takeaway,2023-10-29
+TXN_4107857,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-01-29
+TXN_2052771,Tea,4,1.5,6.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_4635037,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-05-17
+TXN_2160119,UNKNOWN,5,4.0,20.0,Cash,,2023-12-27
+TXN_9103776,Tea,4,1.5,6.0,Credit Card,In-store,2023-05-03
+TXN_7538221,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-03-31
+TXN_4565754,Smoothie,,4.0,ERROR,Digital Wallet,Takeaway,2023-10-06
+TXN_8807333,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-03-18
+TXN_8006056,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-12-19
+TXN_2216532,Tea,3,1.5,4.5,Cash,ERROR,2023-12-27
+TXN_6553720,Coffee,4,2.0,8.0,,In-store,2023-02-02
+TXN_5828907,Cookie,5,1.0,5.0,Digital Wallet,,2023-05-13
+TXN_2336248,Cake,,3.0,15.0,,Takeaway,2023-10-19
+TXN_3321611,ERROR,3,4.0,,,Takeaway,2023-09-09
+TXN_6022618,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-12-18
+TXN_1665810,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-02-26
+TXN_1399696,Cake,5,3.0,15.0,Cash,In-store,2023-04-08
+TXN_9154381,Cookie,2,1.0,2.0,Credit Card,In-store,2023-04-21
+TXN_5333966,Juice,4,3.0,12.0,UNKNOWN,In-store,2023-06-11
+TXN_8361813,Cookie,3,1.0,3.0,Cash,In-store,2023-08-01
+TXN_9841222,Sandwich,5,4.0,20.0,Credit Card,ERROR,2023-04-23
+TXN_4754346,Juice,4,3.0,12.0,Credit Card,In-store,2023-08-31
+TXN_5910268,Salad,4,5.0,ERROR,,Takeaway,2023-07-04
+TXN_9433806,Coffee,1,2.0,2.0,,,
+TXN_5227574,Juice,4,3.0,12.0,Digital Wallet,ERROR,2023-04-10
+TXN_5485774,Coffee,2,2.0,4.0,Credit Card,,2023-07-20
+TXN_6504165,Juice,3,UNKNOWN,9.0,Cash,Takeaway,2023-02-13
+TXN_6297232,Coffee,,2.0,UNKNOWN,,,2023-04-07
+TXN_2391659,Tea,5,1.5,ERROR,,UNKNOWN,2023-02-16
+TXN_8964493,Smoothie,1,4.0,4.0,Cash,,2023-02-10
+TXN_1931832,,4,4.0,16.0,Credit Card,,2023-05-07
+TXN_4939667,Salad,1,5.0,5.0,Cash,Takeaway,2023-01-23
+TXN_7126803,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-05-24
+TXN_9649878,Cake,5,3.0,15.0,Cash,,2023-12-24
+TXN_5086063,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-09-28
+TXN_5026564,Smoothie,3,4.0,12.0,Cash,,2023-09-12
+TXN_9680054,Cake,3,3.0,9.0,,In-store,2023-03-14
+TXN_7299015,Coffee,5,2.0,10.0,,Takeaway,2023-12-02
+TXN_6040824,Sandwich,1,4.0,4.0,Cash,,2023-01-07
+TXN_4520062,,2,1.5,3.0,,In-store,2023-01-10
+TXN_5889049,Cookie,2,1.0,2.0,,In-store,2023-07-14
+TXN_1177438,Salad,4,5.0,20.0,,Takeaway,2023-08-21
+TXN_6345691,,5,4.0,20.0,Credit Card,,2023-09-03
+TXN_6523635,ERROR,2,5.0,10.0,,Takeaway,2023-04-22
+TXN_7494217,Cookie,1,1.0,1.0,Cash,In-store,
+TXN_6854151,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-02-07
+TXN_6862075,,3,3.0,9.0,Credit Card,In-store,2023-08-13
+TXN_9202272,Sandwich,3,4.0,12.0,,,2023-11-29
+TXN_8620934,Cookie,5,1.0,5.0,,In-store,2023-09-10
+TXN_8133627,Cake,5,3.0,15.0,Cash,In-store,2023-08-15
+TXN_5777224,Tea,3,1.5,4.5,UNKNOWN,,2023-09-16
+TXN_1895899,Smoothie,4,UNKNOWN,16.0,Credit Card,In-store,2023-07-17
+TXN_3658211,Cake,UNKNOWN,3.0,12.0,Cash,Takeaway,2023-04-02
+TXN_5117140,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-08-17
+TXN_2513950,Smoothie,4,4.0,16.0,,In-store,2023-04-03
+TXN_7890585,Cake,5,3.0,15.0,Cash,,2023-08-11
+TXN_5106045,Coffee,3,UNKNOWN,6.0,Credit Card,,2023-11-17
+TXN_5177565,Sandwich,5,4.0,20.0,,,2023-10-24
+TXN_2792107,Cake,1,3.0,3.0,,ERROR,2023-07-10
+TXN_4036747,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-05-27
+TXN_2955691,Cake,1,3.0,3.0,,Takeaway,2023-04-04
+TXN_6324736,Sandwich,5,4.0,20.0,Credit Card,,ERROR
+TXN_9641364,Cookie,3,1.0,3.0,ERROR,In-store,2023-03-04
+TXN_3488590,Cookie,,1.0,2.0,Credit Card,Takeaway,2023-12-28
+TXN_9720549,Cookie,1,1.0,1.0,Credit Card,In-store,2023-07-30
+TXN_2477550,ERROR,2,4.0,8.0,Cash,Takeaway,2023-02-02
+TXN_2172960,Smoothie,1,4.0,ERROR,Digital Wallet,,2023-07-04
+TXN_5901182,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-07-15
+TXN_4695415,Cake,5,3.0,15.0,,In-store,ERROR
+TXN_1923984,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-08-31
+TXN_4163149,Salad,1,5.0,UNKNOWN,Cash,,2023-07-30
+TXN_5996894,Juice,1,3.0,3.0,Credit Card,,2023-06-12
+TXN_2979899,Cake,5,3.0,15.0,Digital Wallet,,2023-05-26
+TXN_7762739,Sandwich,4,4.0,16.0,,In-store,2023-11-05
+TXN_6392156,Cookie,5,1.0,ERROR,Credit Card,Takeaway,2023-11-12
+TXN_7278248,Salad,UNKNOWN,5.0,25.0,Cash,Takeaway,2023-10-23
+TXN_1315847,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-06-19
+TXN_9367729,Coffee,2,2.0,4.0,,Takeaway,2023-10-10
+TXN_1464150,Coffee,5,2.0,10.0,Cash,Takeaway,2023-02-14
+TXN_1746001,Cookie,ERROR,1.0,3.0,Digital Wallet,Takeaway,2023-03-15
+TXN_4203560,Juice,1,3.0,3.0,,UNKNOWN,2023-08-20
+TXN_1493452,Sandwich,3,4.0,12.0,,,2023-11-08
+TXN_4171998,Sandwich,,4.0,8.0,UNKNOWN,Takeaway,2023-10-18
+TXN_4528664,Salad,3,5.0,,Cash,In-store,2023-12-31
+TXN_1775278,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-02-22
+TXN_1459078,Cookie,5,1.0,5.0,,In-store,2023-11-10
+TXN_6252589,Smoothie,2,4.0,8.0,Digital Wallet,In-store,ERROR
+TXN_1411473,Coffee,3,2.0,6.0,Credit Card,In-store,2023-01-04
+TXN_5132747,Coffee,2,2.0,4.0,,,2023-10-28
+TXN_9851026,Salad,2,5.0,10.0,,Takeaway,ERROR
+TXN_7684072,Tea,2,1.5,3.0,Credit Card,,2023-05-12
+TXN_3660999,Cake,3,3.0,9.0,Digital Wallet,,2023-02-02
+TXN_7828462,UNKNOWN,,1.5,4.5,Cash,Takeaway,2023-01-11
+TXN_3976744,Juice,1,3.0,3.0,Cash,,2023-12-25
+TXN_3397978,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-08-01
+TXN_8568597,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-04-03
+TXN_4152709,Sandwich,4,4.0,16.0,,,2023-12-03
+TXN_5222110,Coffee,2,2.0,4.0,,,2023-01-30
+TXN_1987716,Coffee,1,2.0,2.0,Credit Card,,2023-11-13
+TXN_3643348,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-09-06
+TXN_6537449,Salad,2,5.0,10.0,,In-store,2023-01-15
+TXN_1244509,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-02-21
+TXN_3490516,Coffee,5,2.0,10.0,,,2023-04-28
+TXN_2726254,Smoothie,3,,12.0,,Takeaway,2023-06-08
+TXN_9917989,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-10-20
+TXN_4933689,Cake,1,3.0,3.0,Cash,In-store,ERROR
+TXN_4168628,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-04-27
+TXN_2490026,Cake,5,3.0,15.0,,,2023-10-21
+TXN_7327440,UNKNOWN,3,1.0,3.0,Cash,In-store,2023-05-02
+TXN_3597656,Coffee,4,2.0,8.0,Digital Wallet,,2023-04-03
+TXN_1765281,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-01-28
+TXN_4667663,Cake,5,3.0,15.0,Credit Card,,2023-03-07
+TXN_8571235,Cake,1,3.0,3.0,Cash,Takeaway,2023-03-01
+TXN_2580487,Cake,1,3.0,3.0,,Takeaway,2023-01-13
+TXN_2611683,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-04-11
+TXN_4271744,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-06-19
+TXN_2917072,Tea,3,1.5,4.5,UNKNOWN,Takeaway,2023-01-25
+TXN_4653861,Sandwich,UNKNOWN,4.0,16.0,Cash,Takeaway,ERROR
+TXN_5777903,Coffee,UNKNOWN,2.0,4.0,,Takeaway,2023-05-15
+TXN_5153086,Tea,3,1.5,4.5,Cash,In-store,2023-06-27
+TXN_6004967,Salad,4,5.0,UNKNOWN,Credit Card,,2023-01-13
+TXN_3435509,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-08-19
+TXN_2488232,Tea,2,1.5,3.0,,,2023-10-05
+TXN_8771574,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-05-03
+TXN_1181626,Cookie,4,1.0,4.0,,Takeaway,2023-02-06
+TXN_4081759,UNKNOWN,UNKNOWN,2.0,4.0,,,2023-09-30
+TXN_6177161,Tea,5,1.5,7.5,Credit Card,In-store,2023-04-01
+TXN_2500345,Salad,5,5.0,25.0,,In-store,2023-04-16
+TXN_1228652,Salad,1,ERROR,5.0,Cash,In-store,2023-07-24
+TXN_4476151,Juice,4,3.0,12.0,Credit Card,In-store,2023-02-15
+TXN_7990902,Coffee,5,2.0,10.0,ERROR,In-store,ERROR
+TXN_6557174,Salad,4,5.0,20.0,Credit Card,In-store,2023-08-20
+TXN_5089516,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-11-04
+TXN_5915706,Tea,1,1.5,1.5,Cash,In-store,2023-08-18
+TXN_9341159,Cake,5,3.0,15.0,,,2023-09-29
+TXN_1870303,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-05-05
+TXN_5680238,Juice,5,3.0,15.0,,,2023-12-17
+TXN_7766134,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-01-05
+TXN_2617257,Cookie,1,1.0,1.0,Cash,Takeaway,2023-08-20
+TXN_8993132,Cake,3,3.0,9.0,,In-store,2023-01-21
+TXN_4268167,Smoothie,4,4.0,16.0,,,2023-07-06
+TXN_9358399,Tea,5,1.5,7.5,Credit Card,,2023-06-16
+TXN_2793054,Smoothie,4,4.0,16.0,,Takeaway,2023-04-29
+TXN_6179169,Sandwich,2,4.0,8.0,Cash,In-store,2023-10-21
+TXN_7932895,Smoothie,2,4.0,8.0,,In-store,2023-04-04
+TXN_3364751,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-04-12
+TXN_1097334,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-03-21
+TXN_9914084,UNKNOWN,1,2.0,2.0,ERROR,Takeaway,2023-06-16
+TXN_5982786,Juice,4,3.0,UNKNOWN,Credit Card,In-store,2023-12-26
+TXN_3160090,Salad,1,5.0,5.0,,Takeaway,2023-07-23
+TXN_2300313,Coffee,4,2.0,8.0,,In-store,2023-06-02
+TXN_9461396,Smoothie,5,4.0,20.0,,,2023-05-23
+TXN_6887407,Cake,3,3.0,9.0,Cash,In-store,2023-09-15
+TXN_6425991,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-08-06
+TXN_6040882,Cookie,1,1.0,1.0,Cash,In-store,2023-06-06
+TXN_4151440,Cake,5,3.0,15.0,,In-store,2023-11-16
+TXN_7921799,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-09-14
+TXN_1715317,UNKNOWN,5,3.0,15.0,Digital Wallet,In-store,2023-02-10
+TXN_2482242,Cookie,4,1.0,4.0,,,2023-02-07
+TXN_5861636,Coffee,4,2.0,8.0,Credit Card,,2023-05-15
+TXN_7272630,Tea,4,1.5,6.0,Cash,Takeaway,2023-03-24
+TXN_7157169,Sandwich,3,4.0,12.0,,,2023-01-29
+TXN_9325384,Juice,5,3.0,15.0,,In-store,2023-04-24
+TXN_2832778,Juice,2,3.0,6.0,Credit Card,,2023-09-27
+TXN_9894745,Tea,,1.5,3.0,Cash,Takeaway,2023-08-28
+TXN_1244299,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-07-18
+TXN_1694090,Coffee,4,2.0,8.0,Digital Wallet,,2023-11-30
+TXN_5965095,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-06-16
+TXN_7911650,Juice,2,3.0,6.0,Cash,Takeaway,2023-03-13
+TXN_9610933,Tea,3,1.5,4.5,Cash,,2023-05-20
+TXN_7440879,ERROR,1,3.0,3.0,,In-store,2023-12-30
+TXN_4228312,Coffee,4,2.0,8.0,Digital Wallet,,2023-01-22
+TXN_6431703,Sandwich,1,4.0,,Credit Card,Takeaway,2023-08-25
+TXN_1063524,Smoothie,5,4.0,20.0,Credit Card,,2023-11-09
+TXN_9031518,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-01-13
+TXN_5781767,Sandwich,5,,20.0,Credit Card,In-store,2023-04-27
+TXN_4465589,,ERROR,1.5,3.0,Credit Card,,2023-03-26
+TXN_2035838,UNKNOWN,UNKNOWN,3.0,15.0,Digital Wallet,Takeaway,2023-02-01
+TXN_9817602,,2,4.0,8.0,Credit Card,Takeaway,2023-12-26
+TXN_9643180,Coffee,2,2.0,4.0,Cash,,2023-06-10
+TXN_9070074,Coffee,5,2.0,10.0,Digital Wallet,,2023-02-03
+TXN_5274961,,1,3.0,3.0,Credit Card,In-store,2023-11-04
+TXN_8715388,Salad,1,5.0,5.0,,In-store,2023-11-04
+TXN_1980303,Tea,3,1.5,ERROR,Digital Wallet,,2023-04-22
+TXN_9291130,Cookie,,1.0,5.0,Cash,In-store,2023-05-11
+TXN_6485220,Cake,3,3.0,9.0,Cash,ERROR,ERROR
+TXN_2652800,Cake,4,3.0,12.0,Cash,,2023-11-30
+TXN_7068406,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-01-26
+TXN_5380220,Coffee,4,2.0,8.0,Credit Card,In-store,2023-10-18
+TXN_7842557,Tea,4,1.5,6.0,,In-store,2023-02-09
+TXN_7208533,Tea,1,1.5,1.5,Cash,In-store,2023-05-15
+TXN_6916853,Smoothie,5,4.0,20.0,Cash,,2023-12-22
+TXN_9086710,Salad,2,5.0,10.0,,In-store,2023-10-27
+TXN_1830278,Cookie,3,1.0,3.0,Credit Card,,2023-05-15
+TXN_8388122,Tea,4,1.5,6.0,,In-store,2023-11-01
+TXN_8612901,Juice,3,3.0,UNKNOWN,Digital Wallet,UNKNOWN,2023-03-18
+TXN_7752958,Juice,2,3.0,6.0,,,2023-09-22
+TXN_5311814,Tea,4,1.5,6.0,Digital Wallet,,2023-07-06
+TXN_2933739,Cookie,1,1.0,1.0,Digital Wallet,,2023-09-15
+TXN_1239876,,2,4.0,8.0,Digital Wallet,In-store,2023-04-04
+TXN_6295047,Tea,UNKNOWN,1.5,6.0,Digital Wallet,,2023-09-06
+TXN_3858791,Cookie,5,1.0,5.0,Credit Card,,2023-06-25
+TXN_1737731,Smoothie,5,4.0,20.0,Digital Wallet,,2023-06-29
+TXN_6131195,Salad,1,5.0,5.0,,,2023-10-24
+TXN_3251829,Tea,,1.5,,Digital Wallet,In-store,2023-07-25
+TXN_2727347,Cake,5,3.0,15.0,Cash,Takeaway,2023-01-20
+TXN_7242713,Sandwich,1,4.0,4.0,,In-store,2023-04-21
+TXN_7797231,,5,UNKNOWN,10.0,Digital Wallet,,2023-05-05
+TXN_3651337,Smoothie,4,4.0,16.0,Cash,In-store,2023-10-25
+TXN_4740892,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-11-19
+TXN_7218719,Cake,1,3.0,3.0,Cash,,2023-10-07
+TXN_3455415,Cookie,2,1.0,2.0,Credit Card,,2023-03-31
+TXN_2475259,Smoothie,2,4.0,8.0,Cash,,
+TXN_3390882,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-07-03
+TXN_3848261,Tea,2,1.5,3.0,,Takeaway,2023-08-03
+TXN_2797925,Cake,2,3.0,UNKNOWN,Cash,,2023-10-19
+TXN_2599005,Cake,2,3.0,6.0,Cash,,2023-06-10
+TXN_1872692,Salad,5,5.0,25.0,Cash,In-store,2023-08-09
+TXN_1372492,Salad,4,5.0,20.0,Cash,Takeaway,2023-03-28
+TXN_6549132,Salad,5,,25.0,,,2023-12-05
+TXN_1003246,Juice,2,3.0,6.0,,,2023-02-15
+TXN_5732615,Coffee,ERROR,2.0,4.0,Cash,Takeaway,2023-12-05
+TXN_3197621,Sandwich,5,4.0,20.0,,In-store,2023-02-10
+TXN_9006674,Tea,1,1.5,1.5,,Takeaway,
+TXN_6221348,Sandwich,1,ERROR,4.0,,,2023-03-28
+TXN_4986514,Tea,3,1.5,4.5,Credit Card,In-store,2023-06-06
+TXN_1050083,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-06-28
+TXN_5880567,Smoothie,5,4.0,20.0,ERROR,In-store,2023-02-13
+TXN_1068317,Juice,3,3.0,ERROR,Digital Wallet,Takeaway,2023-03-16
+TXN_7389329,Coffee,4,2.0,8.0,,,2023-01-18
+TXN_3951460,,4,4.0,16.0,,Takeaway,2023-04-21
+TXN_6584150,Juice,5,3.0,15.0,Credit Card,,2023-10-27
+TXN_7754428,Cookie,2,1.0,2.0,,In-store,2023-07-27
+TXN_3918515,UNKNOWN,4,5.0,20.0,Credit Card,Takeaway,2023-03-29
+TXN_6484387,Cookie,5,,5.0,Cash,,2023-11-23
+TXN_4156369,Cake,5,3.0,15.0,,In-store,2023-08-07
+TXN_4483226,Juice,1,3.0,3.0,Credit Card,,2023-08-08
+TXN_6457997,UNKNOWN,1,ERROR,4.0,Credit Card,,2023-12-12
+TXN_2553269,ERROR,5,1.0,5.0,Digital Wallet,,2023-04-09
+TXN_5297692,Juice,5,3.0,15.0,Credit Card,,2023-03-21
+TXN_8241724,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-05-14
+TXN_4916936,Smoothie,1,4.0,4.0,,Takeaway,2023-06-04
+TXN_1425215,Juice,1,3.0,3.0,Cash,Takeaway,2023-03-13
+TXN_4222908,Cookie,ERROR,1.0,1.0,,In-store,2023-12-14
+TXN_3938018,Coffee,ERROR,2.0,8.0,,Takeaway,2023-10-10
+TXN_2363378,Coffee,5,2.0,10.0,Cash,Takeaway,2023-04-23
+TXN_8267616,Tea,4,1.5,6.0,Cash,,2023-03-01
+TXN_4786680,ERROR,3,4.0,12.0,UNKNOWN,In-store,2023-02-05
+TXN_6437181,ERROR,4,3.0,12.0,Credit Card,,2023-04-10
+TXN_2335312,UNKNOWN,2,3.0,6.0,Digital Wallet,,2023-06-23
+TXN_8999576,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-04-09
+TXN_4844022,ERROR,1,1.0,1.0,,Takeaway,2023-02-26
+TXN_5513984,Tea,1,1.5,1.5,Credit Card,In-store,2023-09-13
+TXN_1662024,UNKNOWN,4,1.0,4.0,,In-store,2023-01-16
+TXN_5600914,Smoothie,4,4.0,16.0,Credit Card,,2023-02-16
+TXN_9923860,Cookie,2,1.0,2.0,,,2023-11-16
+TXN_5346493,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-04-08
+TXN_3528599,Cookie,1,1.0,1.0,,,2023-12-09
+TXN_5738521,Coffee,5,2.0,10.0,Digital Wallet,,2023-03-14
+TXN_6219634,Salad,1,5.0,5.0,Cash,Takeaway,2023-09-11
+TXN_3539062,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-10-04
+TXN_8782513,Sandwich,5,4.0,20.0,,Takeaway,2023-10-15
+TXN_2252218,UNKNOWN,4,5.0,20.0,Cash,,
+TXN_2851804,Coffee,3,2.0,6.0,,,2023-11-30
+TXN_9175519,Cake,4,3.0,12.0,,ERROR,2023-10-05
+TXN_6224451,Sandwich,1,4.0,ERROR,Credit Card,UNKNOWN,2023-03-19
+TXN_3174488,UNKNOWN,4,1.0,4.0,Cash,Takeaway,2023-06-28
+TXN_7630912,Juice,2,ERROR,6.0,Credit Card,,2023-01-04
+TXN_5650608,Juice,UNKNOWN,3.0,3.0,Digital Wallet,,2023-06-25
+TXN_2134911,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-10-07
+TXN_4013761,Coffee,3,2.0,6.0,UNKNOWN,,2023-09-07
+TXN_9257475,UNKNOWN,4,3.0,12.0,Digital Wallet,,2023-07-06
+TXN_6616311,Coffee,4,2.0,8.0,ERROR,,2023-09-01
+TXN_9123562,Juice,5,3.0,15.0,Credit Card,Takeaway,UNKNOWN
+TXN_6991430,Cookie,5,1.0,5.0,Cash,In-store,2023-05-31
+TXN_6778974,Smoothie,2,4.0,8.0,,,2023-09-07
+TXN_1818438,Coffee,5,2.0,10.0,Cash,,2023-06-18
+TXN_5486886,Smoothie,1,4.0,4.0,,,2023-12-23
+TXN_5470598,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-03-14
+TXN_3186333,Cookie,5,1.0,5.0,Cash,In-store,2023-08-19
+TXN_8748633,Sandwich,5,ERROR,20.0,Cash,Takeaway,2023-04-27
+TXN_3228558,Sandwich,2,4.0,8.0,Credit Card,,2023-12-13
+TXN_6388107,,3,3.0,9.0,Digital Wallet,In-store,2023-12-04
+TXN_6506895,Cake,5,3.0,15.0,Credit Card,In-store,2023-08-10
+TXN_2917211,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-11-19
+TXN_5882566,Cake,1,3.0,3.0,,Takeaway,2023-07-09
+TXN_2413548,Tea,2,1.5,3.0,Credit Card,,2023-08-12
+TXN_6633097,Juice,4,3.0,12.0,Credit Card,In-store,UNKNOWN
+TXN_7116936,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-05-19
+TXN_7991322,Coffee,5,2.0,10.0,Digital Wallet,,2023-11-14
+TXN_1914728,,5,1.0,5.0,Cash,In-store,2023-06-16
+TXN_4209748,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-10-24
+TXN_8941438,Juice,4,3.0,12.0,Digital Wallet,,2023-07-23
+TXN_7932127,Coffee,3,2.0,UNKNOWN,,,2023-07-29
+TXN_7097699,Tea,4,1.5,6.0,,Takeaway,2023-12-16
+TXN_7054849,Cake,4,3.0,12.0,Cash,Takeaway,2023-06-16
+TXN_7185724,Cake,4,3.0,12.0,ERROR,Takeaway,2023-05-06
+TXN_5664982,Tea,5,1.5,,Digital Wallet,In-store,2023-12-24
+TXN_9378562,Juice,3,3.0,9.0,,,2023-09-06
+TXN_2892693,Cookie,4,1.0,4.0,Credit Card,In-store,2023-03-02
+TXN_2265603,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,
+TXN_6552269,UNKNOWN,4,3.0,12.0,Cash,Takeaway,2023-04-29
+TXN_4639918,Sandwich,1,4.0,4.0,Digital Wallet,ERROR,2023-11-05
+TXN_6037144,Tea,3,1.5,4.5,Cash,Takeaway,2023-09-02
+TXN_3494014,Cake,1,3.0,3.0,Credit Card,In-store,2023-06-09
+TXN_3656884,Coffee,5,2.0,10.0,Credit Card,,2023-10-08
+TXN_2277013,Smoothie,3,4.0,12.0,,,2023-07-26
+TXN_5423636,Sandwich,4,4.0,16.0,Cash,UNKNOWN,2023-10-18
+TXN_8040251,Coffee,1,2.0,2.0,Digital Wallet,,2023-04-16
+TXN_1635137,Cake,2,3.0,6.0,Cash,,2023-12-28
+TXN_8411549,Tea,4,,6.0,Credit Card,In-store,2023-02-15
+TXN_3747376,UNKNOWN,2,1.0,2.0,Digital Wallet,Takeaway,2023-11-03
+TXN_1503903,Tea,1,1.5,1.5,Cash,Takeaway,2023-03-20
+TXN_8606152,Smoothie,5,4.0,20.0,Credit Card,,2023-08-05
+TXN_1260517,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-04-17
+TXN_6898368,Smoothie,3,4.0,12.0,Digital Wallet,,2023-05-01
+TXN_2224251,Juice,4,3.0,,Digital Wallet,Takeaway,2023-04-14
+TXN_4567429,Tea,3,1.5,4.5,Cash,,2023-10-11
+TXN_8622404,Cookie,3,1.0,UNKNOWN,,,2023-09-21
+TXN_1152249,Smoothie,3,4.0,ERROR,,In-store,2023-05-09
+TXN_2989533,Salad,5,5.0,25.0,,Takeaway,2023-01-30
+TXN_3734446,,5,2.0,10.0,Digital Wallet,,2023-04-16
+TXN_9517380,Tea,4,UNKNOWN,6.0,Cash,,2023-10-29
+TXN_3599216,ERROR,ERROR,1.5,1.5,Cash,In-store,2023-09-21
+TXN_1363508,Salad,4,5.0,20.0,Cash,,2023-08-08
+TXN_7969017,Tea,3,1.5,4.5,Digital Wallet,,2023-02-17
+TXN_6987705,Cookie,5,1.0,5.0,Cash,,2023-06-04
+TXN_8490157,Salad,2,5.0,10.0,Credit Card,In-store,2023-09-06
+TXN_7878395,Salad,3,5.0,15.0,Credit Card,In-store,2023-05-26
+TXN_1672632,,3,5.0,15.0,Digital Wallet,,2023-07-04
+TXN_9216314,Cake,1,3.0,3.0,Credit Card,UNKNOWN,2023-03-07
+TXN_1647144,Salad,2,UNKNOWN,10.0,,Takeaway,2023-08-29
+TXN_4090464,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-01-16
+TXN_2172301,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-04-06
+TXN_3730077,Cookie,2,1.0,2.0,Credit Card,,2023-07-08
+TXN_8253046,Cake,1,3.0,3.0,ERROR,In-store,2023-12-20
+TXN_2901304,Cookie,3,1.0,3.0,,ERROR,2023-07-01
+TXN_6198799,Salad,1,ERROR,5.0,,,2023-05-27
+TXN_9910573,Salad,2,5.0,,,Takeaway,2023-01-28
+TXN_3680192,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-05-20
+TXN_9268974,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-10-29
+TXN_7435796,Coffee,2,2.0,4.0,Cash,In-store,2023-11-03
+TXN_1882390,Cookie,1,1.0,1.0,,Takeaway,2023-05-22
+TXN_2465074,Smoothie,1,4.0,UNKNOWN,Digital Wallet,,2023-09-29
+TXN_8038871,Juice,5,3.0,15.0,Digital Wallet,,2023-06-09
+TXN_1269172,Sandwich,1,4.0,4.0,Cash,,2023-08-22
+TXN_4564556,Coffee,3,2.0,6.0,Credit Card,,2023-11-21
+TXN_8139533,Smoothie,1,ERROR,4.0,Cash,In-store,2023-09-21
+TXN_1998401,,1,4.0,4.0,Cash,,2023-09-17
+TXN_9327493,UNKNOWN,1,2.0,2.0,,UNKNOWN,2023-03-27
+TXN_7349319,Cookie,3,1.0,3.0,Digital Wallet,,2023-03-10
+TXN_7294526,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-12-02
+TXN_5618976,Coffee,2,2.0,4.0,Cash,Takeaway,2023-12-05
+TXN_3964398,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-10-20
+TXN_4372163,Sandwich,1,4.0,4.0,,,2023-03-10
+TXN_7242133,Coffee,3,2.0,6.0,,UNKNOWN,2023-05-20
+TXN_7083168,Cookie,4,1.0,4.0,,Takeaway,2023-06-01
+TXN_5107006,UNKNOWN,4,1.0,4.0,,,2023-04-18
+TXN_1210183,Tea,3,1.5,4.5,ERROR,In-store,2023-01-23
+TXN_3419352,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-10-22
+TXN_1900036,Cookie,1,1.0,1.0,UNKNOWN,,2023-12-20
+TXN_7497565,Cookie,4,1.0,4.0,,Takeaway,2023-10-07
+TXN_6851735,UNKNOWN,1,1.0,1.0,Digital Wallet,,2023-01-17
+TXN_6716918,Coffee,2,2.0,4.0,,,2023-04-10
+TXN_6654975,Salad,3,5.0,15.0,,In-store,2023-08-11
+TXN_9184804,Cookie,2,UNKNOWN,2.0,Digital Wallet,,2023-11-08
+TXN_9100063,Sandwich,2,4.0,8.0,,In-store,2023-09-16
+TXN_6202631,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-07-29
+TXN_1868447,Tea,3,1.5,4.5,Cash,ERROR,2023-09-30
+TXN_4726531,Salad,5,5.0,25.0,Cash,Takeaway,2023-09-09
+TXN_8640655,Coffee,3,2.0,6.0,,UNKNOWN,2023-12-27
+TXN_8377812,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-03-27
+TXN_2603561,Coffee,3,2.0,6.0,Digital Wallet,,2023-04-25
+TXN_9822173,Cake,5,3.0,15.0,Digital Wallet,,2023-05-22
+TXN_2163150,Salad,1,5.0,5.0,Cash,In-store,2023-08-25
+TXN_2371464,Smoothie,4,4.0,16.0,Cash,In-store,2023-09-20
+TXN_3389521,Salad,5,ERROR,25.0,Digital Wallet,,2023-02-10
+TXN_8916290,Salad,5,5.0,25.0,Digital Wallet,,2023-07-08
+TXN_6130281,ERROR,2,4.0,8.0,Cash,,2023-01-18
+TXN_2505416,Cookie,UNKNOWN,1.0,2.0,ERROR,UNKNOWN,2023-05-18
+TXN_8275626,Coffee,2,2.0,4.0,,Takeaway,2023-09-10
+TXN_9803409,Cookie,4,1.0,4.0,,In-store,2023-01-24
+TXN_3094597,Sandwich,4,4.0,16.0,,,2023-03-11
+TXN_5276842,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-06-26
+TXN_1367003,Salad,5,5.0,25.0,Cash,In-store,2023-11-10
+TXN_1752992,UNKNOWN,3,2.0,6.0,,,2023-12-12
+TXN_5716276,UNKNOWN,4,1.5,6.0,Digital Wallet,,2023-09-12
+TXN_5696844,Cookie,2,1.0,2.0,,In-store,2023-01-29
+TXN_5672156,Cookie,2,,2.0,Credit Card,In-store,2023-07-05
+TXN_6480646,ERROR,2,1.5,3.0,,Takeaway,2023-10-28
+TXN_1603051,ERROR,4,1.0,4.0,Credit Card,Takeaway,2023-03-21
+TXN_6293225,Cake,4,3.0,12.0,Cash,UNKNOWN,2023-07-02
+TXN_6567880,Sandwich,5,UNKNOWN,20.0,Credit Card,,2023-08-15
+TXN_6355620,Cookie,1,UNKNOWN,1.0,Cash,,2023-06-18
+TXN_3466686,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-09-03
+TXN_6064301,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-07-12
+TXN_5005674,Salad,4,5.0,20.0,Credit Card,In-store,2023-10-03
+TXN_1714471,Juice,4,3.0,12.0,Cash,Takeaway,2023-08-17
+TXN_5420062,UNKNOWN,4,5.0,20.0,Cash,In-store,2023-06-06
+TXN_6377813,Salad,2,5.0,10.0,Credit Card,,2023-08-07
+TXN_3271393,Smoothie,4,4.0,16.0,Cash,In-store,
+TXN_2857444,Smoothie,1,ERROR,ERROR,Cash,Takeaway,2023-05-10
+TXN_1064565,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-03-14
+TXN_1784150,UNKNOWN,3,1.0,,,,2023-03-10
+TXN_9104545,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-03-19
+TXN_2108125,Coffee,1,2.0,2.0,Credit Card,In-store,2023-10-06
+TXN_7795324,Salad,2,5.0,10.0,,,2023-06-28
+TXN_1203191,Coffee,5,2.0,10.0,ERROR,In-store,2023-10-12
+TXN_8743849,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-05-04
+TXN_8588231,Cake,4,3.0,12.0,,Takeaway,2023-09-02
+TXN_6324818,Salad,5,5.0,25.0,,,2023-06-26
+TXN_4536827,Cookie,3,,3.0,Digital Wallet,Takeaway,2023-10-14
+TXN_6226704,,4,2.0,8.0,Digital Wallet,In-store,2023-09-07
+TXN_2693108,Cookie,3,1.0,ERROR,Cash,In-store,2023-11-18
+TXN_6234070,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-01-31
+TXN_9816901,Coffee,2,2.0,4.0,Cash,ERROR,2023-12-07
+TXN_9489495,Coffee,1,2.0,2.0,Credit Card,,2023-05-20
+TXN_7637178,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-05-26
+TXN_1281536,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-03-19
+TXN_2591969,Salad,ERROR,5.0,20.0,Credit Card,In-store,ERROR
+TXN_8736069,Tea,5,1.5,7.5,Cash,Takeaway,2023-07-06
+TXN_7975336,Tea,5,1.5,UNKNOWN,Credit Card,Takeaway,2023-12-03
+TXN_9278090,Cake,5,3.0,15.0,Credit Card,,2023-12-28
+TXN_8939048,Cookie,3,1.0,3.0,Digital Wallet,,
+TXN_1193809,Tea,3,1.5,4.5,Digital Wallet,,2023-01-21
+TXN_9281710,Juice,3,3.0,9.0,Credit Card,In-store,2023-08-05
+TXN_3784001,Sandwich,1,4.0,4.0,,Takeaway,
+TXN_3291149,Coffee,5,2.0,10.0,,,2023-12-09
+TXN_3596270,Coffee,UNKNOWN,2.0,8.0,Credit Card,Takeaway,2023-05-05
+TXN_8172182,Cake,2,3.0,6.0,,,2023-06-22
+TXN_3902135,Tea,4,1.5,6.0,Credit Card,ERROR,2023-06-20
+TXN_9007414,Cake,3,3.0,9.0,Cash,,2023-12-08
+TXN_9131337,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-05-24
+TXN_2278015,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-04-10
+TXN_1077060,Coffee,3,2.0,6.0,,Takeaway,2023-08-22
+TXN_9362728,Sandwich,1,4.0,4.0,,In-store,2023-12-26
+TXN_6471185,Juice,UNKNOWN,3.0,15.0,,In-store,2023-03-17
+TXN_5677927,UNKNOWN,5,5.0,25.0,Digital Wallet,,2023-12-20
+TXN_6177081,Cookie,ERROR,UNKNOWN,1.0,Cash,ERROR,2023-07-26
+TXN_9281586,Sandwich,5,4.0,20.0,,ERROR,2023-05-20
+TXN_8721484,ERROR,4,2.0,8.0,,UNKNOWN,2023-04-03
+TXN_9350427,Juice,5,3.0,15.0,,,2023-01-24
+TXN_7860054,Tea,5,1.5,7.5,Credit Card,In-store,2023-02-07
+TXN_9233730,Tea,5,1.5,7.5,Credit Card,,2023-05-28
+TXN_8304399,Tea,2,1.5,3.0,Cash,In-store,2023-06-08
+TXN_1538515,Juice,4,3.0,12.0,Cash,,2023-06-11
+TXN_9774251,,2,3.0,6.0,Digital Wallet,Takeaway,2023-06-16
+TXN_4565233,Salad,3,5.0,15.0,Credit Card,In-store,2023-11-16
+TXN_6898341,Tea,2,1.5,3.0,Credit Card,In-store,2023-08-21
+TXN_1016246,Coffee,1,2.0,2.0,ERROR,,2023-01-19
+TXN_9160109,Cake,1,3.0,3.0,Credit Card,,2023-08-03
+TXN_1082012,Smoothie,5,4.0,20.0,Credit Card,,2023-01-04
+TXN_8325464,UNKNOWN,5,4.0,20.0,Credit Card,Takeaway,2023-08-02
+TXN_7322436,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-06-29
+TXN_1733916,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-01-12
+TXN_6068564,Cake,4,3.0,,Credit Card,Takeaway,2023-09-28
+TXN_7023753,Coffee,ERROR,2.0,10.0,Credit Card,Takeaway,2023-05-16
+TXN_4507630,Smoothie,2,4.0,8.0,UNKNOWN,Takeaway,2023-05-11
+TXN_5037728,Smoothie,UNKNOWN,4.0,12.0,Credit Card,ERROR,2023-08-18
+TXN_4577234,UNKNOWN,4,3.0,12.0,UNKNOWN,In-store,2023-06-09
+TXN_6309570,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-09-26
+TXN_7587652,UNKNOWN,1,3.0,3.0,Cash,,2023-08-23
+TXN_1118799,ERROR,4,4.0,,Credit Card,Takeaway,2023-09-19
+TXN_5738282,Cake,4,3.0,12.0,Credit Card,In-store,UNKNOWN
+TXN_8192063,Juice,4,3.0,12.0,Cash,,2023-02-06
+TXN_2687593,UNKNOWN,5,3.0,15.0,,Takeaway,2023-06-27
+TXN_1603563,Cake,4,3.0,12.0,,Takeaway,2023-04-13
+TXN_6346483,Coffee,1,2.0,2.0,Credit Card,,2023-06-08
+TXN_3499910,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-09-29
+TXN_8616276,UNKNOWN,2,UNKNOWN,3.0,Digital Wallet,Takeaway,2023-07-22
+TXN_5941840,Cookie,4,1.0,4.0,,,2023-04-01
+TXN_6249023,Juice,1,3.0,3.0,Credit Card,,2023-11-03
+TXN_8620426,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-11-28
+TXN_2037742,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-11-14
+TXN_7013527,Salad,2,5.0,10.0,Credit Card,In-store,2023-05-18
+TXN_2798420,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-03-17
+TXN_6500126,Smoothie,2,UNKNOWN,UNKNOWN,,UNKNOWN,
+TXN_8106064,Cookie,UNKNOWN,1.0,1.0,,,2023-06-17
+TXN_5483442,Tea,UNKNOWN,1.5,7.5,Cash,,2023-04-03
+TXN_3926570,Coffee,3,2.0,6.0,,UNKNOWN,2023-09-04
+TXN_9489442,,3,2.0,6.0,Credit Card,Takeaway,2023-02-06
+TXN_5506907,Cookie,2,1.0,2.0,Cash,Takeaway,2023-12-08
+TXN_8155325,,5,2.0,10.0,Digital Wallet,In-store,2023-11-27
+TXN_5353468,Tea,2,1.5,3.0,Credit Card,In-store,2023-11-30
+TXN_2111293,Smoothie,3,4.0,12.0,,Takeaway,2023-05-29
+TXN_2101632,Sandwich,4,4.0,16.0,,Takeaway,2023-06-12
+TXN_3355537,Tea,3,1.5,4.5,Digital Wallet,ERROR,2023-01-09
+TXN_4594866,Cookie,1,1.0,1.0,Digital Wallet,ERROR,2023-03-24
+TXN_7485712,Sandwich,4,4.0,16.0,Cash,In-store,2023-04-15
+TXN_4848431,Salad,5,5.0,25.0,Credit Card,,2023-01-09
+TXN_7352058,Coffee,2,2.0,4.0,UNKNOWN,Takeaway,2023-08-24
+TXN_3442244,Cake,4,3.0,12.0,,Takeaway,2023-05-13
+TXN_9810868,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-10-05
+TXN_1430778,,1,1.5,1.5,Credit Card,Takeaway,2023-05-26
+TXN_4837909,Cake,5,3.0,15.0,,Takeaway,2023-11-19
+TXN_4722816,Salad,4,5.0,20.0,Cash,In-store,2023-10-19
+TXN_1833012,Salad,3,5.0,15.0,Digital Wallet,,2023-08-16
+TXN_6933222,Tea,1,1.5,1.5,Cash,,2023-01-22
+TXN_7737862,Cookie,2,1.0,2.0,Credit Card,,2023-08-29
+TXN_7814690,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-05-10
+TXN_8880299,UNKNOWN,1,1.5,1.5,UNKNOWN,,2023-11-16
+TXN_6083650,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-07-01
+TXN_8342990,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-04-23
+TXN_4407959,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-01-28
+TXN_4382970,Tea,,1.5,1.5,,In-store,2023-06-04
+TXN_3422759,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-02-19
+TXN_1074435,Coffee,1,2.0,2.0,,In-store,2023-11-25
+TXN_8164332,Tea,4,1.5,6.0,Cash,Takeaway,2023-04-22
+TXN_1912525,ERROR,4,4.0,16.0,Cash,Takeaway,2023-11-25
+TXN_9715885,Smoothie,4,4.0,16.0,UNKNOWN,In-store,2023-06-16
+TXN_1583983,Tea,3,1.5,4.5,Credit Card,,2023-03-02
+TXN_3634860,Juice,5,3.0,15.0,Credit Card,,2023-05-28
+TXN_5732357,Tea,5,1.5,7.5,Credit Card,,2023-05-06
+TXN_2379052,UNKNOWN,1,5.0,5.0,,,2023-02-16
+TXN_7502273,UNKNOWN,5,2.0,10.0,UNKNOWN,In-store,2023-11-14
+TXN_2567222,Coffee,3,2.0,6.0,UNKNOWN,Takeaway,2023-09-09
+TXN_3166181,Cookie,3,1.0,3.0,Credit Card,In-store,2023-05-21
+TXN_5644074,Sandwich,2,,8.0,Digital Wallet,In-store,2023-11-08
+TXN_5173881,Cookie,3,1.0,3.0,Cash,Takeaway,2023-01-29
+TXN_2396923,Cookie,1,ERROR,1.0,Digital Wallet,,2023-11-02
+TXN_7249235,ERROR,3,4.0,12.0,Cash,ERROR,2023-05-27
+TXN_9612877,Smoothie,1,4.0,4.0,Cash,In-store,2023-03-07
+TXN_4841285,Tea,2,1.5,3.0,Credit Card,UNKNOWN,2023-05-04
+TXN_1263426,Sandwich,2,UNKNOWN,8.0,,UNKNOWN,2023-10-20
+TXN_5293518,Sandwich,3,,12.0,,In-store,2023-07-16
+TXN_4296204,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-11-28
+TXN_7180164,Sandwich,ERROR,4.0,20.0,Cash,Takeaway,2023-01-05
+TXN_6478978,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-10-27
+TXN_2030107,Juice,4,3.0,12.0,,Takeaway,2023-01-03
+TXN_4897182,Cake,3,3.0,9.0,Cash,Takeaway,2023-11-26
+TXN_4612269,Salad,5,,25.0,,ERROR,2023-01-09
+TXN_7630750,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-03-16
+TXN_6380978,Tea,1,1.5,1.5,Cash,,2023-12-31
+TXN_3744974,UNKNOWN,1,3.0,3.0,,In-store,2023-01-09
+TXN_7551023,Salad,5,5.0,25.0,Cash,,2023-10-06
+TXN_2629168,Juice,1,3.0,3.0,Credit Card,,
+TXN_6416741,Coffee,ERROR,2.0,8.0,Cash,,2023-12-03
+TXN_1269252,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-18
+TXN_2377708,Cookie,1,1.0,1.0,,Takeaway,2023-01-03
+TXN_3193212,Cake,1,3.0,3.0,Cash,In-store,2023-11-23
+TXN_1427963,Coffee,1,2.0,2.0,Cash,,2023-10-14
+TXN_3391446,Tea,1,1.5,1.5,,Takeaway,2023-01-14
+TXN_4849180,UNKNOWN,5,,15.0,Credit Card,In-store,2023-10-14
+TXN_2370338,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-10-30
+TXN_8628848,Juice,1,3.0,3.0,Credit Card,In-store,2023-01-29
+TXN_4294955,Salad,5,5.0,25.0,UNKNOWN,UNKNOWN,2023-10-19
+TXN_6894703,Cookie,1,1.0,1.0,Digital Wallet,,2023-06-06
+TXN_9926931,Cookie,5,1.0,,,Takeaway,2023-01-26
+TXN_9681369,Salad,5,5.0,25.0,,,2023-10-23
+TXN_9246948,Cake,5,3.0,15.0,Credit Card,,2023-11-11
+TXN_8519330,Cookie,4,1.0,4.0,,,2023-03-18
+TXN_1720329,Cookie,2,1.0,UNKNOWN,Cash,,2023-04-06
+TXN_9859715,Smoothie,5,4.0,20.0,,,2023-07-11
+TXN_2805332,Cake,4,3.0,12.0,Cash,,2023-08-10
+TXN_4807265,Sandwich,3,4.0,12.0,Digital Wallet,ERROR,2023-11-19
+TXN_5275315,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-01-19
+TXN_7423281,Juice,1,3.0,3.0,Digital Wallet,,2023-06-01
+TXN_9764251,Cookie,4,1.0,4.0,ERROR,Takeaway,2023-06-18
+TXN_1034956,Sandwich,4,4.0,16.0,Cash,In-store,ERROR
+TXN_9272043,Cake,4,3.0,12.0,,,2023-04-20
+TXN_5591048,UNKNOWN,3,2.0,6.0,,In-store,2023-01-15
+TXN_4455667,Sandwich,2,4.0,8.0,Credit Card,,2023-08-13
+TXN_9945729,,2,5.0,10.0,Digital Wallet,,2023-02-03
+TXN_8124663,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-10-15
+TXN_1769466,UNKNOWN,5,2.0,10.0,Digital Wallet,Takeaway,2023-08-01
+TXN_3209184,Salad,ERROR,5.0,20.0,Cash,Takeaway,2023-03-19
+TXN_6717074,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-06-12
+TXN_2833327,UNKNOWN,3,2.0,6.0,Cash,,2023-07-05
+TXN_3856021,Salad,1,5.0,5.0,Credit Card,,2023-02-24
+TXN_2902289,Tea,5,1.5,7.5,Credit Card,In-store,2023-12-16
+TXN_9456575,Tea,5,1.5,7.5,Cash,,2023-06-10
+TXN_9231214,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-05-24
+TXN_6935106,Tea,5,1.5,7.5,,In-store,UNKNOWN
+TXN_2005789,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-03-13
+TXN_4814965,Salad,2,5.0,10.0,Digital Wallet,,2023-07-23
+TXN_5656252,Sandwich,4,4.0,16.0,,Takeaway,2023-08-04
+TXN_6739950,Salad,ERROR,5.0,20.0,Credit Card,In-store,2023-03-04
+TXN_1165762,,3,2.0,6.0,Credit Card,,2023-10-22
+TXN_1122700,Salad,5,5.0,ERROR,Digital Wallet,In-store,2023-11-09
+TXN_6441337,Coffee,5,2.0,10.0,ERROR,Takeaway,2023-02-22
+TXN_9134335,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-01-30
+TXN_7278970,Salad,2,5.0,10.0,,In-store,2023-08-15
+TXN_7376255,UNKNOWN,UNKNOWN,UNKNOWN,25.0,,In-store,2023-05-27
+TXN_1075969,Cookie,2,1.0,2.0,Digital Wallet,ERROR,2023-08-13
+TXN_1972843,Coffee,2,2.0,4.0,ERROR,ERROR,2023-02-20
+TXN_9546951,Sandwich,4,4.0,16.0,,,2023-12-14
+TXN_2336946,Sandwich,4,4.0,16.0,,,2023-05-29
+TXN_4219548,Coffee,5,2.0,10.0,,Takeaway,2023-07-24
+TXN_5799196,Sandwich,3,4.0,12.0,Digital Wallet,,2023-12-03
+TXN_3337203,Smoothie,3,4.0,12.0,,Takeaway,2023-11-16
+TXN_4561006,Juice,3,3.0,9.0,Credit Card,,2023-11-23
+TXN_6652858,Salad,5,5.0,25.0,Credit Card,In-store,2023-09-13
+TXN_5932892,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-11-19
+TXN_7466586,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-04-02
+TXN_4207981,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-03-17
+TXN_2771482,Salad,4,5.0,20.0,Credit Card,,2023-02-03
+TXN_9450903,Smoothie,3,4.0,12.0,Digital Wallet,,2023-04-07
+TXN_1165779,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-06-30
+TXN_8205635,Cake,5,3.0,15.0,Credit Card,ERROR,
+TXN_1984966,,2,1.5,3.0,Credit Card,Takeaway,2023-03-31
+TXN_4607933,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-09-22
+TXN_3486178,Cake,5,3.0,15.0,Cash,,2023-06-09
+TXN_2324227,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-06-07
+TXN_2452819,Cookie,3,1.0,3.0,Credit Card,In-store,2023-07-31
+TXN_2342256,Tea,3,1.5,4.5,,,
+TXN_4789193,Juice,3,3.0,9.0,,,2023-02-21
+TXN_5743519,Smoothie,2,4.0,,Cash,,2023-05-23
+TXN_1783857,Coffee,2,UNKNOWN,4.0,Digital Wallet,In-store,2023-11-29
+TXN_6269540,ERROR,ERROR,4.0,12.0,,,2023-12-06
+TXN_8106538,Coffee,3,UNKNOWN,6.0,Digital Wallet,,2023-07-09
+TXN_6732494,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-03-18
+TXN_3828620,ERROR,1,5.0,5.0,,In-store,2023-10-15
+TXN_9958548,Tea,4,1.5,6.0,,In-store,UNKNOWN
+TXN_5458161,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-07-19
+TXN_1518379,Juice,4,3.0,12.0,,In-store,2023-08-12
+TXN_9097840,Tea,3,1.5,4.5,Credit Card,,2023-02-06
+TXN_5747094,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-05-11
+TXN_9782087,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-07-27
+TXN_5824950,Coffee,1,2.0,2.0,Credit Card,In-store,2023-12-06
+TXN_6682782,Cookie,5,1.0,5.0,Cash,In-store,2023-12-15
+TXN_2468359,,2,5.0,10.0,,,2023-07-20
+TXN_1902038,UNKNOWN,4,2.0,8.0,Credit Card,Takeaway,2023-04-07
+TXN_9405019,Cake,5,3.0,15.0,,,
+TXN_7210366,Cake,2,3.0,6.0,Digital Wallet,UNKNOWN,2023-03-25
+TXN_6327785,ERROR,3,1.5,4.5,Credit Card,,2023-11-20
+TXN_3206293,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-05-04
+TXN_5827969,Salad,5,5.0,25.0,Digital Wallet,,2023-07-03
+TXN_6999471,,1,3.0,3.0,,,2023-08-07
+TXN_2859077,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-01-31
+TXN_3643361,Tea,1,1.5,,Cash,,2023-01-12
+TXN_8066306,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-01-07
+TXN_2260351,Coffee,3,2.0,6.0,Cash,,2023-10-26
+TXN_5224275,Cookie,4,1.0,4.0,Credit Card,In-store,2023-12-17
+TXN_3842567,Salad,1,5.0,5.0,Credit Card,In-store,2023-03-13
+TXN_8515063,UNKNOWN,3,1.0,3.0,,Takeaway,2023-12-06
+TXN_2188137,UNKNOWN,1,1.5,1.5,Credit Card,UNKNOWN,2023-01-15
+TXN_3104589,ERROR,2,1.0,2.0,Cash,Takeaway,2023-03-01
+TXN_9638367,Coffee,1,2.0,2.0,UNKNOWN,,2023-07-22
+TXN_8742742,Cake,4,3.0,12.0,,UNKNOWN,2023-03-07
+TXN_5687012,Salad,2,5.0,10.0,Cash,,2023-03-12
+TXN_5784372,Salad,2,ERROR,10.0,Cash,,2023-05-23
+TXN_2737300,Cake,ERROR,3.0,3.0,,In-store,2023-12-25
+TXN_5905025,Cookie,4,1.0,4.0,,Takeaway,2023-03-08
+TXN_6602557,Cake,4,3.0,12.0,Cash,Takeaway,2023-02-06
+TXN_8065180,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-06-07
+TXN_4448424,Salad,4,,20.0,Digital Wallet,,2023-01-31
+TXN_3396099,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-04-06
+TXN_2693431,Salad,2,5.0,10.0,Digital Wallet,,2023-05-20
+TXN_7767493,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-02-20
+TXN_2954575,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-11-14
+TXN_8983868,UNKNOWN,5,2.0,10.0,Credit Card,,2023-03-10
+TXN_3540841,ERROR,,1.5,4.5,Credit Card,In-store,2023-03-22
+TXN_8933027,Juice,5,3.0,15.0,Credit Card,,2023-07-14
+TXN_5763287,Cake,2,,6.0,Credit Card,,2023-06-27
+TXN_7272945,Smoothie,4,4.0,16.0,,Takeaway,2023-04-13
+TXN_8511110,Tea,3,1.5,4.5,,,2023-10-17
+TXN_9307650,Coffee,3,2.0,6.0,UNKNOWN,Takeaway,2023-02-22
+TXN_1812185,Juice,2,3.0,6.0,Digital Wallet,,2023-09-21
+TXN_2134650,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-02-11
+TXN_7899761,Juice,2,3.0,6.0,UNKNOWN,In-store,2023-10-08
+TXN_6785552,Juice,5,3.0,15.0,Cash,,2023-01-19
+TXN_8794205,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-10-22
+TXN_2464879,Cake,2,3.0,6.0,Credit Card,,2023-10-11
+TXN_8294790,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-09-01
+TXN_4207219,Cake,1,3.0,3.0,Cash,In-store,2023-09-16
+TXN_1921415,Cake,1,3.0,3.0,Cash,Takeaway,2023-11-03
+TXN_7122109,Coffee,5,2.0,10.0,,Takeaway,2023-05-19
+TXN_3601338,Cake,3,3.0,9.0,Credit Card,ERROR,2023-03-06
+TXN_7403839,Coffee,1,2.0,2.0,,,2023-12-23
+TXN_3709876,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-11-04
+TXN_6063689,Cookie,3,1.0,3.0,Cash,In-store,2023-02-01
+TXN_8126762,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-06-08
+TXN_5940531,Tea,1,1.5,1.5,,In-store,2023-01-11
+TXN_9844453,Tea,2,1.5,3.0,,,2023-01-09
+TXN_5774784,Cake,5,3.0,15.0,,In-store,2023-10-04
+TXN_6241682,Sandwich,3,4.0,12.0,,In-store,2023-09-07
+TXN_1235828,Tea,4,1.5,6.0,Cash,Takeaway,2023-02-19
+TXN_9206403,Cookie,1,1.0,1.0,,In-store,2023-12-15
+TXN_8377178,Coffee,5,2.0,10.0,,,2023-02-03
+TXN_8125141,Tea,3,1.5,4.5,,Takeaway,2023-04-18
+TXN_9673343,,2,4.0,8.0,Cash,In-store,2023-06-22
+TXN_8734331,,3,1.5,4.5,,,2023-05-17
+TXN_9565246,Coffee,5,2.0,10.0,Cash,UNKNOWN,2023-12-28
+TXN_9914747,Coffee,5,2.0,10.0,,,2023-12-05
+TXN_6148776,Coffee,5,2.0,,,Takeaway,2023-03-02
+TXN_4992510,Cookie,4,1.0,4.0,Cash,In-store,2023-01-26
+TXN_8384806,Sandwich,3,UNKNOWN,12.0,,Takeaway,2023-07-07
+TXN_6472826,Juice,4,3.0,12.0,Cash,In-store,2023-04-11
+TXN_8131052,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-09-16
+TXN_8425819,Sandwich,1,4.0,4.0,,,2023-01-09
+TXN_8116619,Smoothie,3,4.0,12.0,Cash,In-store,UNKNOWN
+TXN_6636395,Juice,4,3.0,12.0,Cash,In-store,2023-01-30
+TXN_2137354,Coffee,2,2.0,4.0,,UNKNOWN,2023-05-17
+TXN_3353615,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-07-24
+TXN_2703095,Salad,1,5.0,5.0,,UNKNOWN,2023-10-05
+TXN_7282082,Sandwich,4,4.0,16.0,,In-store,2023-02-02
+TXN_6705109,Cake,3,3.0,9.0,Cash,In-store,2023-08-05
+TXN_1857902,Sandwich,5,4.0,20.0,ERROR,Takeaway,2023-04-26
+TXN_5788053,Sandwich,5,4.0,20.0,Digital Wallet,,2023-01-04
+TXN_8650185,Smoothie,5,4.0,20.0,Cash,,2023-06-13
+TXN_1171281,Coffee,2,2.0,4.0,Digital Wallet,,2023-02-06
+TXN_9875865,Cookie,3,1.0,,Digital Wallet,ERROR,2023-10-23
+TXN_6244602,Cake,5,3.0,15.0,Digital Wallet,,2023-05-06
+TXN_5093855,,4,ERROR,6.0,Cash,Takeaway,2023-11-23
+TXN_5588102,ERROR,4,1.0,4.0,Credit Card,In-store,2023-01-14
+TXN_7762815,Smoothie,5,4.0,20.0,Credit Card,,2023-07-26
+TXN_8421481,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-07-27
+TXN_3717307,Cookie,,1.0,1.0,Credit Card,In-store,2023-07-02
+TXN_6201227,Salad,2,5.0,10.0,Cash,Takeaway,2023-01-15
+TXN_9052231,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-08-20
+TXN_8228865,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-09-19
+TXN_5875188,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-07-09
+TXN_7997704,Sandwich,2,4.0,,Digital Wallet,,2023-04-28
+TXN_4409875,Cake,3,3.0,9.0,Digital Wallet,,2023-09-08
+TXN_4015427,Cookie,5,1.0,5.0,Credit Card,,2023-08-05
+TXN_3358787,Cake,1,3.0,3.0,Digital Wallet,,2023-06-10
+TXN_8557847,,4,4.0,16.0,,Takeaway,2023-09-02
+TXN_1307239,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-10-26
+TXN_5138519,Cake,5,3.0,15.0,Cash,In-store,2023-05-22
+TXN_8763436,Juice,4,3.0,12.0,Cash,,2023-04-11
+TXN_3067609,UNKNOWN,4,5.0,,Cash,,2023-12-25
+TXN_2450896,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,
+TXN_4052950,Salad,2,5.0,10.0,Credit Card,UNKNOWN,2023-03-13
+TXN_2207332,Coffee,1,2.0,2.0,Credit Card,,2023-01-12
+TXN_6633385,ERROR,2,3.0,6.0,Credit Card,Takeaway,2023-02-12
+TXN_8302551,Cake,4,3.0,12.0,,,
+TXN_6710660,Salad,2,5.0,10.0,Cash,In-store,2023-02-08
+TXN_9523369,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-08-25
+TXN_3548756,Juice,3,3.0,9.0,Digital Wallet,,2023-02-24
+TXN_9332035,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-02
+TXN_7539774,Salad,1,ERROR,5.0,,In-store,2023-02-12
+TXN_7846513,Sandwich,3,4.0,12.0,Credit Card,,2023-10-19
+TXN_6188931,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-01-28
+TXN_6707466,Salad,,5.0,10.0,Credit Card,,2023-04-02
+TXN_4076392,Coffee,3,2.0,6.0,,In-store,2023-12-24
+TXN_2365394,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-04-06
+TXN_7089466,Cookie,4,1.0,4.0,,,2023-12-26
+TXN_2898188,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-04-26
+TXN_1632205,Cookie,4,1.0,4.0,ERROR,In-store,2023-02-04
+TXN_3741197,Cake,4,3.0,12.0,Credit Card,,2023-10-13
+TXN_5300938,Tea,5,1.5,7.5,Cash,Takeaway,2023-10-30
+TXN_3547013,Tea,3,1.5,4.5,,UNKNOWN,2023-04-26
+TXN_7705748,Juice,3,3.0,9.0,Digital Wallet,,2023-07-14
+TXN_7469391,Coffee,5,2.0,10.0,Cash,In-store,UNKNOWN
+TXN_8073173,Tea,5,1.5,7.5,Cash,,2023-07-05
+TXN_1489746,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-12-18
+TXN_2864951,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-10-09
+TXN_6817889,Tea,1,1.5,1.5,,,2023-10-04
+TXN_7809825,UNKNOWN,2,4.0,8.0,Credit Card,,2023-08-26
+TXN_7402573,Sandwich,4,4.0,UNKNOWN,,Takeaway,2023-02-13
+TXN_4762520,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-07-17
+TXN_6869880,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-08-05
+TXN_3054405,Juice,3,3.0,9.0,Cash,In-store,2023-11-19
+TXN_2085992,Cake,1,3.0,3.0,,Takeaway,2023-05-15
+TXN_1443201,Cookie,5,1.0,5.0,Credit Card,In-store,2023-10-03
+TXN_9157460,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-01-23
+TXN_2299364,Salad,1,5.0,5.0,Cash,In-store,2023-10-26
+TXN_9948645,Salad,1,5.0,5.0,Credit Card,,2023-08-29
+TXN_8244640,Cookie,1,1.0,1.0,ERROR,Takeaway,2023-09-24
+TXN_9507568,Smoothie,4,4.0,16.0,Credit Card,,2023-10-12
+TXN_7952916,Coffee,4,2.0,8.0,,,2023-12-10
+TXN_1058927,Sandwich,4,4.0,16.0,Cash,,2023-07-08
+TXN_2165365,Coffee,5,,10.0,Digital Wallet,Takeaway,2023-06-08
+TXN_4497327,Cookie,2,1.0,2.0,Credit Card,UNKNOWN,2023-11-08
+TXN_3677890,Sandwich,UNKNOWN,4.0,12.0,Credit Card,In-store,2023-02-28
+TXN_6029333,Cake,1,3.0,3.0,,,2023-06-10
+TXN_9300970,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-03-06
+TXN_3931747,,4,1.0,4.0,,Takeaway,2023-01-14
+TXN_5747642,Salad,2,5.0,10.0,Cash,Takeaway,2023-07-26
+TXN_1505875,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-05-17
+TXN_5417192,Cookie,4,1.0,4.0,Cash,In-store,2023-06-23
+TXN_1522140,Cookie,4,1.0,4.0,Cash,,2023-05-28
+TXN_5357157,Juice,4,3.0,12.0,Credit Card,In-store,2023-05-21
+TXN_2000400,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-09-29
+TXN_5612022,Cookie,5,1.0,5.0,Digital Wallet,ERROR,2023-09-27
+TXN_3105489,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-03-14
+TXN_4509329,Tea,1,1.5,1.5,,Takeaway,2023-10-22
+TXN_1724815,UNKNOWN,,4.0,12.0,,In-store,2023-08-16
+TXN_2096922,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-12-11
+TXN_2563679,Salad,3,5.0,15.0,Digital Wallet,,2023-04-09
+TXN_2930503,Juice,3,3.0,9.0,,In-store,2023-06-18
+TXN_9265178,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-03-18
+TXN_7126770,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-11-09
+TXN_6348409,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-07-26
+TXN_3776109,UNKNOWN,1,5.0,5.0,,,2023-05-20
+TXN_2538739,Salad,2,5.0,10.0,,In-store,2023-07-29
+TXN_4159135,Coffee,3,2.0,6.0,,Takeaway,2023-02-09
+TXN_1454866,Sandwich,1,UNKNOWN,4.0,Digital Wallet,Takeaway,2023-12-13
+TXN_4654061,Sandwich,2,4.0,8.0,Credit Card,,2023-05-04
+TXN_8160791,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-10-24
+TXN_1647069,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-04-06
+TXN_8499005,ERROR,5,2.0,10.0,,,2023-10-26
+TXN_1512185,Coffee,4,2.0,8.0,Cash,Takeaway,2023-06-16
+TXN_8632653,Juice,2,3.0,6.0,ERROR,In-store,2023-12-24
+TXN_8744240,,4,4.0,16.0,Cash,,2023-06-19
+TXN_4190750,Juice,5,3.0,15.0,,Takeaway,2023-04-02
+TXN_9470260,Coffee,5,2.0,10.0,,In-store,2023-10-07
+TXN_6257213,Juice,5,3.0,15.0,Cash,,2023-12-12
+TXN_1004563,Tea,5,1.5,7.5,Credit Card,In-store,2023-10-28
+TXN_5352739,Sandwich,4,4.0,UNKNOWN,,,2023-07-31
+TXN_7387056,Juice,4,3.0,ERROR,Credit Card,,2023-10-24
+TXN_1927431,Cookie,1,1.0,1.0,Credit Card,In-store,2023-02-07
+TXN_3432433,Cookie,5,1.0,5.0,Cash,In-store,2023-02-19
+TXN_1130142,Cookie,1,1.0,1.0,Credit Card,In-store,2023-03-13
+TXN_6682443,Cake,4,3.0,12.0,Digital Wallet,,2023-09-03
+TXN_3279039,Cake,4,3.0,12.0,Credit Card,In-store,2023-06-26
+TXN_6119612,,3,3.0,ERROR,Cash,,2023-12-25
+TXN_1295824,Tea,1,1.5,1.5,Credit Card,,2023-08-01
+TXN_8305936,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-08-02
+TXN_9550664,Salad,2,ERROR,10.0,,,2023-06-29
+TXN_3808895,Salad,2,5.0,10.0,Cash,In-store,2023-07-13
+TXN_9843811,Juice,2,3.0,6.0,Credit Card,,2023-03-01
+TXN_6405258,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-08-10
+TXN_1224087,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-03-20
+TXN_7727118,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-11-04
+TXN_8456072,Smoothie,1,4.0,4.0,,In-store,2023-07-11
+TXN_8173006,Salad,3,5.0,15.0,,Takeaway,2023-12-21
+TXN_2769769,ERROR,5,5.0,25.0,Credit Card,In-store,2023-04-01
+TXN_8413949,Juice,1,3.0,3.0,Credit Card,In-store,2023-10-14
+TXN_7538763,Smoothie,1,4.0,,,Takeaway,2023-11-18
+TXN_6541110,Cookie,3,1.0,3.0,Cash,In-store,2023-12-30
+TXN_6264390,,2,4.0,8.0,Cash,,2023-06-29
+TXN_6814891,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-06-26
+TXN_9884180,Salad,1,5.0,5.0,Cash,Takeaway,2023-05-19
+TXN_6424202,Cookie,2,UNKNOWN,UNKNOWN,Credit Card,In-store,2023-11-20
+TXN_6775024,Coffee,2,2.0,4.0,Cash,In-store,2023-01-30
+TXN_8540553,Cake,1,3.0,3.0,,In-store,2023-07-13
+TXN_6501361,Salad,5,5.0,25.0,Cash,In-store,2023-01-17
+TXN_5671997,Juice,3,,9.0,,Takeaway,2023-09-03
+TXN_4283360,Coffee,2,2.0,4.0,Credit Card,In-store,2023-12-19
+TXN_3956393,Cookie,4,1.0,4.0,Credit Card,In-store,2023-01-14
+TXN_1971103,Juice,4,3.0,12.0,,,2023-08-22
+TXN_9576057,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-03-03
+TXN_1435035,Smoothie,1,4.0,4.0,,In-store,2023-12-31
+TXN_8111101,Sandwich,5,4.0,20.0,Cash,,2023-01-12
+TXN_8323012,Tea,3,1.5,4.5,Credit Card,,2023-12-17
+TXN_9415451,Cake,3,3.0,9.0,,Takeaway,2023-01-04
+TXN_7072883,Smoothie,1,4.0,4.0,Credit Card,,2023-10-05
+TXN_7455637,Juice,3,3.0,9.0,,Takeaway,2023-04-23
+TXN_3779292,Salad,2,5.0,10.0,Credit Card,In-store,2023-12-30
+TXN_2629420,Smoothie,2,4.0,8.0,,Takeaway,2023-01-16
+TXN_5848025,Tea,5,1.5,7.5,Credit Card,In-store,2023-01-19
+TXN_1452253,Sandwich,2,4.0,,,,2023-05-12
+TXN_4661976,Smoothie,3,4.0,12.0,Digital Wallet,,2023-10-13
+TXN_4818703,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-04-20
+TXN_9849760,Cake,2,3.0,6.0,,Takeaway,2023-09-01
+TXN_6387334,Smoothie,5,4.0,ERROR,Digital Wallet,In-store,2023-02-19
+TXN_6431384,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-08-06
+TXN_2445017,Tea,5,1.5,7.5,,Takeaway,2023-07-23
+TXN_9202190,Sandwich,,4.0,20.0,,In-store,2023-08-25
+TXN_4695464,Cookie,4,1.0,4.0,,Takeaway,UNKNOWN
+TXN_1486576,Sandwich,4,4.0,16.0,,Takeaway,2023-09-10
+TXN_5530717,Juice,1,3.0,3.0,Credit Card,In-store,2023-03-10
+TXN_7490314,Cookie,2,1.0,2.0,,In-store,2023-05-14
+TXN_1811734,Coffee,4,2.0,8.0,,,2023-07-16
+TXN_3100053,Cake,3,3.0,9.0,Cash,In-store,2023-12-19
+TXN_5812394,Salad,5,5.0,25.0,Cash,,2023-10-17
+TXN_6315475,Coffee,2,2.0,4.0,,,2023-09-23
+TXN_5477578,Smoothie,,4.0,4.0,Digital Wallet,Takeaway,2023-03-12
+TXN_5373441,Salad,1,5.0,ERROR,,In-store,2023-06-02
+TXN_1094145,Cookie,3,1.0,3.0,Credit Card,,2023-03-15
+TXN_8680875,ERROR,2,1.5,UNKNOWN,Cash,Takeaway,2023-07-21
+TXN_6504180,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-08-31
+TXN_6378045,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-05-07
+TXN_4502704,Tea,4,1.5,6.0,UNKNOWN,In-store,2023-04-04
+TXN_6992967,Smoothie,5,4.0,20.0,Cash,,2023-08-29
+TXN_6266147,Juice,3,3.0,9.0,Credit Card,In-store,2023-01-31
+TXN_7499330,Cookie,1,1.0,UNKNOWN,Credit Card,In-store,2023-10-28
+TXN_8815623,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-02-03
+TXN_7632478,Juice,2,3.0,6.0,Digital Wallet,,2023-04-11
+TXN_5431854,Cookie,3,1.0,3.0,,In-store,2023-01-18
+TXN_3518789,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-12-01
+TXN_6162668,ERROR,4,5.0,20.0,Digital Wallet,,2023-03-30
+TXN_4767006,Cake,1,3.0,3.0,Cash,Takeaway,2023-08-23
+TXN_2880409,Tea,4,1.5,6.0,Cash,,2023-09-11
+TXN_4277671,Tea,5,1.5,7.5,,Takeaway,2023-08-21
+TXN_8810601,Juice,2,3.0,6.0,Digital Wallet,,2023-08-18
+TXN_6572164,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-01-15
+TXN_6281959,,4,1.5,6.0,UNKNOWN,In-store,2023-03-16
+TXN_6714068,Coffee,1,UNKNOWN,2.0,,,2023-02-17
+TXN_2470532,ERROR,1,2.0,2.0,Digital Wallet,In-store,2023-01-21
+TXN_6920323,Sandwich,1,4.0,4.0,Credit Card,,2023-06-10
+TXN_6519486,Cake,5,3.0,15.0,,,2023-02-05
+TXN_7524971,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-09-05
+TXN_4650447,Tea,1,1.5,1.5,Cash,UNKNOWN,2023-08-18
+TXN_3928174,Coffee,3,2.0,6.0,,,2023-09-11
+TXN_1475403,Cookie,1,1.0,,Cash,In-store,
+TXN_1700027,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-06-04
+TXN_2026084,ERROR,2,2.0,4.0,Cash,In-store,2023-10-20
+TXN_5942938,,3,3.0,9.0,Credit Card,,2023-05-24
+TXN_8813764,Cookie,UNKNOWN,1.0,1.0,Credit Card,In-store,2023-05-08
+TXN_5202349,Cookie,4,1.0,4.0,,In-store,2023-11-27
+TXN_2409052,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-07-08
+TXN_8528546,Cake,3,3.0,9.0,Cash,,2023-12-09
+TXN_4849860,Tea,4,1.5,6.0,Credit Card,In-store,2023-12-01
+TXN_1840897,UNKNOWN,1,UNKNOWN,5.0,ERROR,,2023-06-03
+TXN_7689696,ERROR,5,4.0,20.0,Digital Wallet,Takeaway,2023-07-03
+TXN_6905794,Salad,1,5.0,,Cash,Takeaway,2023-05-31
+TXN_4469769,Salad,5,5.0,25.0,,UNKNOWN,2023-08-15
+TXN_9452261,Cake,5,3.0,15.0,,,2023-11-29
+TXN_7347515,Smoothie,3,4.0,12.0,ERROR,Takeaway,2023-04-25
+TXN_1940330,Tea,4,1.5,6.0,,In-store,2023-01-12
+TXN_1576355,Coffee,4,2.0,8.0,,,2023-10-20
+TXN_8615635,UNKNOWN,ERROR,1.0,4.0,,In-store,2023-01-12
+TXN_9511794,Cookie,1,1.0,1.0,Cash,Takeaway,2023-06-10
+TXN_9024781,Smoothie,4,4.0,16.0,Cash,In-store,2023-09-12
+TXN_7771526,Juice,1,3.0,3.0,Cash,In-store,2023-04-28
+TXN_7070302,Salad,3,5.0,15.0,,In-store,2023-04-30
+TXN_6511228,Salad,4,5.0,20.0,Credit Card,UNKNOWN,2023-11-01
+TXN_5320512,Tea,5,1.5,7.5,,In-store,2023-04-25
+TXN_2972777,Juice,4,ERROR,12.0,Credit Card,,2023-04-08
+TXN_8591813,Coffee,3,2.0,6.0,Cash,Takeaway,2023-10-31
+TXN_4095768,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-06-18
+TXN_9107508,Coffee,1,2.0,2.0,,,2023-06-06
+TXN_2791987,Smoothie,UNKNOWN,4.0,4.0,Credit Card,UNKNOWN,2023-06-23
+TXN_6045577,ERROR,3,2.0,6.0,Credit Card,,2023-07-06
+TXN_5534944,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-01-26
+TXN_7887682,UNKNOWN,2,2.0,4.0,Credit Card,Takeaway,2023-06-17
+TXN_5037517,UNKNOWN,5,4.0,20.0,ERROR,In-store,2023-06-01
+TXN_6805091,ERROR,2,4.0,8.0,Cash,ERROR,2023-12-28
+TXN_5839300,Cake,1,3.0,3.0,Credit Card,UNKNOWN,2023-07-01
+TXN_7801115,Tea,1,1.5,1.5,Cash,,2023-12-18
+TXN_4753853,,5,3.0,15.0,Credit Card,Takeaway,2023-05-07
+TXN_7145259,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-11-11
+TXN_2817018,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-04-25
+TXN_6762490,Juice,5,3.0,15.0,Cash,ERROR,2023-05-03
+TXN_9705872,Cookie,3,ERROR,3.0,,In-store,
+TXN_6012446,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-07-20
+TXN_8936086,Sandwich,4,4.0,16.0,,In-store,2023-11-27
+TXN_4135134,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-08-11
+TXN_7808032,Cookie,4,ERROR,4.0,,Takeaway,2023-12-19
+TXN_2212234,Juice,2,3.0,6.0,Cash,In-store,2023-12-22
+TXN_8611918,ERROR,3,5.0,15.0,Cash,Takeaway,2023-06-27
+TXN_5115009,Cake,4,3.0,12.0,,Takeaway,2023-02-21
+TXN_9827492,Tea,3,1.5,4.5,,,2023-07-13
+TXN_6344003,Cake,1,3.0,3.0,,,2023-12-22
+TXN_1993155,Juice,1,3.0,3.0,,,2023-05-23
+TXN_4566012,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-05-10
+TXN_1030539,Cake,3,3.0,9.0,,Takeaway,2023-11-06
+TXN_3830605,Coffee,ERROR,2.0,2.0,,Takeaway,2023-12-07
+TXN_5052515,Tea,,1.5,1.5,Cash,In-store,2023-09-19
+TXN_5125382,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-12-26
+TXN_5015183,Cake,2,3.0,6.0,ERROR,In-store,2023-08-29
+TXN_1661068,Salad,3,5.0,15.0,Cash,Takeaway,2023-04-09
+TXN_9549381,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-11-23
+TXN_7812084,Sandwich,4,4.0,16.0,Cash,In-store,2023-01-17
+TXN_1694364,Sandwich,3,4.0,12.0,,Takeaway,2023-06-10
+TXN_4191925,Coffee,2,2.0,4.0,,UNKNOWN,2023-10-21
+TXN_2258091,Juice,2,3.0,6.0,,In-store,2023-10-11
+TXN_6482262,Juice,3,3.0,9.0,Credit Card,,2023-05-13
+TXN_1951166,Tea,2,1.5,,Credit Card,ERROR,2023-08-28
+TXN_4552615,Cake,2,3.0,6.0,Cash,Takeaway,2023-04-09
+TXN_6745856,Cake,4,3.0,12.0,Cash,In-store,2023-06-16
+TXN_4898949,Salad,1,5.0,5.0,,In-store,2023-09-18
+TXN_7027560,ERROR,5,1.5,7.5,,In-store,2023-10-05
+TXN_9646000,ERROR,2,ERROR,UNKNOWN,,In-store,2023-12-14
+TXN_2338426,Coffee,2,2.0,4.0,,,2023-05-07
+TXN_3369191,Cookie,5,1.0,5.0,Cash,Takeaway,2023-02-07
+TXN_5551020,Sandwich,2,4.0,ERROR,Credit Card,,2023-01-31
+TXN_9269683,Sandwich,5,4.0,20.0,Digital Wallet,,2023-09-26
+TXN_9287350,Smoothie,2,4.0,8.0,,In-store,2023-01-28
+TXN_6541809,Tea,3,1.5,4.5,,,2023-05-01
+TXN_4398750,Sandwich,2,4.0,8.0,Cash,In-store,2023-05-28
+TXN_7493097,Cake,,3.0,15.0,Credit Card,UNKNOWN,2023-11-04
+TXN_9850541,Cookie,4,1.0,4.0,Cash,Takeaway,2023-09-02
+TXN_4262142,Cake,2,3.0,6.0,Cash,Takeaway,2023-01-02
+TXN_7153313,Tea,1,1.5,1.5,Cash,,2023-12-29
+TXN_8581124,Salad,2,5.0,10.0,Credit Card,,2023-05-08
+TXN_3589218,Salad,2,5.0,10.0,Credit Card,In-store,2023-06-21
+TXN_7303515,Salad,4,5.0,20.0,Cash,In-store,2023-05-29
+TXN_2586183,Cookie,2,1.0,2.0,Cash,,2023-09-04
+TXN_2436779,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-05-24
+TXN_4001763,Juice,3,3.0,9.0,,Takeaway,2023-05-11
+TXN_9317529,Juice,4,,12.0,Credit Card,,2023-07-10
+TXN_6974587,Salad,3,5.0,15.0,Cash,ERROR,2023-06-16
+TXN_4379467,Tea,UNKNOWN,1.5,1.5,,,2023-06-16
+TXN_2719734,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-05-22
+TXN_2887332,Sandwich,5,4.0,20.0,,,2023-11-16
+TXN_8566668,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-02-12
+TXN_8284384,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-06-05
+TXN_2139240,Sandwich,4,4.0,16.0,Digital Wallet,,2023-04-06
+TXN_5454841,Cookie,5,1.0,5.0,,Takeaway,2023-06-04
+TXN_8104431,Tea,5,1.5,7.5,,In-store,2023-03-07
+TXN_5141000,Smoothie,4,4.0,16.0,,Takeaway,2023-06-16
+TXN_2508499,Tea,3,1.5,4.5,Credit Card,In-store,2023-02-22
+TXN_4571510,Smoothie,3,4.0,12.0,Cash,Takeaway,2023-11-19
+TXN_4742476,Coffee,2,2.0,4.0,Cash,In-store,2023-10-27
+TXN_8510436,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-07-19
+TXN_7509630,Cookie,3,1.0,3.0,Cash,In-store,2023-04-20
+TXN_5276301,Cake,3,3.0,9.0,Cash,UNKNOWN,2023-03-13
+TXN_4977130,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-07-08
+TXN_4293196,Cookie,,1.0,3.0,,In-store,2023-06-17
+TXN_9284099,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-07-20
+TXN_1900411,Salad,3,5.0,15.0,,,2023-09-24
+TXN_7454416,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-12-07
+TXN_4178899,Coffee,2,2.0,4.0,,Takeaway,2023-04-05
+TXN_9027002,Smoothie,4,UNKNOWN,16.0,Credit Card,Takeaway,2023-12-31
+TXN_6587399,Smoothie,1,4.0,4.0,,Takeaway,2023-08-08
+TXN_7179013,Juice,5,3.0,15.0,Credit Card,In-store,2023-05-06
+TXN_7694559,Cookie,3,1.0,3.0,Cash,Takeaway,2023-05-05
+TXN_4391496,Sandwich,1,4.0,4.0,Cash,,2023-02-20
+TXN_5668193,Coffee,5,2.0,10.0,Cash,Takeaway,2023-08-14
+TXN_1448501,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-09-10
+TXN_7139869,Tea,1,1.5,1.5,Cash,In-store,2023-06-22
+TXN_6419668,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-04-29
+TXN_8810001,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-12-23
+TXN_5647773,Salad,2,5.0,10.0,,In-store,2023-07-20
+TXN_4439120,Cookie,2,1.0,2.0,Credit Card,In-store,2023-03-31
+TXN_4613510,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-02-16
+TXN_7937275,Cake,4,3.0,12.0,Credit Card,ERROR,2023-09-18
+TXN_7565052,Smoothie,5,4.0,20.0,,In-store,2023-06-18
+TXN_2044375,Salad,1,5.0,5.0,Cash,Takeaway,2023-01-05
+TXN_1772692,Smoothie,3,4.0,12.0,Cash,,2023-09-05
+TXN_6399545,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-03-22
+TXN_2980279,,1,3.0,3.0,Digital Wallet,Takeaway,2023-04-23
+TXN_6286062,Coffee,1,2.0,2.0,Credit Card,,UNKNOWN
+TXN_4049031,Coffee,5,2.0,10.0,Digital Wallet,,2023-08-22
+TXN_1328968,Tea,1,ERROR,1.5,,In-store,2023-06-28
+TXN_8549381,ERROR,5,4.0,20.0,Digital Wallet,,2023-02-06
+TXN_2080228,Juice,1,3.0,3.0,,In-store,2023-06-21
+TXN_7416880,Cake,1,3.0,3.0,Credit Card,In-store,2023-07-20
+TXN_1360379,Tea,1,1.5,1.5,Credit Card,UNKNOWN,2023-08-23
+TXN_9617454,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-22
+TXN_6421446,Cake,2,3.0,6.0,Cash,Takeaway,2023-09-17
+TXN_6272674,Coffee,3,2.0,6.0,Cash,,2023-09-12
+TXN_6805882,Cookie,4,1.0,4.0,Cash,In-store,2023-09-04
+TXN_1475459,Tea,4,1.5,6.0,,Takeaway,2023-11-09
+TXN_2825812,Cake,3,,9.0,Cash,Takeaway,2023-06-26
+TXN_5380198,Cake,3,3.0,9.0,UNKNOWN,,UNKNOWN
+TXN_5398922,Salad,1,5.0,5.0,Cash,In-store,2023-01-10
+TXN_3458602,Cake,2,3.0,6.0,Cash,In-store,2023-11-18
+TXN_6571440,Smoothie,2,4.0,8.0,,Takeaway,2023-01-18
+TXN_1368769,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-06-02
+TXN_4343848,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-07-16
+TXN_7656355,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-09-11
+TXN_4434005,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-03-20
+TXN_7975760,,3,3.0,9.0,Digital Wallet,In-store,2023-12-02
+TXN_9177867,Tea,3,1.5,4.5,Digital Wallet,,2023-09-14
+TXN_8158986,Cookie,5,1.0,5.0,,In-store,2023-12-10
+TXN_9882625,Sandwich,1,4.0,4.0,Cash,In-store,2023-03-26
+TXN_8937461,Cookie,5,1.0,5.0,Digital Wallet,,2023-12-22
+TXN_2485272,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-06-30
+TXN_4085337,Smoothie,3,4.0,12.0,,In-store,2023-10-25
+TXN_6838802,Coffee,1,2.0,2.0,,Takeaway,2023-08-29
+TXN_2114182,Cookie,3,1.0,3.0,Digital Wallet,UNKNOWN,2023-07-28
+TXN_8417552,Coffee,1,2.0,2.0,ERROR,Takeaway,2023-12-09
+TXN_4126189,Tea,,1.5,1.5,Credit Card,,2023-09-30
+TXN_1892454,Juice,1,3.0,3.0,UNKNOWN,,2023-07-19
+TXN_9592941,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-04-08
+TXN_1063342,Sandwich,5,4.0,20.0,,In-store,2023-01-13
+TXN_4407203,UNKNOWN,4,1.0,4.0,Cash,Takeaway,2023-08-21
+TXN_7153885,Salad,1,5.0,5.0,Credit Card,,2023-05-22
+TXN_1917388,ERROR,2,3.0,6.0,Digital Wallet,,2023-04-15
+TXN_5279972,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-01-07
+TXN_6953244,Smoothie,5,4.0,20.0,Cash,,2023-09-13
+TXN_5347792,Salad,3,5.0,15.0,Digital Wallet,,2023-02-10
+TXN_4876195,Tea,2,1.5,3.0,,In-store,ERROR
+TXN_1574190,Smoothie,3,4.0,12.0,UNKNOWN,,2023-12-17
+TXN_4829492,,2,3.0,6.0,Credit Card,Takeaway,2023-01-09
+TXN_9550629,Smoothie,1,4.0,4.0,,In-store,2023-02-06
+TXN_6470865,Coffee,ERROR,2.0,ERROR,Digital Wallet,Takeaway,2023-09-18
+TXN_3986639,Salad,1,5.0,5.0,Credit Card,In-store,2023-10-09
+TXN_3227673,Cookie,1,1.0,ERROR,Cash,,2023-10-13
+TXN_2915287,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-01-16
+TXN_2513558,Juice,4,3.0,12.0,,,2023-10-11
+TXN_7460497,Cake,5,3.0,15.0,Cash,,2023-11-13
+TXN_1607471,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-01-03
+TXN_1244739,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-09-13
+TXN_7878672,Coffee,1,UNKNOWN,2.0,Cash,In-store,2023-10-25
+TXN_6807913,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-01-22
+TXN_6438869,Juice,5,3.0,15.0,Credit Card,Takeaway,2023-10-30
+TXN_1047204,Cookie,3,1.0,3.0,Digital Wallet,UNKNOWN,2023-04-13
+TXN_6017458,,5,5.0,25.0,Credit Card,,2023-04-23
+TXN_4311086,Cake,4,3.0,12.0,ERROR,In-store,2023-10-10
+TXN_1075446,Cookie,4,1.0,4.0,Credit Card,,2023-07-17
+TXN_8958723,Sandwich,4,4.0,16.0,Digital Wallet,,2023-11-12
+TXN_2206740,Coffee,3,2.0,6.0,,Takeaway,2023-06-07
+TXN_2337113,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-11-19
+TXN_2417721,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-10-20
+TXN_5808539,Sandwich,1,4.0,ERROR,,Takeaway,2023-06-30
+TXN_6574910,Cookie,1,1.0,1.0,Digital Wallet,,2023-09-13
+TXN_5342900,Cake,5,3.0,15.0,Cash,,2023-07-12
+TXN_8949453,,5,4.0,20.0,,Takeaway,2023-11-13
+TXN_2853459,Tea,4,1.5,6.0,Cash,,2023-08-14
+TXN_3379182,Juice,4,3.0,12.0,Cash,,2023-06-03
+TXN_9629448,Tea,2,1.5,3.0,,In-store,2023-02-22
+TXN_8233101,Salad,2,5.0,10.0,Cash,In-store,2023-02-12
+TXN_1247244,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-12-27
+TXN_4292280,Cake,4,3.0,12.0,Cash,Takeaway,2023-01-01
+TXN_3670476,Tea,3,1.5,4.5,Cash,Takeaway,2023-03-25
+TXN_4506936,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-03-20
+TXN_4009914,Sandwich,2,4.0,8.0,,In-store,ERROR
+TXN_2827994,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-12-04
+TXN_5342051,Sandwich,3,4.0,12.0,Cash,,2023-04-21
+TXN_7924635,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-02-21
+TXN_5958999,Tea,2,1.5,3.0,,,2023-04-13
+TXN_9098841,Cake,1,3.0,3.0,Credit Card,,2023-08-07
+TXN_9723314,Coffee,4,2.0,8.0,Cash,In-store,2023-10-10
+TXN_2311186,Smoothie,3,4.0,12.0,Digital Wallet,ERROR,2023-07-16
+TXN_8061460,Sandwich,3,4.0,12.0,Credit Card,Takeaway,UNKNOWN
+TXN_4659573,Cake,UNKNOWN,3.0,15.0,,,2023-05-15
+TXN_3920436,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-11-19
+TXN_5514988,Cookie,5,1.0,5.0,Credit Card,ERROR,UNKNOWN
+TXN_7825638,UNKNOWN,4,3.0,12.0,ERROR,,2023-12-09
+TXN_8710758,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-01-12
+TXN_4873180,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-01-17
+TXN_9643918,,3,1.0,3.0,Credit Card,In-store,2023-07-21
+TXN_9997620,Cookie,2,1.0,2.0,Cash,,2023-12-11
+TXN_2830671,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-11-08
+TXN_7876619,UNKNOWN,2,3.0,6.0,Cash,In-store,2023-09-27
+TXN_5898238,UNKNOWN,UNKNOWN,2.0,10.0,Credit Card,UNKNOWN,2023-06-29
+TXN_5337074,Cookie,3,1.0,3.0,Credit Card,In-store,2023-01-12
+TXN_9774186,Tea,3,1.5,4.5,,,2023-07-03
+TXN_8619494,Coffee,2,2.0,4.0,Digital Wallet,In-store,ERROR
+TXN_7268802,Salad,2,5.0,ERROR,Digital Wallet,Takeaway,2023-04-10
+TXN_3894735,Juice,5,3.0,15.0,ERROR,,2023-03-10
+TXN_1842981,Tea,5,1.5,ERROR,Credit Card,,2023-04-12
+TXN_1720238,Salad,5,5.0,25.0,ERROR,Takeaway,2023-05-08
+TXN_8520687,Salad,5,5.0,25.0,,Takeaway,2023-04-21
+TXN_5793417,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-12-29
+TXN_2927909,Cake,4,3.0,12.0,Credit Card,,2023-10-04
+TXN_3412484,Cake,4,3.0,12.0,,Takeaway,2023-09-06
+TXN_3754190,UNKNOWN,3,3.0,9.0,Digital Wallet,In-store,UNKNOWN
+TXN_4048203,Smoothie,2,4.0,8.0,,Takeaway,2023-12-13
+TXN_9181224,Sandwich,5,4.0,20.0,Cash,,UNKNOWN
+TXN_6841304,Cake,1,3.0,3.0,,,2023-03-13
+TXN_2156454,Cookie,5,1.0,5.0,,In-store,2023-08-17
+TXN_2001807,UNKNOWN,5,4.0,20.0,UNKNOWN,In-store,2023-08-10
+TXN_4781960,Juice,1,3.0,3.0,Digital Wallet,,2023-03-28
+TXN_4381404,Salad,ERROR,5.0,25.0,,,2023-08-15
+TXN_8406851,UNKNOWN,2,3.0,6.0,,In-store,2023-09-09
+TXN_3982257,Coffee,2,2.0,4.0,Digital Wallet,,2023-07-23
+TXN_1463795,Coffee,5,2.0,10.0,Credit Card,,2023-08-04
+TXN_7454894,Tea,,1.5,1.5,Cash,Takeaway,2023-07-25
+TXN_5930304,Sandwich,2,4.0,8.0,Digital Wallet,,2023-11-02
+TXN_4249989,Coffee,4,2.0,8.0,Digital Wallet,,2023-01-22
+TXN_2957017,Sandwich,,4.0,20.0,Cash,In-store,2023-06-13
+TXN_2733833,Cake,,3.0,12.0,,In-store,2023-09-09
+TXN_6585794,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-02-15
+TXN_5721846,Cookie,3,1.0,3.0,Cash,Takeaway,2023-04-14
+TXN_6487493,Salad,3,5.0,15.0,Cash,In-store,2023-03-13
+TXN_4476636,Coffee,3,UNKNOWN,6.0,Credit Card,In-store,UNKNOWN
+TXN_1197495,Juice,5,3.0,15.0,UNKNOWN,Takeaway,ERROR
+TXN_9395087,Tea,1,1.5,1.5,Cash,In-store,2023-06-12
+TXN_4477559,Juice,5,3.0,15.0,Credit Card,,2023-10-02
+TXN_5542033,Sandwich,3,4.0,12.0,Digital Wallet,UNKNOWN,2023-06-26
+TXN_8850984,Sandwich,3,,12.0,Cash,Takeaway,2023-05-27
+TXN_1710823,Salad,2,5.0,10.0,Credit Card,,2023-01-27
+TXN_6575440,Tea,1,1.5,1.5,Cash,,2023-02-05
+TXN_5225537,Tea,5,1.5,7.5,Digital Wallet,,2023-11-04
+TXN_1583315,Cookie,3,1.0,3.0,,Takeaway,2023-10-17
+TXN_8130122,Sandwich,2,4.0,8.0,,In-store,2023-10-23
+TXN_3587444,Juice,2,3.0,6.0,Credit Card,,2023-02-03
+TXN_7053280,UNKNOWN,,2.0,10.0,,In-store,2023-05-28
+TXN_9407000,Sandwich,4,4.0,16.0,,Takeaway,2023-10-03
+TXN_3017917,Cookie,3,UNKNOWN,3.0,Credit Card,Takeaway,2023-08-31
+TXN_8090925,ERROR,3,1.0,3.0,Digital Wallet,In-store,2023-07-11
+TXN_7738013,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-11-28
+TXN_8542781,Cake,2,3.0,6.0,,UNKNOWN,2023-05-18
+TXN_6617283,Tea,4,1.5,6.0,Digital Wallet,,2023-06-09
+TXN_1461221,Salad,2,5.0,10.0,Cash,In-store,2023-04-30
+TXN_2056358,Coffee,3,2.0,6.0,Cash,In-store,2023-09-17
+TXN_1858674,Smoothie,2,4.0,8.0,,In-store,2023-04-09
+TXN_2251009,Cookie,5,1.0,5.0,,,2023-04-02
+TXN_5616473,Sandwich,4,4.0,16.0,Cash,ERROR,2023-07-28
+TXN_7022398,Sandwich,4,4.0,16.0,,,2023-12-23
+TXN_2615514,Cookie,5,,5.0,Digital Wallet,UNKNOWN,
+TXN_7379939,,1,1.0,1.0,Cash,UNKNOWN,2023-04-21
+TXN_7331525,Cake,2,3.0,6.0,,,ERROR
+TXN_1004184,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-05-18
+TXN_4141868,Tea,3,1.5,4.5,Credit Card,,2023-02-08
+TXN_9871971,Smoothie,3,4.0,12.0,,Takeaway,2023-10-06
+TXN_4168771,Coffee,5,2.0,10.0,Digital Wallet,,2023-08-02
+TXN_6328925,Salad,4,5.0,20.0,Credit Card,,2023-09-05
+TXN_1226662,Salad,1,5.0,5.0,,In-store,2023-06-17
+TXN_7562171,Tea,1,1.5,1.5,,In-store,2023-09-02
+TXN_6843677,,ERROR,2.0,8.0,,Takeaway,2023-09-09
+TXN_2980632,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-01-14
+TXN_2609762,Coffee,5,2.0,10.0,,Takeaway,2023-07-26
+TXN_7253734,Sandwich,UNKNOWN,4.0,20.0,Digital Wallet,,2023-09-28
+TXN_6679600,Coffee,1,2.0,2.0,Digital Wallet,,2023-03-15
+TXN_8722854,Juice,1,3.0,3.0,Credit Card,Takeaway,UNKNOWN
+TXN_8279992,Juice,5,3.0,15.0,ERROR,,2023-07-03
+TXN_5722123,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-11-23
+TXN_3446174,Cake,5,3.0,15.0,Cash,,2023-10-31
+TXN_3518261,Sandwich,2,4.0,8.0,Digital Wallet,,2023-08-05
+TXN_5927925,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-11-02
+TXN_5101593,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-01-25
+TXN_1578981,Cake,1,3.0,3.0,Cash,In-store,2023-05-15
+TXN_7876388,Cookie,4,1.0,4.0,Cash,In-store,2023-10-05
+TXN_5939363,Tea,5,1.5,7.5,Credit Card,In-store,2023-02-14
+TXN_1636908,Cake,4,3.0,12.0,Digital Wallet,,2023-10-17
+TXN_5221688,Coffee,2,2.0,4.0,Cash,,2023-07-03
+TXN_1196923,Smoothie,2,4.0,8.0,ERROR,,2023-04-27
+TXN_8944698,Coffee,3,2.0,6.0,Credit Card,,2023-09-15
+TXN_8167275,Salad,5,5.0,25.0,,,UNKNOWN
+TXN_2167159,Cake,,3.0,6.0,Cash,UNKNOWN,2023-04-06
+TXN_7811387,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-11-30
+TXN_1884923,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-05-11
+TXN_8215595,Tea,2,1.5,3.0,Cash,,2023-11-23
+TXN_7618171,Cake,5,3.0,15.0,Cash,,
+TXN_9857674,Tea,5,1.5,7.5,,Takeaway,2023-06-12
+TXN_7389626,Tea,2,1.5,3.0,,UNKNOWN,ERROR
+TXN_6035512,Cake,5,3.0,15.0,Cash,Takeaway,2023-02-19
+TXN_1398769,Smoothie,1,4.0,4.0,Cash,In-store,2023-06-02
+TXN_6874354,Sandwich,4,4.0,16.0,Credit Card,,2023-03-23
+TXN_9690711,Cookie,2,1.0,2.0,Credit Card,In-store,2023-09-13
+TXN_5620636,Tea,4,UNKNOWN,6.0,,In-store,2023-06-12
+TXN_7234224,Cake,3,3.0,9.0,,,2023-10-31
+TXN_3844347,Sandwich,4,ERROR,16.0,Cash,,2023-10-04
+TXN_4507533,Cake,1,3.0,3.0,Digital Wallet,,2023-08-31
+TXN_7636238,Sandwich,4,4.0,16.0,Credit Card,,2023-03-27
+TXN_8913153,Smoothie,2,4.0,8.0,Credit Card,,2023-09-02
+TXN_7595206,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-12-02
+TXN_8424592,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-11-09
+TXN_1769882,ERROR,3,3.0,UNKNOWN,,Takeaway,2023-03-17
+TXN_2000406,Cake,2,3.0,6.0,Credit Card,UNKNOWN,2023-06-06
+TXN_3105786,Smoothie,3,4.0,12.0,,In-store,2023-10-04
+TXN_7820220,Cake,3,3.0,9.0,Credit Card,In-store,2023-03-16
+TXN_5880883,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-02-02
+TXN_4447856,Smoothie,2,4.0,8.0,Cash,Takeaway,2023-09-11
+TXN_6613909,Cake,4,3.0,12.0,Credit Card,In-store,2023-06-30
+TXN_5331924,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-06-30
+TXN_9090433,Cookie,2,1.0,,Cash,ERROR,2023-07-12
+TXN_9393467,ERROR,5,3.0,15.0,Cash,UNKNOWN,2023-09-25
+TXN_9811033,Cookie,3,1.0,UNKNOWN,Cash,Takeaway,2023-11-30
+TXN_5452419,Coffee,4,UNKNOWN,8.0,Cash,In-store,2023-01-25
+TXN_5384343,Juice,1,3.0,3.0,Credit Card,,2023-03-29
+TXN_6580743,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-12-18
+TXN_8361821,Tea,5,1.5,7.5,Cash,In-store,2023-06-30
+TXN_2103626,Juice,3,3.0,9.0,Cash,In-store,2023-04-23
+TXN_1891141,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-10-25
+TXN_1252575,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-10-16
+TXN_5354721,,5,3.0,15.0,UNKNOWN,Takeaway,2023-09-07
+TXN_6723498,Salad,3,5.0,15.0,,Takeaway,2023-01-28
+TXN_1852224,Tea,4,ERROR,6.0,Cash,Takeaway,2023-01-06
+TXN_5247378,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-06-16
+TXN_8786479,Coffee,4,2.0,8.0,,,2023-05-29
+TXN_5108439,Salad,2,5.0,10.0,,In-store,2023-05-06
+TXN_4993989,Smoothie,2,4.0,8.0,,,2023-11-15
+TXN_8004510,Cake,ERROR,3.0,9.0,Cash,Takeaway,2023-12-29
+TXN_8541473,Coffee,3,2.0,6.0,ERROR,ERROR,2023-08-02
+TXN_8917822,Cake,2,3.0,6.0,Digital Wallet,,2023-12-12
+TXN_8108731,Juice,5,3.0,15.0,,,2023-08-13
+TXN_4570750,UNKNOWN,1,2.0,,Cash,Takeaway,2023-05-18
+TXN_1190151,Juice,5,3.0,15.0,Digital Wallet,,2023-08-14
+TXN_8304002,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-05-02
+TXN_4341764,Coffee,2,2.0,4.0,Cash,,2023-12-02
+TXN_1751183,,5,4.0,20.0,Credit Card,,2023-12-25
+TXN_2112333,Cookie,2,1.0,2.0,Credit Card,In-store,UNKNOWN
+TXN_1046384,Smoothie,1,4.0,4.0,Cash,UNKNOWN,2023-06-09
+TXN_1736630,ERROR,5,1.5,7.5,Credit Card,,2023-07-16
+TXN_8287437,Tea,2,1.5,3.0,,,2023-03-16
+TXN_4153132,Salad,3,5.0,UNKNOWN,Digital Wallet,,2023-03-21
+TXN_3243410,Tea,2,ERROR,3.0,,,2023-10-30
+TXN_3061634,Coffee,1,2.0,2.0,Digital Wallet,,2023-03-17
+TXN_7433308,Salad,4,5.0,20.0,Cash,Takeaway,2023-02-14
+TXN_6991736,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-11-07
+TXN_7334272,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-07-07
+TXN_8120577,,3,3.0,9.0,Cash,In-store,2023-09-08
+TXN_9072093,Cookie,1,1.0,1.0,,,2023-03-06
+TXN_4705417,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-12-14
+TXN_8145970,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-10-26
+TXN_1910553,Smoothie,5,4.0,20.0,Cash,,2023-10-01
+TXN_9115899,Cake,2,UNKNOWN,6.0,Credit Card,In-store,2023-02-23
+TXN_2785563,Juice,5,3.0,15.0,Cash,Takeaway,ERROR
+TXN_6020552,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-01-14
+TXN_7970906,Coffee,UNKNOWN,2.0,8.0,ERROR,In-store,2023-03-07
+TXN_5317458,Salad,2,5.0,10.0,Credit Card,,2023-01-22
+TXN_6913384,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-09-18
+TXN_1910487,Sandwich,3,,12.0,Digital Wallet,In-store,2023-08-14
+TXN_6142549,Juice,3,3.0,9.0,Digital Wallet,ERROR,2023-03-12
+TXN_7266318,Sandwich,1,4.0,ERROR,,In-store,2023-01-16
+TXN_4390911,Salad,2,5.0,10.0,Digital Wallet,,2023-12-19
+TXN_1445532,Coffee,3,2.0,6.0,Cash,Takeaway,2023-03-03
+TXN_8841996,Sandwich,2,4.0,8.0,,,2023-12-09
+TXN_9814511,ERROR,1,3.0,3.0,Credit Card,,2023-01-05
+TXN_2563505,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-10-27
+TXN_5183674,Coffee,2,2.0,4.0,Digital Wallet,,2023-04-13
+TXN_6748199,Salad,2,5.0,10.0,Cash,,2023-07-23
+TXN_3463281,Cake,5,,15.0,,Takeaway,2023-10-06
+TXN_5795475,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-09-21
+TXN_2322399,Salad,4,5.0,20.0,,Takeaway,2023-04-15
+TXN_5865534,Smoothie,4,4.0,16.0,Digital Wallet,ERROR,2023-10-16
+TXN_7060144,Cake,5,3.0,15.0,Credit Card,,
+TXN_5159669,Tea,4,1.5,6.0,Credit Card,,2023-09-30
+TXN_4268051,Cookie,1,1.0,UNKNOWN,Digital Wallet,In-store,2023-05-05
+TXN_8120958,Cookie,5,,5.0,Credit Card,,2023-06-21
+TXN_6126149,Tea,2,1.5,3.0,,,
+TXN_5530097,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-12-19
+TXN_7805241,Salad,4,5.0,20.0,ERROR,,2023-04-16
+TXN_2427834,Tea,4,1.5,6.0,ERROR,In-store,2023-06-15
+TXN_6949949,Salad,3,5.0,15.0,,,2023-05-14
+TXN_9094261,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-05-15
+TXN_5661323,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-05-06
+TXN_2356583,Smoothie,4,ERROR,16.0,Digital Wallet,In-store,2023-11-30
+TXN_4248711,Smoothie,1,4.0,4.0,Cash,,2023-08-01
+TXN_6270766,Cookie,1,1.0,1.0,,In-store,2023-11-10
+TXN_9697154,Tea,3,1.5,4.5,Credit Card,In-store,2023-10-08
+TXN_6381860,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-08-21
+TXN_6028331,Cake,4,3.0,12.0,Cash,,2023-10-22
+TXN_8830924,Tea,2,1.5,3.0,Credit Card,,2023-10-25
+TXN_3866156,Coffee,4,2.0,8.0,,Takeaway,2023-02-28
+TXN_6872833,Coffee,UNKNOWN,2.0,2.0,,,2023-11-02
+TXN_6405210,Coffee,4,2.0,8.0,Cash,UNKNOWN,2023-08-11
+TXN_4740952,Tea,4,1.5,6.0,,Takeaway,2023-02-21
+TXN_6321174,Tea,4,1.5,6.0,Digital Wallet,,2023-12-09
+TXN_5613875,Tea,5,1.5,7.5,,In-store,UNKNOWN
+TXN_6052901,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-08-16
+TXN_1253619,Juice,5,3.0,15.0,,,2023-05-25
+TXN_5537517,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-10-27
+TXN_5496019,Cookie,5,1.0,5.0,Cash,In-store,2023-11-26
+TXN_4579666,Smoothie,2,4.0,8.0,,,2023-10-23
+TXN_6359281,Coffee,2,2.0,4.0,Credit Card,UNKNOWN,2023-09-16
+TXN_3620122,Sandwich,1,4.0,4.0,Cash,In-store,2023-05-06
+TXN_8367716,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-02-03
+TXN_6779763,Cookie,1,1.0,ERROR,Credit Card,UNKNOWN,2023-04-25
+TXN_1985142,Smoothie,3,4.0,12.0,Digital Wallet,,UNKNOWN
+TXN_8385321,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-02-08
+TXN_5345258,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-03-13
+TXN_8932759,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-09-01
+TXN_6958638,Tea,,1.5,1.5,Digital Wallet,Takeaway,2023-11-27
+TXN_3898665,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-03-07
+TXN_4996304,Coffee,2,2.0,4.0,Credit Card,,2023-08-17
+TXN_9566593,Cake,2,3.0,6.0,Digital Wallet,,2023-09-30
+TXN_4808700,Cookie,4,1.0,4.0,Cash,Takeaway,2023-01-13
+TXN_5776252,Tea,4,1.5,6.0,Cash,Takeaway,2023-08-11
+TXN_5673476,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-02-09
+TXN_6363733,Tea,1,1.5,1.5,ERROR,Takeaway,2023-10-25
+TXN_5297995,Tea,5,1.5,7.5,,In-store,2023-07-04
+TXN_8049635,Salad,3,5.0,15.0,Cash,,2023-11-16
+TXN_2881529,,1,3.0,3.0,,In-store,2023-07-04
+TXN_3459927,Cookie,ERROR,1.0,5.0,Digital Wallet,In-store,2023-07-20
+TXN_6478968,Salad,2,5.0,10.0,,,2023-09-12
+TXN_4135861,Salad,2,5.0,10.0,Credit Card,,2023-03-16
+TXN_2031545,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-05-02
+TXN_4676976,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-05-26
+TXN_7421018,Sandwich,4,4.0,16.0,Digital Wallet,,2023-08-26
+TXN_8239121,Smoothie,UNKNOWN,4.0,4.0,,In-store,2023-05-11
+TXN_1435192,Cake,2,3.0,6.0,,,2023-06-18
+TXN_5364052,Sandwich,2,4.0,8.0,Credit Card,,2023-02-05
+TXN_8345649,Cookie,5,1.0,5.0,Cash,,2023-08-23
+TXN_8560548,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-09-02
+TXN_2345332,Tea,3,1.5,4.5,,In-store,2023-07-05
+TXN_9389434,Cake,5,3.0,15.0,,In-store,2023-06-16
+TXN_1240476,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-04-20
+TXN_8345092,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-07-24
+TXN_5849947,Sandwich,5,4.0,20.0,Cash,ERROR,2023-02-02
+TXN_8227648,ERROR,,1.5,4.5,,Takeaway,2023-05-31
+TXN_7800602,Tea,1,1.5,1.5,Cash,,2023-04-30
+TXN_5926836,Cake,5,3.0,15.0,,In-store,2023-08-07
+TXN_4397994,Cookie,5,1.0,5.0,,Takeaway,2023-09-26
+TXN_1585827,Cake,3,3.0,9.0,Credit Card,In-store,2023-09-30
+TXN_3384640,Salad,4,5.0,20.0,,Takeaway,2023-10-17
+TXN_1990029,Tea,4,1.5,6.0,Credit Card,In-store,2023-11-18
+TXN_5796131,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-09-30
+TXN_5166412,UNKNOWN,4,1.0,4.0,UNKNOWN,Takeaway,2023-06-17
+TXN_7804740,Smoothie,2,4.0,8.0,Digital Wallet,,2023-10-19
+TXN_9082461,Cake,5,ERROR,15.0,Digital Wallet,In-store,2023-05-30
+TXN_6665881,Juice,2,3.0,6.0,Credit Card,,2023-07-04
+TXN_4046039,Juice,5,3.0,15.0,,In-store,2023-04-20
+TXN_8447640,Sandwich,UNKNOWN,4.0,20.0,Cash,In-store,2023-06-12
+TXN_3042768,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-09-07
+TXN_4664329,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-01-06
+TXN_7442492,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-07-23
+TXN_8664335,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-06-12
+TXN_7379007,Cake,2,3.0,6.0,,Takeaway,
+TXN_1434857,Cake,5,3.0,15.0,ERROR,In-store,2023-01-13
+TXN_1700374,Sandwich,5,4.0,20.0,,In-store,2023-08-11
+TXN_8383484,ERROR,2,3.0,6.0,,,2023-12-20
+TXN_1261028,Juice,3,3.0,9.0,ERROR,In-store,2023-10-27
+TXN_1478016,,4,1.0,4.0,,In-store,2023-08-04
+TXN_5321145,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-08-29
+TXN_3884995,Juice,5,3.0,15.0,Cash,In-store,2023-12-25
+TXN_4178488,Sandwich,3,4.0,12.0,Cash,In-store,2023-05-08
+TXN_4826214,UNKNOWN,3,2.0,6.0,Digital Wallet,Takeaway,2023-11-23
+TXN_2579157,Sandwich,1,4.0,4.0,UNKNOWN,,2023-09-27
+TXN_3597806,Cookie,3,1.0,3.0,Credit Card,UNKNOWN,2023-12-11
+TXN_7897119,Juice,4,3.0,UNKNOWN,ERROR,In-store,2023-05-27
+TXN_2245037,Coffee,2,2.0,4.0,,,2023-10-18
+TXN_4833378,Cake,5,3.0,15.0,Digital Wallet,,2023-10-15
+TXN_7055306,Salad,1,5.0,5.0,,Takeaway,2023-03-09
+TXN_9135433,Cookie,4,1.0,UNKNOWN,,In-store,2023-12-18
+TXN_1715684,Smoothie,1,4.0,4.0,UNKNOWN,In-store,2023-07-13
+TXN_9073440,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-08-28
+TXN_4089355,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-02-18
+TXN_3834078,Juice,1,3.0,3.0,,In-store,2023-01-29
+TXN_5048650,Smoothie,2,4.0,UNKNOWN,Cash,Takeaway,2023-11-18
+TXN_1882700,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-04-18
+TXN_2112911,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-09-18
+TXN_7568316,Cake,2,3.0,6.0,Credit Card,,2023-11-28
+TXN_3642982,Coffee,5,2.0,10.0,Cash,UNKNOWN,2023-10-04
+TXN_4475094,Sandwich,3,4.0,12.0,ERROR,ERROR,2023-08-12
+TXN_6768812,Coffee,4,2.0,8.0,ERROR,,2023-03-30
+TXN_1419669,Cake,5,3.0,15.0,Cash,Takeaway,2023-03-07
+TXN_9810604,Cake,2,3.0,6.0,ERROR,Takeaway,2023-04-02
+TXN_4791243,Cookie,5,1.0,5.0,,Takeaway,2023-05-12
+TXN_5665311,UNKNOWN,2,1.0,2.0,Credit Card,In-store,2023-05-17
+TXN_7920897,Salad,2,5.0,10.0,,In-store,2023-07-29
+TXN_7515272,UNKNOWN,1,3.0,3.0,,,2023-08-12
+TXN_5453836,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-05-29
+TXN_5578796,Tea,4,1.5,6.0,,In-store,2023-04-27
+TXN_8620592,Smoothie,2,4.0,8.0,,In-store,2023-07-14
+TXN_7402846,Juice,UNKNOWN,3.0,6.0,Credit Card,Takeaway,2023-10-11
+TXN_9487214,Coffee,5,2.0,10.0,UNKNOWN,,2023-03-25
+TXN_2274702,Cookie,5,1.0,5.0,Credit Card,In-store,2023-12-11
+TXN_2701016,Cake,5,3.0,15.0,Digital Wallet,,2023-03-06
+TXN_8809853,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-10-29
+TXN_7683607,Cake,1,3.0,3.0,Cash,,2023-03-17
+TXN_2402928,Coffee,4,2.0,8.0,Cash,,2023-10-20
+TXN_6516391,Cake,2,3.0,6.0,Digital Wallet,,2023-06-16
+TXN_9685326,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-04-07
+TXN_6181456,ERROR,1,1.0,,,Takeaway,2023-05-08
+TXN_9858627,Juice,4,3.0,12.0,UNKNOWN,,2023-01-22
+TXN_9923613,Sandwich,4,4.0,16.0,,In-store,2023-11-08
+TXN_7656770,Coffee,1,2.0,2.0,Credit Card,,2023-12-24
+TXN_4092551,Juice,5,3.0,15.0,Credit Card,Takeaway,2023-10-11
+TXN_9894204,UNKNOWN,2,2.0,4.0,Cash,Takeaway,2023-08-08
+TXN_7241288,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-04-11
+TXN_9833195,Coffee,2,2.0,4.0,,Takeaway,2023-03-03
+TXN_9153854,Sandwich,2,4.0,8.0,,In-store,2023-04-04
+TXN_1436851,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-07-28
+TXN_8598575,Sandwich,4,4.0,16.0,Digital Wallet,,2023-11-14
+TXN_1417871,Salad,3,5.0,15.0,Cash,Takeaway,2023-03-12
+TXN_7844352,ERROR,2,,6.0,Credit Card,,2023-07-26
+TXN_2339781,Smoothie,2,4.0,8.0,,In-store,2023-01-02
+TXN_6674257,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-07-20
+TXN_2649010,Tea,UNKNOWN,1.5,6.0,Cash,Takeaway,2023-08-01
+TXN_1339158,Salad,4,5.0,20.0,Cash,,UNKNOWN
+TXN_7948933,Sandwich,3,4.0,12.0,Cash,,ERROR
+TXN_4965631,Smoothie,3,4.0,12.0,Credit Card,ERROR,2023-01-27
+TXN_9254064,Coffee,2,2.0,4.0,Cash,Takeaway,2023-12-10
+TXN_4554168,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-04-08
+TXN_6536418,Salad,5,5.0,25.0,Credit Card,In-store,2023-02-11
+TXN_9024186,Juice,2,UNKNOWN,6.0,Cash,Takeaway,2023-12-17
+TXN_4580084,Sandwich,5,4.0,,Credit Card,Takeaway,2023-12-17
+TXN_3996874,Tea,4,1.5,6.0,Digital Wallet,,2023-05-18
+TXN_7106595,ERROR,ERROR,1.5,3.0,Credit Card,Takeaway,2023-06-19
+TXN_5439860,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-04-18
+TXN_3216618,Salad,4,5.0,20.0,Credit Card,In-store,2023-12-30
+TXN_8360779,Cookie,4,1.0,4.0,Credit Card,In-store,2023-10-25
+TXN_3700419,Cookie,4,1.0,4.0,ERROR,,2023-01-09
+TXN_6369590,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-10-26
+TXN_5039782,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-06-21
+TXN_7047860,Coffee,2,,4.0,,Takeaway,2023-06-18
+TXN_2985748,Coffee,3,2.0,6.0,,Takeaway,2023-12-19
+TXN_8616557,Sandwich,5,4.0,20.0,,In-store,2023-08-28
+TXN_3171673,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-12-07
+TXN_4827637,Smoothie,4,4.0,16.0,Cash,In-store,2023-04-28
+TXN_1170198,Tea,4,1.5,6.0,Credit Card,In-store,2023-02-09
+TXN_8166527,Salad,2,5.0,10.0,Cash,In-store,2023-05-24
+TXN_3097593,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-06-18
+TXN_2981117,UNKNOWN,1,3.0,3.0,UNKNOWN,In-store,2023-10-02
+TXN_3431526,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-12-27
+TXN_1817076,ERROR,3,3.0,UNKNOWN,Cash,In-store,2023-05-31
+TXN_1489218,Salad,2,5.0,10.0,Digital Wallet,,2023-09-13
+TXN_1936644,Juice,3,3.0,9.0,Digital Wallet,ERROR,2023-01-28
+TXN_4293694,Smoothie,5,4.0,20.0,Cash,,2023-08-03
+TXN_9469529,Coffee,2,2.0,4.0,,UNKNOWN,2023-08-09
+TXN_2946861,UNKNOWN,3,3.0,,UNKNOWN,,2023-03-28
+TXN_7919609,Sandwich,ERROR,4.0,12.0,,In-store,2023-01-31
+TXN_7692019,Juice,3,3.0,9.0,,In-store,2023-10-14
+TXN_7677750,Tea,2,1.5,,Cash,Takeaway,2023-12-24
+TXN_9799633,Juice,4,3.0,12.0,Cash,In-store,2023-11-07
+TXN_4252036,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-01-22
+TXN_6637989,Smoothie,1,4.0,4.0,Cash,,2023-11-09
+TXN_2860514,Cookie,5,1.0,5.0,Credit Card,,2023-09-01
+TXN_4143449,Smoothie,3,4.0,12.0,Digital Wallet,,2023-08-23
+TXN_1499208,,1,4.0,4.0,Cash,Takeaway,2023-11-01
+TXN_1960599,Cake,4,3.0,12.0,Cash,,2023-01-06
+TXN_1184377,Juice,1,3.0,3.0,Cash,,2023-10-25
+TXN_6995795,Salad,4,5.0,20.0,,In-store,2023-11-28
+TXN_7805508,Smoothie,5,4.0,20.0,,In-store,2023-07-10
+TXN_6193929,Juice,5,3.0,15.0,ERROR,Takeaway,2023-06-20
+TXN_1942950,Sandwich,4,4.0,16.0,,Takeaway,2023-03-25
+TXN_9759221,Coffee,3,ERROR,6.0,Cash,Takeaway,2023-06-23
+TXN_1205522,Cake,5,3.0,15.0,,In-store,2023-12-26
+TXN_7792223,Smoothie,3,4.0,UNKNOWN,Credit Card,,2023-07-21
+TXN_7205370,Smoothie,4,4.0,16.0,Cash,,2023-12-07
+TXN_9992148,Tea,3,1.5,4.5,Cash,Takeaway,2023-01-14
+TXN_6305420,Cookie,3,1.0,3.0,,In-store,2023-06-17
+TXN_9982090,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-06-03
+TXN_6507690,Juice,,3.0,3.0,Digital Wallet,In-store,2023-01-30
+TXN_8487057,Smoothie,5,4.0,20.0,,Takeaway,2023-06-01
+TXN_6646382,Tea,4,1.5,6.0,ERROR,ERROR,2023-09-16
+TXN_5255092,Sandwich,1,4.0,4.0,ERROR,Takeaway,2023-10-08
+TXN_8402941,Cake,5,3.0,15.0,Credit Card,In-store,2023-11-26
+TXN_4265056,Juice,1,3.0,3.0,Cash,,2023-07-16
+TXN_4605871,Cookie,1,1.0,1.0,ERROR,ERROR,2023-06-20
+TXN_7976001,Juice,4,3.0,12.0,Credit Card,In-store,2023-06-27
+TXN_4969003,Cookie,1,1.0,UNKNOWN,Digital Wallet,In-store,2023-04-19
+TXN_3629728,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-03-11
+TXN_7027319,Smoothie,,4.0,12.0,Credit Card,Takeaway,2023-02-25
+TXN_1907428,Juice,4,3.0,12.0,Credit Card,In-store,2023-06-06
+TXN_6594753,Juice,3,3.0,9.0,,UNKNOWN,2023-03-16
+TXN_8554646,Coffee,2,2.0,4.0,Cash,,2023-01-10
+TXN_5860664,Juice,5,3.0,15.0,Digital Wallet,,2023-06-06
+TXN_3586768,Coffee,2,2.0,4.0,,In-store,2023-05-23
+TXN_5765294,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-11-14
+TXN_4966149,Juice,2,3.0,6.0,Cash,,2023-04-10
+TXN_3652726,Sandwich,3,4.0,12.0,,In-store,2023-08-03
+TXN_2273573,Cookie,5,1.0,5.0,Cash,In-store,2023-11-12
+TXN_7924516,Cookie,1,1.0,1.0,Credit Card,,2023-04-23
+TXN_2083132,Salad,1,5.0,5.0,UNKNOWN,,2023-08-31
+TXN_8837131,ERROR,3,4.0,12.0,Digital Wallet,In-store,2023-12-23
+TXN_2659832,Sandwich,3,,12.0,Credit Card,ERROR,2023-12-05
+TXN_5049646,Juice,2,3.0,6.0,Credit Card,In-store,2023-08-30
+TXN_9182359,Salad,3,5.0,15.0,,In-store,UNKNOWN
+TXN_7401217,Salad,UNKNOWN,5.0,20.0,,,2023-02-06
+TXN_6853142,Smoothie,3,4.0,12.0,Cash,ERROR,2023-07-21
+TXN_4031726,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-11-22
+TXN_9512112,Coffee,4,2.0,8.0,Cash,Takeaway,2023-05-25
+TXN_9428611,Salad,4,5.0,20.0,Digital Wallet,,2023-07-13
+TXN_1472433,ERROR,1,2.0,2.0,Digital Wallet,Takeaway,2023-04-05
+TXN_5235471,Cake,5,3.0,15.0,,In-store,UNKNOWN
+TXN_5483635,Juice,3,3.0,9.0,Credit Card,In-store,2023-03-23
+TXN_1848481,Cookie,4,1.0,4.0,Credit Card,,UNKNOWN
+TXN_3478169,Juice,2,3.0,6.0,Cash,In-store,2023-02-03
+TXN_3842766,Tea,3,1.5,4.5,Credit Card,In-store,2023-03-24
+TXN_7805115,Smoothie,2,4.0,8.0,ERROR,,2023-12-18
+TXN_7565447,Salad,1,5.0,ERROR,,,2023-02-15
+TXN_8225343,Smoothie,1,4.0,4.0,Cash,,2023-05-10
+TXN_3822036,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-05-07
+TXN_3019996,Sandwich,2,4.0,8.0,Cash,,2023-06-27
+TXN_8397209,UNKNOWN,3,1.5,4.5,Cash,In-store,2023-10-12
+TXN_5634977,Coffee,5,2.0,10.0,,In-store,2023-03-06
+TXN_8165784,Cake,5,3.0,15.0,Digital Wallet,,2023-10-15
+TXN_3619141,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-09-30
+TXN_7160017,Juice,1,3.0,3.0,Cash,In-store,2023-09-27
+TXN_9513509,Sandwich,1,4.0,4.0,Credit Card,,2023-04-27
+TXN_5919038,Cookie,1,1.0,1.0,Credit Card,In-store,2023-12-15
+TXN_8384229,Tea,4,1.5,6.0,Digital Wallet,,2023-01-08
+TXN_9011816,Cake,1,3.0,3.0,UNKNOWN,Takeaway,2023-04-02
+TXN_2916992,Salad,2,5.0,10.0,Cash,Takeaway,2023-08-20
+TXN_4350788,Tea,3,UNKNOWN,4.5,,In-store,2023-06-28
+TXN_3132488,Sandwich,UNKNOWN,4.0,16.0,Credit Card,Takeaway,2023-09-12
+TXN_9126573,Salad,4,5.0,20.0,Digital Wallet,,2023-06-17
+TXN_5347338,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-07-04
+TXN_9455737,ERROR,3,5.0,15.0,,,UNKNOWN
+TXN_2930963,UNKNOWN,2,4.0,8.0,Digital Wallet,In-store,2023-02-09
+TXN_7997252,UNKNOWN,3,3.0,9.0,Credit Card,,2023-05-28
+TXN_1907740,Sandwich,1,4.0,4.0,Cash,,2023-03-17
+TXN_3654670,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-06-14
+TXN_1432682,Tea,1,1.5,1.5,,UNKNOWN,2023-07-11
+TXN_3938271,Salad,3,5.0,15.0,,In-store,2023-01-12
+TXN_7619641,Juice,3,3.0,9.0,,In-store,2023-04-02
+TXN_1870423,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-04-12
+TXN_1006942,Salad,1,5.0,5.0,Credit Card,In-store,2023-11-30
+TXN_2282319,Juice,2,3.0,,Cash,In-store,2023-08-14
+TXN_6812735,Tea,5,1.5,7.5,,ERROR,2023-04-21
+TXN_6922833,Tea,1,1.5,1.5,ERROR,Takeaway,2023-11-17
+TXN_1026799,Cake,5,3.0,15.0,Credit Card,,UNKNOWN
+TXN_5783469,Salad,ERROR,5.0,15.0,,ERROR,2023-06-14
+TXN_8489120,Cookie,2,1.0,2.0,Credit Card,,2023-11-07
+TXN_6200609,Salad,5,5.0,UNKNOWN,Digital Wallet,Takeaway,2023-04-12
+TXN_8194534,Coffee,2,2.0,4.0,Cash,,2023-05-19
+TXN_7238674,Cookie,1,1.0,1.0,,,2023-11-03
+TXN_6968752,Tea,1,UNKNOWN,1.5,,,2023-04-07
+TXN_2582926,Smoothie,4,4.0,16.0,,ERROR,ERROR
+TXN_1346953,Tea,3,1.5,4.5,,In-store,2023-09-24
+TXN_8742689,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-01-05
+TXN_2144031,Juice,1,3.0,3.0,,,2023-02-25
+TXN_1996466,Smoothie,1,4.0,4.0,Digital Wallet,,2023-04-24
+TXN_1124796,ERROR,5,1.5,7.5,Credit Card,,2023-10-28
+TXN_7124156,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-07-28
+TXN_3150614,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-08-06
+TXN_5263693,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-01-20
+TXN_1785644,,5,1.5,7.5,,,2023-08-13
+TXN_1702437,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-06-27
+TXN_6500713,Cookie,3,1.0,3.0,,In-store,2023-04-30
+TXN_8725721,Sandwich,1,4.0,4.0,Cash,ERROR,2023-06-04
+TXN_8965025,Salad,1,5.0,5.0,Cash,In-store,2023-04-14
+TXN_8491490,Coffee,2,2.0,4.0,,In-store,2023-01-16
+TXN_4328869,Sandwich,2,4.0,8.0,Cash,,2023-05-02
+TXN_3849711,Smoothie,5,4.0,20.0,Cash,,2023-08-14
+TXN_1334406,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-09-26
+TXN_1556708,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-06-11
+TXN_8422494,Salad,4,5.0,20.0,Cash,In-store,2023-06-08
+TXN_3427754,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-08-06
+TXN_3512545,Cookie,,1.0,4.0,Credit Card,In-store,2023-08-08
+TXN_7703185,Cake,1,UNKNOWN,3.0,Digital Wallet,Takeaway,2023-12-10
+TXN_8455321,Smoothie,3,4.0,12.0,,In-store,2023-01-25
+TXN_9904505,Smoothie,2,4.0,8.0,Digital Wallet,ERROR,2023-06-07
+TXN_5020643,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-10-19
+TXN_8170122,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-03-20
+TXN_5067216,UNKNOWN,4,5.0,20.0,,Takeaway,2023-07-24
+TXN_3930540,Smoothie,3,4.0,12.0,Cash,UNKNOWN,2023-03-24
+TXN_4663537,Coffee,5,2.0,10.0,Credit Card,,2023-10-22
+TXN_5392630,Juice,5,3.0,ERROR,Cash,Takeaway,2023-11-23
+TXN_9480851,Cake,3,3.0,ERROR,,In-store,2023-03-21
+TXN_5927620,Smoothie,1,4.0,4.0,Credit Card,,2023-05-04
+TXN_1561430,Tea,2,1.5,3.0,,Takeaway,2023-10-13
+TXN_1133945,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-10-23
+TXN_5467240,Smoothie,5,4.0,20.0,Digital Wallet,UNKNOWN,2023-10-20
+TXN_3210288,Salad,3,ERROR,15.0,UNKNOWN,Takeaway,2023-04-30
+TXN_1586452,Salad,2,5.0,ERROR,Cash,In-store,2023-02-01
+TXN_9814929,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-10-01
+TXN_8961480,Tea,4,1.5,6.0,Cash,,2023-02-18
+TXN_1826919,Juice,4,3.0,12.0,Credit Card,In-store,2023-02-21
+TXN_3135048,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-02-03
+TXN_3105263,ERROR,4,4.0,16.0,Credit Card,Takeaway,2023-11-25
+TXN_4504141,Sandwich,5,4.0,,Credit Card,,2023-09-28
+TXN_7408461,Juice,3,3.0,9.0,UNKNOWN,In-store,2023-11-05
+TXN_8108115,Coffee,ERROR,2.0,6.0,,In-store,2023-08-24
+TXN_6655437,Juice,1,3.0,3.0,ERROR,,2023-07-07
+TXN_9120328,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-10-22
+TXN_3906862,Cake,5,3.0,15.0,Cash,,2023-08-14
+TXN_8468071,Cookie,4,1.0,4.0,,,2023-08-22
+TXN_7543921,Coffee,3,2.0,6.0,Cash,In-store,2023-12-06
+TXN_8714536,ERROR,4,4.0,16.0,Digital Wallet,Takeaway,2023-05-06
+TXN_3282601,,2,3.0,6.0,Digital Wallet,In-store,2023-02-03
+TXN_4569599,UNKNOWN,2,1.5,3.0,Cash,,2023-02-07
+TXN_2970011,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-06-04
+TXN_5556328,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-12-10
+TXN_8786159,Coffee,3,2.0,6.0,Cash,In-store,2023-04-05
+TXN_2467699,Tea,1,1.5,1.5,Cash,UNKNOWN,2023-06-17
+TXN_3085628,Salad,1,5.0,5.0,Cash,,2023-08-26
+TXN_7952153,Smoothie,2,4.0,8.0,Digital Wallet,,2023-07-24
+TXN_4439321,Coffee,3,2.0,6.0,Cash,In-store,2023-04-25
+TXN_1488127,Tea,5,,7.5,,Takeaway,2023-12-12
+TXN_6687734,Cake,1,3.0,3.0,ERROR,In-store,2023-03-14
+TXN_7323885,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-15
+TXN_7894558,Coffee,2,2.0,4.0,,,2023-01-04
+TXN_4019040,Tea,1,1.5,1.5,Cash,In-store,2023-02-01
+TXN_1570573,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-04-09
+TXN_5991995,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-01-08
+TXN_2437586,Sandwich,4,4.0,16.0,Cash,,2023-08-29
+TXN_7326827,Smoothie,1,4.0,4.0,,In-store,2023-06-30
+TXN_6004431,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-04-07
+TXN_7475500,Cookie,2,1.0,2.0,Cash,,2023-11-22
+TXN_8122317,Coffee,3,2.0,6.0,Cash,Takeaway,2023-10-16
+TXN_2028930,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-25
+TXN_3394874,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-06-18
+TXN_5804346,Tea,UNKNOWN,1.5,1.5,Credit Card,,2023-07-05
+TXN_5926025,,2,4.0,,Digital Wallet,,2023-07-29
+TXN_2220389,Salad,4,5.0,20.0,Credit Card,UNKNOWN,2023-07-26
+TXN_9603773,Cookie,2,1.0,2.0,Credit Card,,2023-10-10
+TXN_1285279,Coffee,2,2.0,4.0,Cash,Takeaway,2023-04-09
+TXN_5244558,Smoothie,4,4.0,16.0,Digital Wallet,,2023-06-06
+TXN_1702434,Smoothie,3,4.0,12.0,Digital Wallet,,2023-07-22
+TXN_2425755,Smoothie,1,4.0,4.0,,Takeaway,2023-09-14
+TXN_5350200,UNKNOWN,1,4.0,4.0,Cash,In-store,2023-12-02
+TXN_7151817,Sandwich,1,4.0,4.0,Cash,In-store,2023-05-18
+TXN_7514589,Juice,3,3.0,9.0,Cash,Takeaway,2023-07-25
+TXN_5962237,Juice,1,3.0,3.0,,Takeaway,2023-10-31
+TXN_9059245,UNKNOWN,1,4.0,4.0,Cash,,2023-07-11
+TXN_2188356,Tea,1,1.5,1.5,,In-store,2023-07-14
+TXN_8019335,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-11-26
+TXN_5921650,Salad,,5.0,20.0,,In-store,2023-10-13
+TXN_5248011,Cake,2,3.0,6.0,,In-store,2023-01-21
+TXN_7332957,Sandwich,5,4.0,20.0,Digital Wallet,,2023-07-26
+TXN_1278539,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-04-04
+TXN_1186221,Salad,4,5.0,20.0,Cash,Takeaway,2023-04-21
+TXN_3086676,Cake,2,3.0,6.0,Cash,UNKNOWN,2023-07-21
+TXN_9696138,Juice,3,3.0,9.0,,,2023-12-01
+TXN_1846455,Sandwich,4,4.0,16.0,,,2023-03-16
+TXN_1548245,,4,4.0,16.0,Credit Card,,2023-03-15
+TXN_1839407,Cookie,3,1.0,3.0,Cash,,2023-03-15
+TXN_9028798,Cake,2,3.0,6.0,Cash,In-store,2023-05-25
+TXN_4672332,Cake,4,3.0,,Cash,In-store,2023-03-29
+TXN_2726078,Coffee,3,2.0,6.0,Digital Wallet,,2023-11-27
+TXN_5249091,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-08-15
+TXN_9507397,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-10-26
+TXN_6948649,ERROR,5,1.5,7.5,Cash,In-store,2023-11-27
+TXN_3300171,Cookie,5,1.0,5.0,Credit Card,In-store,2023-02-14
+TXN_2773085,Coffee,1,,2.0,,,2023-10-16
+TXN_4697112,Sandwich,3,4.0,12.0,Credit Card,,2023-04-08
+TXN_7897423,UNKNOWN,4,5.0,20.0,,,2023-05-24
+TXN_6373380,Coffee,4,2.0,8.0,Cash,In-store,2023-07-21
+TXN_8668590,Cookie,4,1.0,4.0,Digital Wallet,,2023-04-18
+TXN_9121676,Smoothie,4,4.0,16.0,,,2023-12-25
+TXN_4956012,Sandwich,1,4.0,4.0,,In-store,2023-07-20
+TXN_4341126,Cake,2,3.0,6.0,Cash,,2023-07-01
+TXN_9792412,Tea,UNKNOWN,1.5,6.0,Digital Wallet,Takeaway,2023-06-15
+TXN_2103018,Cake,5,3.0,,Credit Card,In-store,2023-11-24
+TXN_9843421,ERROR,3,3.0,9.0,UNKNOWN,In-store,2023-09-06
+TXN_2227781,Cake,1,3.0,3.0,Cash,Takeaway,2023-01-21
+TXN_6159539,Juice,1,3.0,3.0,Digital Wallet,,2023-01-12
+TXN_8014766,UNKNOWN,1,4.0,4.0,,,2023-10-05
+TXN_5234152,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-03-26
+TXN_9468033,Juice,1,3.0,3.0,Credit Card,,2023-12-13
+TXN_3132304,Sandwich,1,4.0,4.0,Credit Card,,2023-01-21
+TXN_6262910,Cake,4,3.0,12.0,Cash,Takeaway,2023-07-02
+TXN_7543841,Cookie,3,1.0,3.0,Cash,In-store,2023-11-07
+TXN_7901672,Cookie,1,1.0,1.0,,,2023-06-24
+TXN_1058957,Juice,2,3.0,6.0,Cash,In-store,2023-03-21
+TXN_7635738,Coffee,ERROR,2.0,8.0,Cash,Takeaway,2023-08-08
+TXN_2728444,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-01-23
+TXN_9073184,Cake,2,3.0,6.0,UNKNOWN,,2023-04-14
+TXN_2044945,ERROR,2,1.5,3.0,Cash,,2023-10-18
+TXN_5665341,Tea,5,1.5,7.5,Cash,,2023-02-27
+TXN_1509627,Juice,4,UNKNOWN,12.0,Digital Wallet,,2023-03-23
+TXN_7813066,Juice,1,,3.0,,,2023-02-28
+TXN_5518591,Cookie,4,1.0,4.0,Digital Wallet,,2023-09-21
+TXN_6540415,Cake,5,3.0,15.0,,UNKNOWN,2023-05-27
+TXN_2991726,Juice,5,ERROR,15.0,,In-store,2023-09-01
+TXN_7939659,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-07-26
+TXN_7531403,Smoothie,2,4.0,8.0,Cash,In-store,2023-07-08
+TXN_3767196,Salad,4,5.0,20.0,Cash,,2023-08-30
+TXN_3562332,Salad,5,5.0,25.0,,,2023-06-20
+TXN_7302788,Coffee,1,2.0,2.0,Cash,In-store,2023-09-18
+TXN_9233948,Cookie,4,1.0,4.0,Cash,,2023-03-26
+TXN_1510673,Juice,3,3.0,9.0,,ERROR,2023-02-26
+TXN_9867586,Smoothie,4,4.0,16.0,,In-store,2023-06-02
+TXN_1750875,Juice,3,3.0,9.0,,,2023-12-13
+TXN_6397944,Salad,5,5.0,25.0,,UNKNOWN,2023-10-31
+TXN_5216430,Cookie,3,,3.0,,UNKNOWN,2023-02-05
+TXN_2723755,Juice,3,3.0,9.0,Cash,,2023-06-30
+TXN_2313646,Sandwich,3,4.0,12.0,,In-store,2023-08-24
+TXN_6327139,ERROR,4,4.0,16.0,,Takeaway,ERROR
+TXN_4028494,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-10-22
+TXN_1412415,Juice,3,3.0,9.0,Cash,In-store,2023-02-24
+TXN_7398884,ERROR,3,4.0,12.0,,Takeaway,2023-12-24
+TXN_6546131,Coffee,4,2.0,8.0,Credit Card,In-store,2023-06-26
+TXN_9030656,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-12-12
+TXN_1950777,Salad,5,5.0,25.0,Cash,Takeaway,2023-08-26
+TXN_4605239,Coffee,1,2.0,2.0,Credit Card,,2023-08-06
+TXN_8019396,Sandwich,3,4.0,12.0,,,2023-10-20
+TXN_3716685,,5,4.0,20.0,Digital Wallet,Takeaway,ERROR
+TXN_1580822,Juice,5,3.0,15.0,Credit Card,,ERROR
+TXN_5060289,Tea,5,1.5,7.5,Credit Card,UNKNOWN,
+TXN_7874772,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-04-26
+TXN_2625464,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-10-06
+TXN_9338442,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-12-29
+TXN_2953908,Coffee,5,2.0,10.0,Credit Card,In-store,2023-10-11
+TXN_2576936,Cake,3,3.0,9.0,Cash,,2023-10-14
+TXN_4586482,Juice,3,3.0,9.0,,In-store,2023-09-04
+TXN_3660806,Cookie,5,UNKNOWN,5.0,,Takeaway,2023-02-14
+TXN_8069514,Smoothie,4,4.0,16.0,Credit Card,,
+TXN_6410244,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-01-06
+TXN_5026431,,5,4.0,20.0,Cash,,2023-12-05
+TXN_3106348,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-01-10
+TXN_6216278,Coffee,4,2.0,8.0,Credit Card,In-store,2023-11-06
+TXN_9947324,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-08-22
+TXN_9531434,Cookie,1,1.0,UNKNOWN,Credit Card,Takeaway,2023-10-09
+TXN_4104718,Cookie,2,1.0,2.0,Cash,,2023-11-08
+TXN_5789560,Juice,2,3.0,6.0,Cash,Takeaway,2023-02-13
+TXN_8285752,Cookie,4,1.0,4.0,,In-store,2023-01-07
+TXN_8099340,UNKNOWN,4,1.5,6.0,,In-store,2023-04-23
+TXN_7733300,Smoothie,2,4.0,8.0,Cash,Takeaway,2023-12-10
+TXN_4416331,Cookie,1,1.0,1.0,,Takeaway,2023-02-13
+TXN_3551665,Juice,4,3.0,12.0,Credit Card,In-store,2023-04-06
+TXN_7377496,UNKNOWN,1,3.0,3.0,Credit Card,Takeaway,2023-02-28
+TXN_4637438,Salad,2,5.0,10.0,,Takeaway,2023-04-07
+TXN_5493965,Juice,1,3.0,3.0,,,2023-06-16
+TXN_2525207,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-25
+TXN_7354480,Cake,2,3.0,6.0,Cash,,2023-01-17
+TXN_6819128,Salad,1,5.0,5.0,Cash,,2023-10-19
+TXN_5023419,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-02-26
+TXN_9864890,Sandwich,3,4.0,12.0,,In-store,2023-12-06
+TXN_8798330,,1,2.0,2.0,,In-store,2023-02-16
+TXN_9951411,Coffee,1,2.0,2.0,Cash,In-store,2023-08-09
+TXN_6755795,Smoothie,5,4.0,20.0,Cash,UNKNOWN,2023-02-22
+TXN_7507071,Smoothie,2,4.0,8.0,,In-store,2023-01-10
+TXN_1018470,Juice,3,3.0,9.0,,ERROR,2023-01-14
+TXN_2924262,Cookie,5,1.0,5.0,,,2023-09-01
+TXN_6472242,Sandwich,1,4.0,4.0,,,2023-03-27
+TXN_8482647,Sandwich,5,4.0,20.0,Credit Card,,2023-01-08
+TXN_6994354,Salad,5,5.0,25.0,,Takeaway,2023-07-03
+TXN_3520910,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-05-06
+TXN_8589003,Tea,4,1.5,,Cash,UNKNOWN,2023-08-25
+TXN_3219263,Smoothie,5,4.0,20.0,UNKNOWN,Takeaway,2023-03-31
+TXN_9619442,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-05-23
+TXN_1050323,Juice,1,3.0,3.0,,In-store,2023-03-10
+TXN_8379815,Smoothie,5,,20.0,Credit Card,,2023-07-31
+TXN_6746916,Coffee,1,2.0,2.0,Cash,Takeaway,2023-11-15
+TXN_1547717,Sandwich,5,4.0,,,,2023-12-15
+TXN_8407982,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-09-17
+TXN_3484276,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-06-14
+TXN_3705669,Tea,2,1.5,3.0,ERROR,,2023-11-23
+TXN_4105487,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-04-13
+TXN_6856558,Juice,4,3.0,12.0,,Takeaway,2023-10-30
+TXN_3669990,Tea,2,1.5,3.0,Cash,Takeaway,2023-01-27
+TXN_5994713,Tea,3,1.5,4.5,,Takeaway,2023-03-05
+TXN_8091357,Coffee,1,2.0,2.0,Cash,UNKNOWN,2023-12-28
+TXN_9555958,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-09-30
+TXN_4194085,Salad,1,5.0,5.0,Credit Card,,2023-05-25
+TXN_7780748,Cookie,3,1.0,3.0,Credit Card,In-store,2023-01-19
+TXN_7914340,Tea,UNKNOWN,1.5,1.5,,ERROR,2023-09-04
+TXN_7780786,Cake,1,3.0,3.0,Credit Card,,2023-10-30
+TXN_1048284,Salad,2,5.0,10.0,Cash,In-store,2023-08-19
+TXN_3301517,Salad,UNKNOWN,5.0,25.0,Credit Card,In-store,2023-04-13
+TXN_3120848,Cookie,1,1.0,1.0,Cash,In-store,2023-11-01
+TXN_3764807,Smoothie,2,,8.0,,,2023-08-28
+TXN_3315467,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-11-17
+TXN_9363990,Cake,3,3.0,,Credit Card,UNKNOWN,2023-01-17
+TXN_9666257,Juice,2,3.0,6.0,,In-store,2023-09-27
+TXN_1504466,Coffee,1,2.0,2.0,Cash,,2023-11-07
+TXN_3324387,UNKNOWN,1,4.0,4.0,Credit Card,,2023-12-13
+TXN_7603895,Smoothie,5,4.0,20.0,Credit Card,In-store,UNKNOWN
+TXN_1477525,Salad,3,5.0,15.0,Cash,Takeaway,2023-11-06
+TXN_9063624,Coffee,1,2.0,2.0,Credit Card,UNKNOWN,2023-04-21
+TXN_1595139,Smoothie,5,4.0,20.0,Cash,,2023-08-24
+TXN_8606912,Salad,5,ERROR,25.0,Digital Wallet,,2023-03-10
+TXN_8548232,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-06-21
+TXN_6074414,Salad,2,5.0,10.0,Credit Card,ERROR,2023-11-13
+TXN_2010658,Smoothie,3,4.0,12.0,,ERROR,2023-02-20
+TXN_5070577,Cookie,,1.0,4.0,Credit Card,Takeaway,2023-02-07
+TXN_5426236,,3,4.0,12.0,Cash,Takeaway,2023-08-31
+TXN_8867957,Sandwich,1,4.0,4.0,Digital Wallet,,2023-01-04
+TXN_3241422,Salad,2,5.0,10.0,Cash,Takeaway,2023-07-17
+TXN_6036254,ERROR,3,2.0,6.0,Credit Card,,2023-09-20
+TXN_3580048,Smoothie,5,,20.0,,,2023-05-17
+TXN_2756336,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-07-07
+TXN_9691873,Juice,2,ERROR,6.0,Digital Wallet,Takeaway,2023-02-15
+TXN_2466187,Coffee,2,2.0,4.0,,Takeaway,2023-04-18
+TXN_9699116,Cookie,2,1.0,2.0,Digital Wallet,In-store,
+TXN_7964520,Coffee,1,2.0,2.0,,In-store,2023-03-26
+TXN_3185667,Tea,5,UNKNOWN,7.5,Digital Wallet,,2023-12-26
+TXN_8167741,Sandwich,4,4.0,16.0,,Takeaway,2023-09-09
+TXN_1015883,Cookie,4,1.0,4.0,Cash,In-store,2023-10-16
+TXN_8838566,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-07-25
+TXN_2423343,Tea,4,1.5,6.0,ERROR,In-store,2023-09-25
+TXN_1496038,Juice,4,3.0,12.0,,In-store,2023-12-22
+TXN_9484436,Salad,1,,5.0,Credit Card,In-store,2023-01-20
+TXN_7670699,Juice,1,3.0,3.0,Cash,In-store,2023-12-24
+TXN_7765640,ERROR,ERROR,2.0,2.0,Credit Card,,2023-07-07
+TXN_5412418,,3,3.0,9.0,Cash,,2023-09-23
+TXN_2053631,Salad,1,5.0,5.0,Credit Card,,2023-03-21
+TXN_3632064,Cookie,5,1.0,5.0,Cash,,2023-02-12
+TXN_4254587,Smoothie,1,4.0,4.0,Digital Wallet,,2023-05-27
+TXN_9605972,Cake,3,3.0,9.0,,ERROR,2023-09-30
+TXN_1323030,Salad,4,5.0,20.0,,In-store,2023-03-30
+TXN_7989903,Juice,2,3.0,6.0,Cash,,2023-06-19
+TXN_7423885,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-09-06
+TXN_1495371,Sandwich,2,4.0,ERROR,Credit Card,Takeaway,2023-07-21
+TXN_8934025,Cookie,2,1.0,2.0,,,2023-12-18
+TXN_7515290,Smoothie,UNKNOWN,4.0,12.0,Digital Wallet,,2023-12-23
+TXN_3711520,Tea,1,1.5,1.5,,In-store,2023-06-29
+TXN_3841683,Sandwich,1,4.0,4.0,UNKNOWN,In-store,2023-06-20
+TXN_9100530,Sandwich,3,4.0,12.0,Digital Wallet,,2023-05-21
+TXN_3112013,Sandwich,5,4.0,20.0,Cash,In-store,2023-01-06
+TXN_7786787,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-07-08
+TXN_7160196,Sandwich,1,4.0,4.0,,In-store,2023-12-06
+TXN_4634894,Coffee,1,2.0,2.0,,,2023-12-09
+TXN_8214944,UNKNOWN,3,1.5,4.5,Credit Card,In-store,2023-11-18
+TXN_1080377,Cake,2,3.0,6.0,ERROR,,2023-04-08
+TXN_8566683,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-08-09
+TXN_2784588,Juice,2,3.0,6.0,Cash,Takeaway,2023-03-26
+TXN_6110769,Cookie,2,1.0,2.0,,,2023-03-02
+TXN_9999124,Juice,2,3.0,6.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_1637334,ERROR,2,1.5,3.0,Credit Card,In-store,2023-08-09
+TXN_9514452,ERROR,5,,10.0,Credit Card,Takeaway,2023-07-29
+TXN_8787350,Sandwich,5,4.0,20.0,,,2023-05-21
+TXN_7533675,Smoothie,3,4.0,12.0,,In-store,2023-10-28
+TXN_2264601,Tea,1,1.5,1.5,,,2023-01-21
+TXN_6024139,Juice,4,3.0,12.0,Digital Wallet,UNKNOWN,2023-08-15
+TXN_9841397,Coffee,4,2.0,8.0,Cash,In-store,2023-12-28
+TXN_7302991,,4,4.0,16.0,Digital Wallet,Takeaway,2023-04-05
+TXN_6093331,Smoothie,2,4.0,8.0,Credit Card,,2023-06-24
+TXN_3087096,Tea,3,,4.5,Cash,,2023-08-19
+TXN_8324315,Salad,1,5.0,5.0,,,2023-08-07
+TXN_8933679,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-09-24
+TXN_3528653,Cake,1,3.0,3.0,UNKNOWN,,2023-02-26
+TXN_4256155,Cake,5,3.0,15.0,,Takeaway,2023-04-06
+TXN_7186675,Cookie,4,1.0,4.0,Cash,,2023-11-09
+TXN_5295223,ERROR,5,5.0,25.0,Cash,In-store,2023-03-23
+TXN_8578861,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-05-16
+TXN_8028042,Coffee,3,2.0,6.0,,,2023-04-05
+TXN_4021467,Coffee,2,2.0,4.0,,Takeaway,2023-04-02
+TXN_4807037,Salad,5,5.0,25.0,Cash,In-store,2023-12-08
+TXN_3975938,Sandwich,3,4.0,12.0,Credit Card,,2023-09-04
+TXN_3312653,Cookie,5,1.0,5.0,Cash,Takeaway,2023-12-09
+TXN_1405498,Juice,2,3.0,6.0,UNKNOWN,Takeaway,2023-12-31
+TXN_6571288,Sandwich,2,4.0,8.0,Credit Card,,2023-10-23
+TXN_7560210,Juice,5,3.0,15.0,ERROR,Takeaway,2023-02-21
+TXN_2905234,Cookie,1,1.0,1.0,Credit Card,,2023-09-24
+TXN_3630981,Coffee,2,2.0,4.0,,In-store,2023-10-31
+TXN_3339728,Juice,5,3.0,15.0,,In-store,2023-05-13
+TXN_3826298,Cookie,3,1.0,3.0,,,2023-11-28
+TXN_7854306,Sandwich,1,4.0,4.0,Cash,In-store,2023-09-17
+TXN_6034709,UNKNOWN,2,2.0,4.0,Credit Card,,2023-06-16
+TXN_3072565,Juice,3,3.0,ERROR,Credit Card,,2023-07-09
+TXN_9544977,Cookie,4,1.0,4.0,,In-store,2023-07-04
+TXN_9924421,Cake,5,3.0,15.0,Credit Card,,UNKNOWN
+TXN_8374101,Salad,5,5.0,25.0,Credit Card,,2023-08-16
+TXN_5814878,Smoothie,2,4.0,8.0,Digital Wallet,,2023-04-02
+TXN_2398895,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-04-04
+TXN_1205020,Tea,5,1.5,7.5,Cash,,2023-10-03
+TXN_4620459,Sandwich,5,4.0,20.0,Cash,ERROR,
+TXN_1631377,Coffee,5,2.0,10.0,,Takeaway,2023-06-07
+TXN_6368424,Cookie,3,1.0,3.0,,,ERROR
+TXN_8116676,Cake,2,3.0,6.0,Digital Wallet,,2023-09-16
+TXN_4116036,Salad,2,ERROR,10.0,Credit Card,In-store,2023-01-22
+TXN_3172090,Juice,1,3.0,3.0,Credit Card,,2023-05-09
+TXN_5193568,Juice,3,3.0,9.0,Cash,,2023-12-10
+TXN_3725152,Coffee,5,2.0,10.0,,,2023-07-08
+TXN_8724711,Salad,3,5.0,15.0,Cash,In-store,2023-02-07
+TXN_9477344,UNKNOWN,2,1.0,2.0,Credit Card,In-store,2023-09-30
+TXN_5899361,Cake,1,3.0,3.0,Credit Card,,2023-08-08
+TXN_8261380,Cake,3,3.0,9.0,Cash,In-store,2023-10-01
+TXN_1188551,UNKNOWN,2,2.0,4.0,,,2023-03-20
+TXN_1887250,Tea,3,1.5,ERROR,,Takeaway,2023-05-15
+TXN_4799873,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-03-04
+TXN_9691151,Coffee,4,2.0,8.0,,In-store,2023-08-23
+TXN_3014261,Salad,4,5.0,20.0,Cash,In-store,2023-11-29
+TXN_9987991,Smoothie,ERROR,4.0,16.0,Credit Card,Takeaway,2023-02-21
+TXN_1093668,Coffee,2,2.0,4.0,Digital Wallet,ERROR,2023-05-18
+TXN_8279966,Coffee,UNKNOWN,2.0,6.0,Cash,In-store,2023-08-24
+TXN_3977835,Tea,5,ERROR,7.5,,In-store,2023-05-06
+TXN_1758689,Smoothie,3,4.0,12.0,Cash,ERROR,2023-02-17
+TXN_4312977,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-03-15
+TXN_6503526,Cookie,5,ERROR,5.0,Credit Card,In-store,2023-10-20
+TXN_8676485,Salad,2,5.0,10.0,,In-store,2023-04-28
+TXN_7176851,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-11-20
+TXN_8695037,Smoothie,ERROR,4.0,8.0,UNKNOWN,,2023-01-24
+TXN_6632882,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-04-30
+TXN_7775016,Sandwich,5,4.0,20.0,Cash,In-store,2023-09-27
+TXN_2176024,Coffee,5,ERROR,10.0,Digital Wallet,In-store,2023-02-03
+TXN_7051683,ERROR,3,3.0,9.0,Digital Wallet,In-store,2023-11-16
+TXN_3670041,Smoothie,3,4.0,12.0,Digital Wallet,,2023-03-22
+TXN_5124080,Cookie,1,1.0,1.0,Credit Card,In-store,2023-01-14
+TXN_3317649,Sandwich,3,4.0,12.0,ERROR,Takeaway,2023-11-06
+TXN_3953316,Cookie,2,1.0,2.0,Digital Wallet,,2023-06-06
+TXN_6160209,Salad,3,5.0,15.0,,In-store,2023-07-28
+TXN_7089316,Tea,2,1.5,3.0,Cash,In-store,2023-11-27
+TXN_5421310,Coffee,ERROR,2.0,8.0,Digital Wallet,In-store,2023-06-10
+TXN_9081409,ERROR,1,3.0,UNKNOWN,Credit Card,In-store,2023-06-16
+TXN_6850528,Cookie,3,1.0,3.0,Cash,In-store,2023-10-13
+TXN_6900182,Smoothie,3,4.0,UNKNOWN,Cash,In-store,2023-09-10
+TXN_2643748,Salad,3,5.0,15.0,Cash,,2023-11-28
+TXN_4858908,Cake,2,3.0,6.0,Cash,In-store,2023-02-11
+TXN_8972137,ERROR,4,3.0,12.0,Credit Card,In-store,2023-05-15
+TXN_2828785,Smoothie,1,4.0,4.0,,In-store,2023-01-24
+TXN_3489721,Coffee,3,2.0,UNKNOWN,Cash,,2023-09-27
+TXN_4791031,Coffee,UNKNOWN,2.0,10.0,Cash,,UNKNOWN
+TXN_5223702,Smoothie,4,4.0,16.0,Credit Card,,2023-06-23
+TXN_2788676,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-05
+TXN_1643447,,1,3.0,3.0,ERROR,,2023-09-03
+TXN_5172164,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-09-13
+TXN_2818867,Salad,3,5.0,15.0,Cash,,2023-01-11
+TXN_1303984,Salad,4,5.0,20.0,Digital Wallet,,2023-07-24
+TXN_3373078,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-12-01
+TXN_3982146,Coffee,3,2.0,6.0,,In-store,2023-07-09
+TXN_1185156,Smoothie,4,4.0,16.0,,Takeaway,2023-03-23
+TXN_6720290,Smoothie,1,4.0,4.0,,In-store,2023-01-25
+TXN_9365447,,2,1.5,3.0,Cash,,2023-12-10
+TXN_7701878,Smoothie,4,4.0,16.0,Credit Card,In-store,2023-08-11
+TXN_7677817,,UNKNOWN,2.0,2.0,Credit Card,,2023-01-17
+TXN_9983530,Smoothie,3,4.0,12.0,,,2023-01-04
+TXN_4755934,Tea,2,1.5,3.0,Cash,,2023-12-29
+TXN_2931198,Cake,2,3.0,6.0,Credit Card,In-store,2023-04-21
+TXN_7426387,Smoothie,5,4.0,20.0,Cash,,2023-10-30
+TXN_3182547,Juice,,3.0,9.0,Digital Wallet,Takeaway,2023-07-28
+TXN_6980463,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-09-03
+TXN_6708165,Juice,5,3.0,15.0,ERROR,In-store,2023-10-19
+TXN_4310629,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-10-02
+TXN_4650611,Coffee,1,2.0,2.0,Credit Card,,2023-10-14
+TXN_7952232,Tea,4,1.5,6.0,Cash,,2023-03-31
+TXN_1593691,Sandwich,2,4.0,8.0,,,2023-03-11
+TXN_9432007,Cookie,4,1.0,4.0,,,ERROR
+TXN_3781198,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-11-04
+TXN_3585464,Cookie,3,1.0,3.0,,Takeaway,2023-09-12
+TXN_8286164,Smoothie,1,4.0,UNKNOWN,,In-store,2023-03-08
+TXN_8851113,Tea,3,1.5,4.5,Digital Wallet,,2023-12-23
+TXN_9131136,Juice,2,3.0,6.0,Credit Card,UNKNOWN,2023-03-20
+TXN_8872160,Salad,5,5.0,25.0,Digital Wallet,,UNKNOWN
+TXN_1449065,Salad,2,5.0,10.0,Cash,,2023-10-03
+TXN_1230311,Juice,3,3.0,9.0,Digital Wallet,UNKNOWN,2023-08-14
+TXN_2325484,Salad,1,UNKNOWN,5.0,Digital Wallet,Takeaway,2023-08-16
+TXN_2647425,Juice,4,3.0,12.0,Credit Card,ERROR,2023-07-30
+TXN_5525916,Coffee,2,2.0,4.0,Cash,Takeaway,2023-03-02
+TXN_4297979,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-08-14
+TXN_1686323,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-11-30
+TXN_5373154,Cake,3,3.0,9.0,Digital Wallet,,2023-04-06
+TXN_6225571,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-09-13
+TXN_9772556,Coffee,5,2.0,10.0,,,2023-10-20
+TXN_3033598,Sandwich,5,4.0,ERROR,Cash,Takeaway,2023-03-12
+TXN_4382956,UNKNOWN,4,1.5,6.0,Credit Card,,2023-11-16
+TXN_8117583,Salad,1,5.0,5.0,Cash,In-store,2023-02-25
+TXN_1101527,Smoothie,UNKNOWN,4.0,20.0,Digital Wallet,,2023-04-20
+TXN_2118759,Coffee,2,2.0,4.0,Digital Wallet,,2023-08-07
+TXN_7603948,Cake,3,3.0,9.0,Credit Card,,2023-01-28
+TXN_5519424,Tea,2,1.5,3.0,Digital Wallet,,2023-09-23
+TXN_3483911,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-07-10
+TXN_5447967,Smoothie,2,ERROR,8.0,Credit Card,,2023-06-06
+TXN_2893987,Cake,4,,12.0,,Takeaway,2023-05-31
+TXN_5120215,Coffee,2,2.0,4.0,Digital Wallet,,2023-10-29
+TXN_4417257,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-05-06
+TXN_2871592,Cookie,4,1.0,4.0,Cash,In-store,2023-08-07
+TXN_8283199,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-01-23
+TXN_1571874,Cake,1,3.0,3.0,Digital Wallet,ERROR,2023-07-10
+TXN_8059782,Cake,5,3.0,15.0,,Takeaway,ERROR
+TXN_6534833,Salad,4,5.0,UNKNOWN,Digital Wallet,In-store,2023-12-14
+TXN_6027500,Smoothie,4,4.0,16.0,,,2023-09-22
+TXN_7029944,Cookie,2,1.0,2.0,Cash,Takeaway,2023-04-17
+TXN_3075169,Sandwich,UNKNOWN,4.0,8.0,Credit Card,In-store,2023-06-25
+TXN_9791421,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-07-15
+TXN_6359031,Coffee,1,2.0,2.0,,,2023-02-28
+TXN_8236432,Salad,1,5.0,5.0,,,2023-12-04
+TXN_7359566,Coffee,1,2.0,2.0,Cash,In-store,2023-04-06
+TXN_4813580,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-04-15
+TXN_9940829,Smoothie,3,4.0,12.0,,In-store,2023-04-04
+TXN_4583957,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-10-08
+TXN_8187222,Coffee,4,2.0,8.0,Credit Card,,2023-03-08
+TXN_1298084,UNKNOWN,2,1.5,3.0,Credit Card,Takeaway,2023-01-02
+TXN_4403699,,1,1.0,1.0,Credit Card,,2023-08-19
+TXN_5639908,Tea,ERROR,1.5,4.5,,In-store,
+TXN_9005782,Tea,4,1.5,ERROR,,In-store,2023-06-18
+TXN_5083311,Sandwich,4,4.0,16.0,Digital Wallet,,2023-04-30
+TXN_4325098,ERROR,5,3.0,15.0,,Takeaway,UNKNOWN
+TXN_8847610,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-12-06
+TXN_9817102,Coffee,3,2.0,6.0,Credit Card,In-store,2023-02-22
+TXN_5566774,Tea,3,1.5,4.5,UNKNOWN,In-store,2023-03-29
+TXN_5555790,Tea,5,ERROR,7.5,Credit Card,In-store,2023-02-19
+TXN_3575713,,,1.5,1.5,Cash,Takeaway,2023-02-18
+TXN_5811955,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-06-29
+TXN_3737378,Smoothie,1,4.0,4.0,Cash,,ERROR
+TXN_5406762,Salad,4,5.0,20.0,Credit Card,ERROR,2023-09-12
+TXN_3039985,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-04-08
+TXN_1424056,Smoothie,1,4.0,4.0,Cash,,2023-07-31
+TXN_1193221,Tea,3,1.5,4.5,Credit Card,In-store,2023-10-21
+TXN_8610501,Sandwich,5,4.0,20.0,Cash,UNKNOWN,2023-09-29
+TXN_9587445,Coffee,4,2.0,8.0,,In-store,2023-08-24
+TXN_3694901,Cookie,2,1.0,2.0,UNKNOWN,In-store,2023-08-16
+TXN_5749454,Juice,UNKNOWN,3.0,12.0,Digital Wallet,Takeaway,2023-12-04
+TXN_8356048,,5,4.0,20.0,Cash,Takeaway,2023-06-05
+TXN_3480278,Smoothie,4,,16.0,Digital Wallet,In-store,2023-12-26
+TXN_9252414,Tea,1,,1.5,,In-store,2023-11-13
+TXN_3010103,ERROR,5,4.0,20.0,,,2023-02-14
+TXN_6699408,Cookie,5,1.0,5.0,Cash,Takeaway,2023-12-22
+TXN_6400351,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-08-11
+TXN_1559512,Juice,5,,15.0,Credit Card,,2023-11-28
+TXN_6091543,Coffee,3,2.0,UNKNOWN,,In-store,2023-07-04
+TXN_2842641,Cake,1,3.0,3.0,,In-store,2023-06-11
+TXN_8875043,Salad,4,5.0,20.0,Digital Wallet,,2023-02-21
+TXN_8212783,Salad,3,ERROR,15.0,Credit Card,In-store,2023-03-30
+TXN_2653400,Smoothie,1,4.0,,Cash,,ERROR
+TXN_7343062,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-08-11
+TXN_2535099,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-02-10
+TXN_2951148,Sandwich,4,4.0,16.0,Cash,In-store,2023-02-21
+TXN_1294101,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-03-31
+TXN_5579227,Smoothie,UNKNOWN,4.0,16.0,Digital Wallet,,2023-06-22
+TXN_8534360,Juice,5,3.0,15.0,ERROR,,2023-02-15
+TXN_4336247,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-03-03
+TXN_7101384,Coffee,1,,2.0,,UNKNOWN,2023-04-23
+TXN_1356599,Cookie,2,1.0,2.0,Cash,Takeaway,2023-12-14
+TXN_4568452,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-01-14
+TXN_5036856,Coffee,5,2.0,10.0,Cash,In-store,2023-03-27
+TXN_6927392,Salad,3,5.0,15.0,Digital Wallet,In-store,ERROR
+TXN_5167925,Juice,1,3.0,3.0,,,2023-09-11
+TXN_1345440,Salad,5,5.0,25.0,Cash,,2023-06-20
+TXN_8043218,Salad,2,5.0,10.0,Cash,In-store,2023-10-23
+TXN_4026277,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-08-27
+TXN_4991731,Tea,,1.5,1.5,Digital Wallet,Takeaway,2023-11-07
+TXN_6196052,Smoothie,5,4.0,UNKNOWN,Cash,Takeaway,2023-04-07
+TXN_9563024,Cookie,3,ERROR,3.0,Digital Wallet,In-store,2023-09-27
+TXN_8326905,Coffee,5,2.0,10.0,,Takeaway,2023-03-10
+TXN_3474333,,3,3.0,9.0,Credit Card,Takeaway,2023-01-13
+TXN_9918597,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-10-17
+TXN_3460926,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-03-25
+TXN_2671272,Smoothie,1,4.0,4.0,Digital Wallet,,2023-02-13
+TXN_8437157,Smoothie,4,4.0,16.0,Credit Card,,2023-02-09
+TXN_3401287,UNKNOWN,3,4.0,12.0,Cash,,2023-02-12
+TXN_7309365,Cake,2,3.0,6.0,Cash,,2023-08-31
+TXN_2175096,UNKNOWN,1,1.5,1.5,,In-store,2023-02-25
+TXN_8872997,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-01-31
+TXN_8425085,Juice,1,3.0,3.0,Credit Card,,2023-12-23
+TXN_3237919,Sandwich,1,4.0,4.0,,,2023-02-04
+TXN_4713643,Coffee,5,ERROR,10.0,,,2023-08-10
+TXN_4806003,Cookie,5,1.0,5.0,Credit Card,,2023-08-06
+TXN_9089797,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-09-19
+TXN_5449092,Juice,4,3.0,12.0,,,2023-06-11
+TXN_6097144,Juice,5,3.0,15.0,,Takeaway,2023-01-27
+TXN_6483589,Juice,3,3.0,9.0,Digital Wallet,,2023-10-13
+TXN_8516055,UNKNOWN,5,4.0,20.0,Credit Card,Takeaway,2023-04-17
+TXN_5430694,Salad,UNKNOWN,5.0,25.0,,,2023-08-24
+TXN_3024493,Smoothie,1,4.0,4.0,Credit Card,In-store,
+TXN_2078232,Tea,1,1.5,1.5,UNKNOWN,,2023-06-11
+TXN_7551689,Cookie,5,1.0,5.0,Cash,,2023-09-16
+TXN_8408103,Sandwich,5,4.0,UNKNOWN,UNKNOWN,Takeaway,2023-06-01
+TXN_5862795,Salad,2,ERROR,10.0,Digital Wallet,,2023-02-25
+TXN_9348801,Cake,1,3.0,3.0,,,2023-11-29
+TXN_8688565,Smoothie,5,4.0,20.0,Digital Wallet,ERROR,2023-05-23
+TXN_3067195,Salad,3,5.0,15.0,Cash,,2023-12-03
+TXN_2710603,Smoothie,5,4.0,20.0,,Takeaway,2023-02-02
+TXN_8978004,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-04-01
+TXN_9679889,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-06-18
+TXN_9818163,Tea,2,UNKNOWN,3.0,Digital Wallet,ERROR,2023-10-23
+TXN_7010020,Cake,5,UNKNOWN,15.0,,In-store,2023-08-07
+TXN_1712662,Juice,2,3.0,6.0,Cash,UNKNOWN,2023-05-31
+TXN_4077799,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-08-12
+TXN_8225571,Tea,4,,6.0,Digital Wallet,,2023-01-17
+TXN_3103520,Cake,3,3.0,9.0,,,2023-09-04
+TXN_2084080,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-09-22
+TXN_2740398,Cookie,4,1.0,4.0,Digital Wallet,In-store,ERROR
+TXN_8046057,Coffee,1,2.0,2.0,Credit Card,In-store,2023-11-24
+TXN_5832968,Salad,5,5.0,25.0,ERROR,Takeaway,2023-06-05
+TXN_6995665,Tea,2,1.5,3.0,UNKNOWN,,ERROR
+TXN_3752448,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-05-16
+TXN_3842881,Salad,5,5.0,25.0,,UNKNOWN,2023-01-25
+TXN_4060160,Coffee,4,2.0,8.0,,In-store,2023-07-05
+TXN_3847405,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-06-15
+TXN_5103644,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-04-17
+TXN_6846020,Juice,5,ERROR,15.0,ERROR,Takeaway,2023-05-03
+TXN_7763764,Cookie,2,1.0,2.0,ERROR,In-store,ERROR
+TXN_4758849,Cake,2,3.0,6.0,,,2023-06-23
+TXN_1034651,Sandwich,3,4.0,12.0,,Takeaway,2023-07-06
+TXN_4128921,Salad,4,5.0,20.0,,Takeaway,2023-09-11
+TXN_8925566,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-08-07
+TXN_1679800,Smoothie,4,4.0,16.0,Cash,In-store,2023-10-17
+TXN_3785678,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-03-13
+TXN_1056256,Cake,4,3.0,12.0,UNKNOWN,In-store,2023-12-04
+TXN_8712303,ERROR,2,3.0,6.0,Credit Card,Takeaway,2023-08-14
+TXN_2289122,Smoothie,4,4.0,16.0,Cash,In-store,2023-08-20
+TXN_2988434,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-12-09
+TXN_1197536,Salad,3,5.0,15.0,,Takeaway,2023-10-02
+TXN_7327362,Coffee,5,2.0,10.0,Credit Card,In-store,2023-06-29
+TXN_5628251,Cake,4,3.0,12.0,Credit Card,,2023-11-14
+TXN_2687748,Juice,3,3.0,9.0,,Takeaway,2023-02-26
+TXN_8309656,Sandwich,3,4.0,12.0,,Takeaway,2023-01-04
+TXN_7597276,Smoothie,4,4.0,16.0,Digital Wallet,,2023-05-01
+TXN_4360906,Sandwich,2,4.0,8.0,,In-store,2023-06-11
+TXN_6000890,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-01-06
+TXN_8917565,Coffee,1,2.0,2.0,Cash,ERROR,2023-11-19
+TXN_6264113,Coffee,4,2.0,8.0,,,2023-12-02
+TXN_3603434,Coffee,5,2.0,10.0,,In-store,2023-01-05
+TXN_7976129,Cake,3,3.0,9.0,,In-store,2023-03-03
+TXN_7420434,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-07-16
+TXN_5818852,Juice,2,3.0,6.0,,,2023-03-04
+TXN_9976598,Juice,4,3.0,12.0,,Takeaway,2023-01-10
+TXN_1556046,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-04-09
+TXN_7129511,Coffee,5,2.0,10.0,Cash,Takeaway,2023-10-29
+TXN_6324434,Coffee,4,2.0,8.0,Cash,Takeaway,2023-12-04
+TXN_2380352,Tea,3,1.5,4.5,Digital Wallet,,2023-11-03
+TXN_6455325,Juice,4,3.0,12.0,Credit Card,In-store,2023-01-05
+TXN_6682253,Tea,5,1.5,7.5,Cash,In-store,2023-02-17
+TXN_8220657,ERROR,2,1.5,,Cash,,2023-08-13
+TXN_7819240,Smoothie,5,4.0,20.0,Cash,In-store,2023-03-06
+TXN_4451380,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-07-10
+TXN_2482298,Salad,2,5.0,10.0,,Takeaway,2023-06-15
+TXN_2606750,Tea,3,1.5,4.5,Cash,ERROR,2023-06-20
+TXN_4493874,Cookie,5,1.0,UNKNOWN,,In-store,2023-11-19
+TXN_2705302,Salad,2,5.0,10.0,Credit Card,,2023-01-18
+TXN_3706167,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-10-02
+TXN_7414587,Tea,3,1.5,4.5,Cash,Takeaway,2023-03-22
+TXN_3360649,Cookie,2,1.0,2.0,,Takeaway,2023-09-10
+TXN_6132245,Salad,2,5.0,10.0,Digital Wallet,,2023-06-01
+TXN_2633322,Salad,4,ERROR,20.0,Digital Wallet,,2023-01-15
+TXN_9910333,Cake,2,3.0,6.0,,In-store,2023-09-15
+TXN_7321479,Cake,1,3.0,3.0,,ERROR,2023-10-31
+TXN_4315166,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-06-10
+TXN_7843112,Cookie,4,1.0,4.0,,UNKNOWN,2023-01-25
+TXN_2879791,Sandwich,1,4.0,4.0,,,2023-07-10
+TXN_2503128,Cake,1,3.0,3.0,Cash,In-store,2023-01-12
+TXN_3091574,Cookie,5,1.0,5.0,ERROR,In-store,2023-07-29
+TXN_2371763,Sandwich,4,4.0,16.0,Cash,,2023-05-17
+TXN_5726114,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-07-14
+TXN_1079844,Salad,2,5.0,10.0,Digital Wallet,,2023-10-27
+TXN_8726097,Tea,1,1.5,1.5,Digital Wallet,Takeaway,ERROR
+TXN_1633337,Salad,5,5.0,25.0,Credit Card,,2023-06-29
+TXN_5222176,Cookie,4,1.0,4.0,,In-store,2023-01-11
+TXN_7480940,Coffee,2,2.0,4.0,Cash,In-store,2023-01-25
+TXN_2437508,Salad,2,5.0,10.0,,Takeaway,2023-11-20
+TXN_7445500,Salad,4,5.0,20.0,Cash,In-store,
+TXN_5036614,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-10-10
+TXN_9731164,Salad,1,5.0,5.0,Cash,,2023-12-07
+TXN_1417291,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-05-11
+TXN_9792093,Sandwich,1,4.0,4.0,,In-store,2023-09-28
+TXN_9989239,Tea,5,1.5,,,In-store,2023-04-28
+TXN_6055570,Tea,3,1.5,4.5,Cash,,2023-02-06
+TXN_1231531,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-07-24
+TXN_8843108,Juice,5,3.0,15.0,,,2023-07-18
+TXN_4643305,Cookie,4,1.0,4.0,,Takeaway,2023-04-12
+TXN_8754977,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-10-24
+TXN_2052060,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-11-07
+TXN_1275124,Coffee,3,2.0,6.0,,UNKNOWN,2023-06-21
+TXN_3534536,Coffee,1,2.0,2.0,Credit Card,,2023-02-02
+TXN_1779679,Coffee,5,,10.0,,In-store,2023-01-06
+TXN_4583908,Sandwich,ERROR,4.0,4.0,Digital Wallet,,2023-06-04
+TXN_6379692,Cookie,5,,5.0,Digital Wallet,Takeaway,2023-11-05
+TXN_3999862,Tea,4,1.5,6.0,,In-store,2023-07-11
+TXN_7694326,Coffee,5,2.0,,,,2023-02-19
+TXN_1171080,Sandwich,3,4.0,12.0,Credit Card,,2023-07-29
+TXN_5658895,Juice,UNKNOWN,3.0,6.0,Cash,UNKNOWN,2023-09-21
+TXN_7704680,,2,5.0,10.0,Credit Card,,2023-08-06
+TXN_6395070,Smoothie,4,4.0,16.0,Credit Card,,2023-12-10
+TXN_9576454,Juice,1,3.0,3.0,Credit Card,In-store,2023-09-23
+TXN_7907259,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-10-19
+TXN_4487345,Sandwich,3,4.0,12.0,,In-store,2023-05-10
+TXN_5929341,Juice,2,3.0,6.0,,Takeaway,2023-05-12
+TXN_6021173,Juice,5,3.0,15.0,Cash,Takeaway,2023-12-16
+TXN_6272473,Coffee,4,2.0,8.0,Cash,Takeaway,2023-03-06
+TXN_5243032,Cookie,1,1.0,1.0,Cash,Takeaway,2023-08-24
+TXN_5863411,Cookie,3,1.0,UNKNOWN,Digital Wallet,In-store,2023-09-21
+TXN_4087571,Cookie,2,1.0,2.0,,,2023-11-24
+TXN_7680197,Cookie,5,1.0,5.0,Cash,Takeaway,2023-09-23
+TXN_8773639,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-02-20
+TXN_5960979,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-05-03
+TXN_7894534,Tea,3,1.5,4.5,Credit Card,In-store,2023-03-16
+TXN_4890770,Coffee,4,2.0,8.0,,Takeaway,2023-10-12
+TXN_6079741,Cookie,UNKNOWN,1.0,4.0,,Takeaway,2023-01-02
+TXN_4612930,Juice,2,3.0,6.0,,,2023-08-13
+TXN_1124311,Cookie,1,1.0,1.0,Cash,,2023-05-05
+TXN_6380636,Coffee,5,2.0,10.0,,ERROR,2023-01-10
+TXN_5720183,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-05-30
+TXN_6382322,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-12-14
+TXN_8119542,,2,1.0,2.0,Digital Wallet,,2023-12-12
+TXN_1674042,Coffee,5,2.0,10.0,Digital Wallet,,2023-09-19
+TXN_8398809,Tea,2,1.5,3.0,UNKNOWN,Takeaway,2023-11-25
+TXN_7728415,Tea,5,1.5,7.5,Credit Card,In-store,2023-12-28
+TXN_5285171,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-12-11
+TXN_2527007,Smoothie,1,4.0,4.0,Digital Wallet,,2023-10-22
+TXN_8331542,Salad,4,5.0,20.0,,In-store,2023-12-23
+TXN_2999220,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-02-23
+TXN_5108188,Cake,2,3.0,6.0,,,2023-08-25
+TXN_6680963,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-08-01
+TXN_2308317,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-11-13
+TXN_8811902,Tea,5,1.5,7.5,Credit Card,,2023-08-07
+TXN_7349134,UNKNOWN,1,4.0,4.0,Credit Card,In-store,2023-05-28
+TXN_1467546,Cookie,3,1.0,3.0,,Takeaway,2023-07-20
+TXN_2276722,Salad,2,5.0,10.0,Cash,Takeaway,2023-12-21
+TXN_2519044,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-05-20
+TXN_2851147,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-06-24
+TXN_3349404,Coffee,3,2.0,6.0,Digital Wallet,UNKNOWN,2023-01-31
+TXN_7939011,Juice,5,3.0,15.0,UNKNOWN,In-store,2023-04-07
+TXN_3877580,Salad,2,5.0,10.0,Digital Wallet,ERROR,2023-05-30
+TXN_5220523,Juice,3,3.0,9.0,Cash,Takeaway,2023-01-30
+TXN_5934526,Coffee,5,2.0,10.0,Credit Card,In-store,2023-05-27
+TXN_8935939,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-03-27
+TXN_3586935,Salad,5,5.0,25.0,Cash,,2023-05-21
+TXN_1781777,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-10-26
+TXN_6461461,Juice,1,3.0,3.0,,In-store,UNKNOWN
+TXN_1707251,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-10-06
+TXN_4493878,Coffee,5,,10.0,Credit Card,In-store,2023-03-11
+TXN_2446874,Juice,4,3.0,12.0,Credit Card,,2023-07-22
+TXN_5747859,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-03-13
+TXN_8172333,Cookie,4,1.0,4.0,Credit Card,,2023-12-25
+TXN_8600523,Tea,3,1.5,4.5,,,2023-12-29
+TXN_7471753,Smoothie,ERROR,4.0,20.0,Cash,In-store,2023-03-13
+TXN_3884527,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-06-06
+TXN_9072517,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-01-09
+TXN_4378200,Tea,5,1.5,7.5,Credit Card,In-store,2023-09-04
+TXN_3918998,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-12-18
+TXN_7674694,Tea,2,1.5,3.0,,,2023-03-30
+TXN_3875049,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-09-15
+TXN_5400266,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-06-14
+TXN_2402978,Cookie,3,1.0,3.0,Credit Card,In-store,2023-01-21
+TXN_6188306,Salad,1,5.0,5.0,,Takeaway,2023-10-26
+TXN_1148874,Cookie,1,1.0,1.0,Credit Card,In-store,2023-09-18
+TXN_1888708,Sandwich,4,4.0,,Cash,,2023-08-17
+TXN_8842592,Cookie,5,1.0,5.0,ERROR,,2023-07-10
+TXN_2761204,Cake,3,3.0,9.0,Cash,,2023-07-14
+TXN_9038745,Smoothie,3,4.0,12.0,ERROR,Takeaway,2023-06-25
+TXN_1374424,Sandwich,5,4.0,20.0,,,2023-04-24
+TXN_7205840,Salad,3,5.0,15.0,,,2023-03-05
+TXN_7714378,Smoothie,2,4.0,ERROR,Cash,,2023-08-10
+TXN_7732813,Tea,ERROR,1.5,3.0,Credit Card,Takeaway,2023-07-16
+TXN_6718205,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-06-30
+TXN_8878429,Cake,5,3.0,15.0,Digital Wallet,In-store,
+TXN_6899576,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-10-26
+TXN_2761003,Smoothie,2,4.0,UNKNOWN,ERROR,In-store,2023-11-08
+TXN_6929413,Tea,1,1.5,1.5,Digital Wallet,,2023-10-13
+TXN_2350703,UNKNOWN,4,3.0,12.0,Cash,In-store,2023-08-20
+TXN_1948437,Smoothie,2,4.0,8.0,,Takeaway,2023-11-03
+TXN_5901887,Smoothie,4,UNKNOWN,16.0,ERROR,Takeaway,2023-08-31
+TXN_1072232,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-01-07
+TXN_7469771,Cake,5,3.0,15.0,ERROR,,2023-12-09
+TXN_7139053,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-09-12
+TXN_6028915,Sandwich,5,UNKNOWN,20.0,Cash,In-store,2023-12-24
+TXN_3622194,Cake,1,3.0,3.0,Digital Wallet,,2023-06-26
+TXN_6431215,Cake,1,3.0,3.0,,ERROR,2023-08-27
+TXN_4385240,Cookie,4,1.0,4.0,Cash,Takeaway,2023-02-10
+TXN_3840523,,2,4.0,8.0,Credit Card,,2023-12-27
+TXN_5697778,Cake,3,3.0,9.0,Cash,,2023-03-08
+TXN_1749299,Smoothie,2,4.0,8.0,UNKNOWN,,2023-10-28
+TXN_6806024,Juice,,3.0,6.0,Credit Card,In-store,2023-04-14
+TXN_8352365,Coffee,5,2.0,10.0,,Takeaway,2023-08-10
+TXN_7143535,Cookie,2,1.0,2.0,,,2023-05-21
+TXN_5090839,Sandwich,5,4.0,20.0,Cash,,2023-03-06
+TXN_5743619,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-11-07
+TXN_8785432,Cookie,2,1.0,2.0,Cash,,2023-08-14
+TXN_1086324,Cake,3,3.0,9.0,,In-store,2023-11-25
+TXN_8888599,Sandwich,5,4.0,20.0,,,ERROR
+TXN_6361309,Cake,5,3.0,15.0,,Takeaway,UNKNOWN
+TXN_8211146,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-04-30
+TXN_5826333,Cookie,1,1.0,1.0,Cash,,2023-05-14
+TXN_1555314,Sandwich,1,4.0,4.0,,Takeaway,2023-02-25
+TXN_4611673,Smoothie,5,4.0,20.0,Digital Wallet,,2023-03-05
+TXN_8839045,Cake,2,3.0,6.0,,In-store,2023-06-13
+TXN_5183249,Sandwich,1,4.0,4.0,,In-store,2023-07-02
+TXN_5104848,Tea,2,1.5,3.0,,Takeaway,2023-01-22
+TXN_9943917,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-01-16
+TXN_2490461,Salad,4,5.0,20.0,,,2023-09-22
+TXN_5852244,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-10-15
+TXN_9874775,Tea,1,1.5,1.5,Cash,,2023-09-02
+TXN_2586215,Juice,2,3.0,6.0,Digital Wallet,,2023-03-23
+TXN_7704229,Coffee,UNKNOWN,2.0,8.0,Cash,,2023-07-15
+TXN_5444860,Tea,2,1.5,3.0,Digital Wallet,,2023-04-28
+TXN_9391494,Coffee,1,2.0,2.0,,,2023-12-17
+TXN_3557583,Smoothie,5,4.0,20.0,Credit Card,ERROR,2023-07-26
+TXN_8739878,UNKNOWN,1,3.0,3.0,,,2023-09-27
+TXN_5386352,ERROR,1,4.0,4.0,Credit Card,,2023-01-18
+TXN_8321887,UNKNOWN,5,1.0,5.0,,,2023-03-21
+TXN_3995266,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-04-21
+TXN_7326974,Cake,4,3.0,12.0,Credit Card,,2023-12-31
+TXN_7277750,Cake,2,3.0,6.0,,,2023-09-29
+TXN_8075323,Sandwich,1,4.0,4.0,Digital Wallet,,2023-04-18
+TXN_4831345,Sandwich,5,4.0,20.0,,In-store,2023-05-10
+TXN_6301984,Juice,5,3.0,15.0,,Takeaway,
+TXN_1456374,Cookie,5,1.0,5.0,Cash,,2023-02-15
+TXN_3263746,Coffee,1,2.0,2.0,Cash,Takeaway,2023-11-14
+TXN_2268203,Salad,3,5.0,15.0,,UNKNOWN,UNKNOWN
+TXN_9502077,Smoothie,3,4.0,12.0,,,2023-12-21
+TXN_4994052,Coffee,4,2.0,8.0,,Takeaway,
+TXN_1671480,Cookie,5,1.0,5.0,,,2023-01-06
+TXN_7430227,Cake,3,3.0,9.0,Cash,In-store,2023-07-24
+TXN_1516182,Cookie,1,1.0,1.0,,,2023-06-18
+TXN_8807199,Salad,5,5.0,25.0,Credit Card,,2023-05-30
+TXN_8700466,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-04-29
+TXN_2190325,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-03-10
+TXN_4150495,Cookie,2,1.0,2.0,Cash,,2023-04-12
+TXN_3794410,Cake,4,3.0,12.0,Credit Card,,2023-12-06
+TXN_5677869,Juice,5,3.0,15.0,Cash,In-store,2023-11-19
+TXN_3436462,Salad,2,5.0,10.0,Credit Card,In-store,2023-06-29
+TXN_7493740,Cake,1,3.0,3.0,,ERROR,2023-05-18
+TXN_7388752,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-08-28
+TXN_9448209,Sandwich,3,4.0,12.0,Cash,In-store,UNKNOWN
+TXN_8655424,Cookie,2,1.0,2.0,,In-store,2023-11-26
+TXN_9720012,Smoothie,5,4.0,20.0,Cash,In-store,2023-09-25
+TXN_6609572,ERROR,4,4.0,16.0,Cash,In-store,2023-06-15
+TXN_9390188,Tea,1,1.5,1.5,,Takeaway,2023-06-20
+TXN_1952465,Cake,2,3.0,6.0,,Takeaway,2023-06-11
+TXN_7605154,Juice,5,3.0,15.0,Cash,In-store,2023-09-09
+TXN_2684400,Coffee,3,2.0,6.0,UNKNOWN,In-store,2023-03-30
+TXN_4702378,Cake,2,3.0,6.0,Cash,UNKNOWN,2023-08-28
+TXN_6312755,Sandwich,2,4.0,8.0,Credit Card,,2023-02-11
+TXN_7584025,Tea,4,1.5,6.0,,In-store,2023-09-18
+TXN_7533540,Sandwich,5,4.0,20.0,,In-store,2023-11-01
+TXN_4425164,Juice,4,3.0,12.0,,,2023-01-13
+TXN_4325648,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-05-04
+TXN_7151374,Tea,4,1.5,6.0,Credit Card,In-store,2023-07-30
+TXN_6413250,Salad,ERROR,5.0,20.0,Cash,UNKNOWN,2023-12-02
+TXN_6496506,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-01-11
+TXN_2695546,Tea,UNKNOWN,1.5,1.5,Credit Card,Takeaway,2023-08-26
+TXN_4823513,Cookie,5,1.0,UNKNOWN,Cash,Takeaway,2023-07-02
+TXN_8960347,Smoothie,UNKNOWN,4.0,12.0,Cash,In-store,
+TXN_3222677,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-12-16
+TXN_9942517,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-04-29
+TXN_8735418,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-03-03
+TXN_7799794,,4,1.0,4.0,Digital Wallet,In-store,2023-08-22
+TXN_6347670,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-06-24
+TXN_9180345,Sandwich,4,UNKNOWN,16.0,Digital Wallet,,2023-06-13
+TXN_9632482,Cake,2,3.0,6.0,Credit Card,,2023-08-27
+TXN_4642770,Tea,4,1.5,6.0,,,2023-09-22
+TXN_5356324,Smoothie,1,4.0,4.0,ERROR,,2023-02-26
+TXN_5148730,Cake,1,3.0,3.0,Cash,UNKNOWN,2023-12-12
+TXN_8848847,Cookie,3,1.0,3.0,Cash,Takeaway,2023-08-15
+TXN_3686848,Tea,3,1.5,4.5,,,2023-04-06
+TXN_2328896,Smoothie,4,4.0,16.0,Cash,,2023-10-20
+TXN_6361856,Cookie,5,1.0,5.0,UNKNOWN,,2023-05-11
+TXN_5942011,Tea,1,1.5,1.5,Cash,,2023-10-08
+TXN_7137364,Salad,5,5.0,25.0,Cash,UNKNOWN,2023-08-09
+TXN_9904042,UNKNOWN,4,4.0,16.0,Credit Card,,2023-06-09
+TXN_1510406,,3,5.0,15.0,,In-store,2023-01-12
+TXN_8176812,Sandwich,5,4.0,20.0,Digital Wallet,,2023-06-21
+TXN_1360872,Coffee,2,UNKNOWN,4.0,Credit Card,In-store,2023-11-04
+TXN_4413776,Coffee,5,2.0,10.0,Cash,Takeaway,2023-07-21
+TXN_1811953,Cookie,2,1.0,2.0,UNKNOWN,,2023-06-26
+TXN_9382596,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-11-18
+TXN_9480564,Cookie,4,1.0,4.0,Cash,In-store,2023-06-12
+TXN_1094479,Cake,3,3.0,9.0,UNKNOWN,In-store,2023-06-08
+TXN_8301190,Coffee,1,2.0,2.0,Cash,Takeaway,2023-04-01
+TXN_7653946,Smoothie,4,4.0,16.0,Cash,,2023-09-19
+TXN_1348274,Cake,5,3.0,15.0,,,2023-11-14
+TXN_2855149,Sandwich,2,4.0,8.0,Cash,In-store,2023-07-16
+TXN_9320167,Juice,5,3.0,15.0,Credit Card,,2023-11-12
+TXN_1135215,Sandwich,3,4.0,12.0,,In-store,2023-04-10
+TXN_6158518,Cookie,5,1.0,5.0,Cash,ERROR,2023-09-28
+TXN_5734442,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-10-01
+TXN_5748083,Salad,UNKNOWN,5.0,10.0,,Takeaway,2023-04-08
+TXN_1804335,Juice,,3.0,9.0,Credit Card,,2023-10-05
+TXN_3644269,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-09-26
+TXN_5611239,UNKNOWN,4,1.0,4.0,Cash,Takeaway,2023-11-18
+TXN_4020100,Cookie,1,1.0,1.0,Cash,In-store,2023-08-09
+TXN_1643870,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-10-07
+TXN_4734216,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-11-30
+TXN_4060538,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-09-08
+TXN_4788388,Cake,UNKNOWN,3.0,9.0,,,2023-06-29
+TXN_9348280,UNKNOWN,2,4.0,8.0,Credit Card,In-store,2023-03-28
+TXN_5173628,Tea,3,1.5,4.5,,Takeaway,2023-05-30
+TXN_9040196,Juice,3,3.0,9.0,Cash,UNKNOWN,2023-06-28
+TXN_1853983,Tea,1,1.5,1.5,Cash,In-store,2023-12-04
+TXN_6154823,ERROR,5,4.0,20.0,Digital Wallet,Takeaway,2023-11-16
+TXN_1936915,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-01-24
+TXN_8693747,Smoothie,4,,16.0,Digital Wallet,,2023-02-13
+TXN_2911864,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-03-21
+TXN_2336921,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-05-01
+TXN_3275800,Coffee,3,2.0,6.0,,Takeaway,2023-05-27
+TXN_6472656,Tea,3,1.5,4.5,Cash,Takeaway,2023-11-25
+TXN_3494191,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-01-08
+TXN_4177717,Cookie,1,1.0,1.0,,,2023-01-07
+TXN_7313328,Juice,1,3.0,3.0,,Takeaway,2023-01-03
+TXN_4019047,ERROR,2,2.0,4.0,,,2023-09-14
+TXN_6832697,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-01-21
+TXN_2919225,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-02-14
+TXN_4937344,Sandwich,UNKNOWN,4.0,4.0,Credit Card,In-store,2023-02-12
+TXN_6444366,Coffee,1,2.0,2.0,Digital Wallet,,2023-08-19
+TXN_7448158,Cake,ERROR,3.0,6.0,Digital Wallet,Takeaway,2023-09-28
+TXN_7630601,Tea,1,1.5,1.5,,Takeaway,2023-08-22
+TXN_7366807,Salad,UNKNOWN,5.0,15.0,,,2023-10-22
+TXN_5762127,Coffee,2,2.0,4.0,,Takeaway,2023-11-10
+TXN_1856153,Coffee,5,2.0,10.0,Credit Card,,2023-12-02
+TXN_4908458,Tea,4,1.5,6.0,,,2023-10-06
+TXN_4214066,Juice,2,3.0,6.0,,In-store,2023-07-23
+TXN_8252793,Cookie,4,1.0,4.0,Digital Wallet,,2023-07-28
+TXN_1313643,Cake,4,3.0,12.0,UNKNOWN,,2023-02-11
+TXN_2941227,Cookie,3,1.0,3.0,Cash,In-store,2023-08-29
+TXN_1206585,Tea,2,1.5,3.0,Cash,,2023-06-29
+TXN_9580673,Juice,2,3.0,ERROR,ERROR,In-store,2023-06-25
+TXN_9874192,Smoothie,3,4.0,12.0,,,2023-11-30
+TXN_4475487,Smoothie,3,4.0,12.0,Cash,In-store,2023-06-01
+TXN_8876663,Salad,UNKNOWN,5.0,10.0,Digital Wallet,Takeaway,2023-03-23
+TXN_3858126,Smoothie,2,4.0,8.0,,In-store,2023-08-25
+TXN_3524464,Smoothie,4,UNKNOWN,16.0,Credit Card,Takeaway,2023-08-31
+TXN_6242107,Coffee,3,2.0,6.0,Cash,,2023-11-14
+TXN_2352246,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-06-20
+TXN_9523335,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-01-29
+TXN_4475412,Sandwich,3,4.0,12.0,UNKNOWN,,2023-10-31
+TXN_2656162,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-04-11
+TXN_7517241,Sandwich,2,4.0,8.0,,ERROR,2023-01-18
+TXN_6243134,Tea,2,1.5,3.0,Digital Wallet,,ERROR
+TXN_2435218,ERROR,UNKNOWN,2.0,10.0,,In-store,2023-05-02
+TXN_9022617,Coffee,1,2.0,2.0,Credit Card,In-store,2023-01-23
+TXN_1031802,Cookie,4,1.0,4.0,ERROR,UNKNOWN,2023-06-27
+TXN_2346296,Cake,4,3.0,12.0,Digital Wallet,,2023-10-04
+TXN_8219210,Smoothie,5,4.0,20.0,Cash,,2023-01-12
+TXN_4541981,Smoothie,4,ERROR,16.0,Credit Card,In-store,2023-01-14
+TXN_8522571,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-09-19
+TXN_6752476,Tea,4,1.5,6.0,,Takeaway,2023-08-28
+TXN_1894142,Sandwich,4,4.0,16.0,Cash,In-store,2023-09-13
+TXN_3766378,UNKNOWN,1,3.0,3.0,Cash,Takeaway,2023-08-18
+TXN_8885727,Tea,2,1.5,3.0,Cash,Takeaway,2023-10-05
+TXN_1422305,Sandwich,4,4.0,16.0,,In-store,2023-03-09
+TXN_4625165,Salad,3,5.0,15.0,Credit Card,,2023-03-02
+TXN_1804132,Smoothie,3,4.0,12.0,,In-store,
+TXN_9323215,Cookie,3,1.0,3.0,,,2023-01-27
+TXN_6824743,Sandwich,2,4.0,ERROR,Digital Wallet,Takeaway,2023-11-08
+TXN_9384397,Sandwich,UNKNOWN,4.0,8.0,Cash,,2023-10-31
+TXN_1034067,Smoothie,3,,12.0,Digital Wallet,,2023-01-07
+TXN_3265085,Cookie,5,1.0,5.0,,In-store,2023-09-05
+TXN_3061498,Salad,5,5.0,25.0,,,2023-11-14
+TXN_6206792,Tea,,ERROR,6.0,Credit Card,,2023-10-13
+TXN_7374304,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-05-10
+TXN_9447946,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-10-21
+TXN_2102561,,2,1.0,2.0,,In-store,2023-04-05
+TXN_5649995,Tea,2,1.5,3.0,,Takeaway,ERROR
+TXN_8223689,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-09-08
+TXN_3207254,Cake,1,3.0,3.0,,Takeaway,2023-04-25
+TXN_2579242,Juice,5,3.0,15.0,,In-store,2023-09-11
+TXN_2187911,Coffee,3,,6.0,Credit Card,Takeaway,2023-04-20
+TXN_2594056,Salad,4,5.0,20.0,Cash,,2023-03-11
+TXN_6591736,Coffee,4,2.0,8.0,,Takeaway,2023-06-21
+TXN_1267753,ERROR,3,1.5,4.5,Credit Card,,2023-06-28
+TXN_4615235,Cake,4,3.0,12.0,Cash,,2023-01-08
+TXN_4824519,Smoothie,5,4.0,20.0,,,2023-12-27
+TXN_4677415,Cake,2,3.0,6.0,Digital Wallet,,2023-12-12
+TXN_3548788,Salad,4,5.0,20.0,Digital Wallet,,2023-02-22
+TXN_2503245,Sandwich,3,4.0,12.0,UNKNOWN,Takeaway,2023-04-15
+TXN_8855046,Juice,3,ERROR,9.0,,Takeaway,2023-12-05
+TXN_9287659,,1,3.0,3.0,,In-store,2023-05-13
+TXN_2417402,Sandwich,3,4.0,12.0,Digital Wallet,,2023-05-09
+TXN_6266017,Cookie,4,1.0,4.0,UNKNOWN,In-store,2023-09-28
+TXN_4619018,Cake,5,3.0,15.0,Digital Wallet,,2023-12-19
+TXN_8352748,UNKNOWN,5,4.0,20.0,Cash,In-store,2023-05-01
+TXN_2221447,Cookie,1,1.0,1.0,Credit Card,In-store,2023-12-06
+TXN_3564954,Smoothie,4,UNKNOWN,16.0,Cash,,2023-03-09
+TXN_8464222,Cake,4,3.0,12.0,Cash,In-store,2023-08-17
+TXN_6815753,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-10-27
+TXN_6738716,Cake,,3.0,15.0,,Takeaway,2023-04-21
+TXN_9477892,Cake,3,3.0,9.0,Credit Card,UNKNOWN,2023-08-21
+TXN_9894270,Cookie,ERROR,1.0,4.0,Credit Card,In-store,ERROR
+TXN_3136701,,2,4.0,8.0,,In-store,2023-12-18
+TXN_4644671,Coffee,3,2.0,6.0,UNKNOWN,,2023-04-20
+TXN_1634534,Juice,5,3.0,15.0,,,2023-12-03
+TXN_7809121,Cake,4,3.0,12.0,,,2023-05-15
+TXN_1350239,Smoothie,5,4.0,20.0,Cash,,2023-11-18
+TXN_5145906,Tea,4,1.5,6.0,,,2023-01-30
+TXN_9603912,Juice,5,3.0,15.0,UNKNOWN,,2023-12-23
+TXN_1205610,,2,1.0,2.0,,In-store,2023-07-19
+TXN_8969428,Salad,3,5.0,15.0,,Takeaway,2023-03-08
+TXN_5269634,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-04-07
+TXN_3043982,Sandwich,5,4.0,20.0,Cash,In-store,2023-01-10
+TXN_6310896,Sandwich,1,4.0,4.0,,In-store,2023-05-01
+TXN_5496282,Smoothie,2,,8.0,,UNKNOWN,2023-03-03
+TXN_3947201,Cookie,5,1.0,5.0,,Takeaway,2023-06-17
+TXN_3666951,Juice,2,3.0,6.0,,In-store,2023-01-06
+TXN_7254494,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-03-16
+TXN_3157867,,2,5.0,10.0,,Takeaway,2023-11-02
+TXN_6164035,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-03-30
+TXN_6234838,Juice,5,3.0,15.0,,In-store,2023-10-30
+TXN_5671075,Tea,5,1.5,7.5,Cash,In-store,2023-12-25
+TXN_5004986,Sandwich,3,4.0,12.0,Digital Wallet,,2023-01-23
+TXN_4856575,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-09-10
+TXN_6064400,Sandwich,5,4.0,20.0,,,2023-07-06
+TXN_8512136,Juice,1,3.0,3.0,Cash,Takeaway,2023-08-26
+TXN_1868529,ERROR,1,5.0,5.0,Credit Card,,2023-01-25
+TXN_3129441,Juice,3,3.0,9.0,Credit Card,In-store,2023-05-31
+TXN_1652596,Smoothie,5,4.0,UNKNOWN,Digital Wallet,,2023-10-04
+TXN_3487896,Coffee,5,2.0,10.0,Credit Card,,2023-01-09
+TXN_1429858,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-03-15
+TXN_1721242,Smoothie,5,4.0,20.0,,In-store,2023-11-23
+TXN_3472707,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-03-26
+TXN_5348750,UNKNOWN,5,5.0,25.0,Credit Card,,2023-07-15
+TXN_3819085,Sandwich,1,4.0,4.0,,Takeaway,2023-11-23
+TXN_2181920,Sandwich,3,4.0,12.0,Cash,,2023-02-11
+TXN_1173155,Coffee,1,2.0,2.0,Cash,In-store,2023-03-14
+TXN_4913079,Sandwich,3,4.0,12.0,ERROR,,2023-08-19
+TXN_1476711,Tea,2,1.5,3.0,,,2023-01-26
+TXN_5341644,Cake,4,3.0,12.0,Cash,,2023-01-24
+TXN_4548274,Juice,5,3.0,15.0,Digital Wallet,,2023-05-09
+TXN_8008815,Salad,2,5.0,10.0,,UNKNOWN,2023-03-16
+TXN_3639760,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-01-29
+TXN_8159727,Salad,5,ERROR,25.0,Digital Wallet,,2023-04-24
+TXN_5061028,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-05-17
+TXN_6962671,Cake,2,3.0,6.0,,,2023-01-20
+TXN_4791072,Coffee,3,2.0,6.0,,ERROR,2023-11-13
+TXN_7263939,,ERROR,4.0,4.0,,,2023-08-08
+TXN_4775791,Smoothie,4,4.0,16.0,Credit Card,,2023-04-13
+TXN_6724554,Tea,3,1.5,ERROR,UNKNOWN,,2023-03-22
+TXN_6897608,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-06-28
+TXN_1481470,Juice,3,3.0,9.0,Digital Wallet,Takeaway,ERROR
+TXN_4226572,Cookie,3,1.0,3.0,,Takeaway,2023-05-16
+TXN_6833530,Juice,4,3.0,12.0,,In-store,2023-11-05
+TXN_5752187,Juice,4,3.0,12.0,Digital Wallet,In-store,ERROR
+TXN_4321368,Coffee,4,2.0,8.0,,Takeaway,2023-12-09
+TXN_3434549,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-05-25
+TXN_7918317,Tea,1,1.5,1.5,Credit Card,,2023-07-27
+TXN_3467985,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-12-10
+TXN_3526095,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-08-30
+TXN_8316915,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-05-30
+TXN_4876685,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-07-14
+TXN_7505290,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-10-21
+TXN_5709834,Cake,4,3.0,12.0,Digital Wallet,,2023-03-24
+TXN_9626624,Smoothie,3,4.0,12.0,Cash,In-store,2023-10-10
+TXN_4563526,Smoothie,4,4.0,16.0,Credit Card,,2023-06-30
+TXN_5512533,Coffee,4,2.0,8.0,Digital Wallet,,2023-06-13
+TXN_9399452,Cake,4,3.0,12.0,Credit Card,In-store,2023-12-03
+TXN_3451212,Cake,3,3.0,9.0,ERROR,,2023-01-29
+TXN_1934166,Sandwich,5,4.0,20.0,Cash,In-store,2023-03-06
+TXN_5594695,Cake,3,3.0,9.0,Credit Card,In-store,2023-01-18
+TXN_8379868,Cake,3,3.0,9.0,Cash,In-store,2023-01-16
+TXN_3708535,Coffee,5,2.0,10.0,,In-store,2023-05-02
+TXN_5299440,Juice,2,3.0,6.0,Credit Card,In-store,2023-10-21
+TXN_4107706,Salad,1,5.0,5.0,,In-store,2023-11-23
+TXN_6059878,Salad,3,5.0,15.0,Digital Wallet,,2023-01-23
+TXN_6476204,UNKNOWN,5,4.0,ERROR,,Takeaway,2023-12-22
+TXN_5777542,Sandwich,2,4.0,8.0,ERROR,,2023-10-22
+TXN_3919225,Cake,2,3.0,6.0,Cash,In-store,2023-03-26
+TXN_5598744,Sandwich,4,4.0,UNKNOWN,Digital Wallet,Takeaway,2023-10-17
+TXN_7355326,Cookie,1,1.0,1.0,,,2023-01-03
+TXN_4071945,Cake,1,,3.0,Cash,,2023-07-17
+TXN_6732096,Smoothie,2,4.0,ERROR,,In-store,2023-04-02
+TXN_4392519,Cookie,2,1.0,2.0,UNKNOWN,Takeaway,2023-09-20
+TXN_1716710,Coffee,2,2.0,4.0,UNKNOWN,,2023-02-23
+TXN_9550397,Coffee,4,2.0,8.0,,,ERROR
+TXN_9655021,Coffee,3,2.0,6.0,UNKNOWN,,2023-04-22
+TXN_3868402,Coffee,3,2.0,6.0,Cash,In-store,2023-01-21
+TXN_4624591,Salad,2,5.0,10.0,Credit Card,In-store,2023-08-03
+TXN_9640865,Cookie,2,1.0,ERROR,Cash,Takeaway,2023-03-18
+TXN_6456008,Salad,5,5.0,25.0,Credit Card,In-store,2023-03-26
+TXN_9547654,Cookie,2,1.0,2.0,UNKNOWN,In-store,2023-11-19
+TXN_4986668,Cake,3,3.0,9.0,Digital Wallet,UNKNOWN,2023-11-30
+TXN_6235329,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-10-11
+TXN_8536578,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-11-11
+TXN_4545512,Coffee,1,2.0,2.0,,Takeaway,2023-12-18
+TXN_2156128,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-07-21
+TXN_9188172,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-08-27
+TXN_5893283,,3,3.0,9.0,Cash,In-store,2023-08-15
+TXN_6408024,Cookie,3,1.0,3.0,,In-store,2023-11-29
+TXN_4788748,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-04-30
+TXN_6460409,Salad,3,5.0,UNKNOWN,Cash,ERROR,2023-01-03
+TXN_1067052,Tea,4,1.5,6.0,,Takeaway,2023-02-18
+TXN_8776634,Juice,5,3.0,15.0,,In-store,2023-06-02
+TXN_2534831,Tea,5,1.5,7.5,Cash,Takeaway,2023-08-19
+TXN_9941872,Salad,3,5.0,15.0,,,2023-04-08
+TXN_2055898,Tea,4,1.5,6.0,,,2023-12-01
+TXN_2007418,Smoothie,4,4.0,16.0,Cash,,2023-06-16
+TXN_6451043,Cookie,2,1.0,2.0,,In-store,2023-02-06
+TXN_2632916,Juice,3,3.0,9.0,Credit Card,,2023-06-17
+TXN_1926794,Smoothie,1,4.0,4.0,,In-store,2023-01-14
+TXN_3201783,Juice,3,3.0,9.0,UNKNOWN,,2023-12-03
+TXN_2374950,Cake,5,3.0,15.0,Digital Wallet,,2023-04-28
+TXN_5962196,Smoothie,2,4.0,8.0,Cash,Takeaway,2023-11-29
+TXN_4342098,Smoothie,4,4.0,16.0,Cash,In-store,2023-05-24
+TXN_7367134,Smoothie,4,4.0,16.0,Digital Wallet,,2023-10-03
+TXN_3651743,Cake,5,3.0,15.0,Cash,In-store,2023-04-24
+TXN_4411007,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-05-17
+TXN_6026451,Juice,2,3.0,6.0,Cash,In-store,2023-11-06
+TXN_5896413,Coffee,3,2.0,6.0,Cash,In-store,ERROR
+TXN_5093312,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-08-12
+TXN_6685570,Tea,1,1.5,1.5,Credit Card,In-store,2023-03-14
+TXN_7905853,Cookie,4,1.0,4.0,Digital Wallet,,2023-07-25
+TXN_3020475,Salad,4,5.0,20.0,,Takeaway,2023-09-13
+TXN_7665695,Tea,3,1.5,4.5,ERROR,In-store,2023-10-21
+TXN_2355099,Salad,5,5.0,25.0,Cash,Takeaway,2023-03-18
+TXN_6071866,Tea,4,1.5,6.0,,,2023-10-14
+TXN_4548715,Sandwich,2,4.0,8.0,,,2023-02-16
+TXN_8156272,Salad,2,5.0,10.0,Cash,In-store,ERROR
+TXN_8344035,Smoothie,2,4.0,8.0,Cash,,2023-08-23
+TXN_7332192,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-11-17
+TXN_4483944,Juice,4,3.0,12.0,,In-store,
+TXN_4713356,Smoothie,5,4.0,20.0,ERROR,In-store,2023-05-08
+TXN_6400461,Coffee,4,2.0,8.0,Digital Wallet,,2023-01-18
+TXN_9262504,Smoothie,3,4.0,12.0,Credit Card,,2023-12-01
+TXN_6225305,Cake,1,3.0,3.0,Cash,Takeaway,2023-05-05
+TXN_1266278,Smoothie,1,4.0,4.0,,Takeaway,2023-11-03
+TXN_2607233,Coffee,3,2.0,6.0,Cash,Takeaway,
+TXN_2797871,Cookie,2,1.0,2.0,UNKNOWN,Takeaway,2023-09-21
+TXN_6753977,Tea,3,1.5,,,In-store,
+TXN_4947561,Salad,UNKNOWN,5.0,15.0,ERROR,Takeaway,2023-06-06
+TXN_3881824,Juice,UNKNOWN,3.0,6.0,Credit Card,,2023-12-30
+TXN_7606965,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-12-08
+TXN_5516374,Smoothie,2,4.0,8.0,,In-store,2023-07-25
+TXN_8059034,Coffee,1,2.0,2.0,Digital Wallet,,2023-01-10
+TXN_2238287,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-05-22
+TXN_2086896,ERROR,4,3.0,12.0,Cash,Takeaway,2023-11-25
+TXN_9667721,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-04-29
+TXN_6317991,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-03-03
+TXN_7866723,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-03-26
+TXN_7954064,ERROR,5,3.0,15.0,Credit Card,In-store,2023-08-31
+TXN_5251180,Cookie,1,1.0,1.0,Digital Wallet,,2023-06-25
+TXN_5891724,Salad,5,5.0,25.0,Credit Card,,2023-12-10
+TXN_9564495,UNKNOWN,4,3.0,12.0,Digital Wallet,,2023-08-01
+TXN_5092646,Smoothie,2,4.0,8.0,,Takeaway,2023-05-08
+TXN_5261036,,5,3.0,15.0,Cash,,2023-10-03
+TXN_2638434,Juice,5,3.0,15.0,Credit Card,In-store,2023-09-18
+TXN_5651620,UNKNOWN,2,4.0,8.0,,,2023-05-16
+TXN_5452210,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-04-17
+TXN_5337566,Cookie,5,1.0,5.0,Cash,Takeaway,2023-03-08
+TXN_3341779,Tea,3,1.5,4.5,Cash,Takeaway,2023-07-30
+TXN_7977951,Cake,5,3.0,15.0,,,2023-12-22
+TXN_8226985,Coffee,2,2.0,4.0,,,2023-03-08
+TXN_7604622,Juice,ERROR,3.0,12.0,Credit Card,,2023-12-22
+TXN_6875870,Salad,5,5.0,25.0,,,2023-09-07
+TXN_9086163,Cookie,2,1.0,2.0,Digital Wallet,ERROR,2023-07-31
+TXN_5061600,Juice,3,3.0,UNKNOWN,,In-store,2023-11-23
+TXN_9987017,Cookie,5,1.0,5.0,Cash,Takeaway,2023-03-14
+TXN_6533576,Salad,5,5.0,25.0,Cash,In-store,2023-08-14
+TXN_5229351,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-08-14
+TXN_5318263,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-06-12
+TXN_8866088,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-07-11
+TXN_1193930,Coffee,1,2.0,2.0,Cash,,
+TXN_2601923,Cake,4,,12.0,Cash,Takeaway,2023-07-24
+TXN_5884081,Cookie,UNKNOWN,1.0,ERROR,Digital Wallet,In-store,2023-07-05
+TXN_5047792,Salad,1,5.0,5.0,,,UNKNOWN
+TXN_7434172,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-11-14
+TXN_1849406,Sandwich,5,4.0,ERROR,Cash,In-store,2023-11-30
+TXN_8388462,Smoothie,,UNKNOWN,8.0,UNKNOWN,Takeaway,2023-08-19
+TXN_6289180,Juice,1,3.0,3.0,Cash,In-store,2023-03-14
+TXN_3974663,Juice,3,3.0,9.0,Cash,Takeaway,2023-10-02
+TXN_9041537,Sandwich,4,4.0,16.0,,,2023-08-28
+TXN_2798069,ERROR,5,1.5,7.5,Digital Wallet,UNKNOWN,2023-09-02
+TXN_7601706,Juice,UNKNOWN,3.0,6.0,Credit Card,In-store,2023-11-15
+TXN_6184247,,1,3.0,3.0,,,
+TXN_3145515,Smoothie,4,4.0,16.0,Cash,,2023-03-31
+TXN_6711224,Juice,1,3.0,3.0,Digital Wallet,,2023-03-26
+TXN_4035164,Juice,5,3.0,15.0,,In-store,2023-11-26
+TXN_1815061,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-01-20
+TXN_9522690,Cookie,4,1.0,4.0,Credit Card,In-store,2023-07-23
+TXN_2858635,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-09-28
+TXN_5492825,UNKNOWN,2,5.0,10.0,,In-store,2023-02-25
+TXN_2083119,UNKNOWN,2,1.0,2.0,,In-store,2023-06-11
+TXN_7030681,Juice,1,3.0,3.0,Cash,,2023-10-01
+TXN_7738316,Cookie,4,1.0,4.0,ERROR,,2023-02-04
+TXN_6817358,Smoothie,2,ERROR,8.0,Credit Card,UNKNOWN,2023-12-22
+TXN_4430474,Cake,2,3.0,6.0,Digital Wallet,,2023-06-08
+TXN_2329938,Sandwich,3,4.0,12.0,Credit Card,,2023-03-29
+TXN_7020104,ERROR,5,1.5,7.5,Digital Wallet,,2023-01-23
+TXN_3642052,Cake,1,3.0,UNKNOWN,,Takeaway,2023-07-19
+TXN_6655913,Cookie,1,1.0,,Credit Card,In-store,2023-04-02
+TXN_1409029,Sandwich,1,4.0,4.0,Cash,,UNKNOWN
+TXN_1617594,Sandwich,1,4.0,4.0,UNKNOWN,In-store,2023-04-23
+TXN_7136372,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-09-22
+TXN_7648238,Cookie,UNKNOWN,1.0,1.0,Cash,,2023-05-12
+TXN_1277813,ERROR,5,3.0,15.0,Digital Wallet,,2023-09-11
+TXN_7251969,Cookie,2,1.0,2.0,,In-store,2023-08-14
+TXN_5790695,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-04-24
+TXN_7101802,Coffee,4,2.0,8.0,,,2023-03-19
+TXN_3277936,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-06-21
+TXN_3233221,Cake,5,3.0,15.0,,Takeaway,2023-06-15
+TXN_6200423,Cookie,1,1.0,1.0,,In-store,2023-02-03
+TXN_1522176,Smoothie,UNKNOWN,4.0,4.0,Digital Wallet,Takeaway,2023-04-29
+TXN_6728574,Juice,3,3.0,9.0,Cash,,2023-05-24
+TXN_6344738,,4,5.0,20.0,Credit Card,Takeaway,ERROR
+TXN_5968705,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-12-16
+TXN_9657902,Juice,1,3.0,3.0,Digital Wallet,,2023-10-30
+TXN_8640383,Juice,2,3.0,6.0,ERROR,,2023-10-08
+TXN_3889213,Cake,1,,3.0,Credit Card,,2023-10-13
+TXN_2252244,Juice,2,UNKNOWN,6.0,Credit Card,,2023-03-10
+TXN_2561071,Juice,5,3.0,15.0,,In-store,2023-01-30
+TXN_6543164,Tea,2,1.5,3.0,Digital Wallet,ERROR,2023-07-10
+TXN_3209025,Salad,2,5.0,10.0,Cash,,2023-10-12
+TXN_9975079,Smoothie,2,4.0,8.0,Cash,,2023-08-26
+TXN_9618962,,3,UNKNOWN,6.0,Credit Card,Takeaway,2023-11-08
+TXN_5949517,,5,4.0,20.0,Digital Wallet,In-store,2023-12-31
+TXN_4103665,Coffee,4,2.0,UNKNOWN,,In-store,2023-04-30
+TXN_8499618,Cake,2,3.0,6.0,ERROR,,2023-05-23
+TXN_6183513,UNKNOWN,3,3.0,9.0,Digital Wallet,,2023-12-22
+TXN_3919672,Cookie,UNKNOWN,1.0,2.0,Credit Card,,2023-11-05
+TXN_7592199,Tea,3,1.5,4.5,Digital Wallet,ERROR,2023-09-14
+TXN_8888249,Coffee,5,2.0,10.0,,,2023-10-17
+TXN_8494571,,5,1.0,5.0,,,2023-02-06
+TXN_7749759,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-12-26
+TXN_7556108,Cookie,5,1.0,5.0,,Takeaway,2023-01-17
+TXN_9360886,Sandwich,1,4.0,4.0,UNKNOWN,,2023-07-25
+TXN_5303464,Juice,4,3.0,12.0,Cash,Takeaway,2023-10-26
+TXN_5324330,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-11-20
+TXN_5862289,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-01-05
+TXN_8203190,Tea,2,1.5,3.0,,In-store,2023-06-16
+TXN_9699948,Coffee,5,2.0,10.0,Cash,In-store,2023-04-18
+TXN_8187087,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-01-31
+TXN_5409141,Coffee,5,2.0,10.0,Cash,Takeaway,2023-02-02
+TXN_9928409,Sandwich,4,4.0,16.0,Credit Card,,2023-06-17
+TXN_9882485,Salad,5,5.0,25.0,Cash,ERROR,UNKNOWN
+TXN_9952479,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-12-06
+TXN_7207901,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-12-11
+TXN_8899602,Salad,4,5.0,20.0,,In-store,
+TXN_4321091,Smoothie,2,4.0,8.0,Cash,In-store,2023-06-15
+TXN_2721997,Cake,3,3.0,9.0,,Takeaway,2023-05-20
+TXN_6738137,Coffee,4,2.0,8.0,,,2023-07-20
+TXN_5365699,Sandwich,5,4.0,20.0,,,2023-05-22
+TXN_4807459,Sandwich,1,4.0,4.0,,,2023-08-11
+TXN_2790608,Juice,1,3.0,3.0,Cash,In-store,2023-12-18
+TXN_2035137,,2,1.5,3.0,Digital Wallet,Takeaway,2023-03-12
+TXN_7603919,ERROR,2,1.0,2.0,,,2023-09-25
+TXN_7429032,Sandwich,2,4.0,8.0,,Takeaway,2023-08-18
+TXN_5241723,Coffee,3,2.0,6.0,Cash,,2023-07-18
+TXN_5151706,Smoothie,1,4.0,4.0,,Takeaway,2023-03-01
+TXN_6231475,Salad,2,5.0,10.0,Credit Card,In-store,2023-03-18
+TXN_6144244,Juice,3,ERROR,9.0,Cash,,2023-01-08
+TXN_3442435,,ERROR,4.0,8.0,Digital Wallet,In-store,2023-04-01
+TXN_2631423,Cookie,3,1.0,3.0,Cash,Takeaway,2023-01-07
+TXN_1616810,UNKNOWN,2,1.0,2.0,,In-store,2023-09-05
+TXN_6505914,Cake,3,3.0,9.0,ERROR,ERROR,2023-01-27
+TXN_1958614,Smoothie,2,4.0,8.0,Digital Wallet,,2023-07-02
+TXN_6890737,,4,4.0,16.0,,,2023-05-22
+TXN_6702416,Cake,1,3.0,3.0,,,2023-09-14
+TXN_5649204,Smoothie,1,4.0,4.0,Cash,In-store,2023-03-05
+TXN_4084177,UNKNOWN,3,1.0,3.0,Credit Card,In-store,2023-08-13
+TXN_2066115,Salad,4,5.0,20.0,Credit Card,In-store,2023-08-18
+TXN_5029643,ERROR,2,1.5,3.0,Digital Wallet,In-store,2023-12-23
+TXN_7986904,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-08-11
+TXN_4633457,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-05-21
+TXN_9368550,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-09-26
+TXN_8049058,Cake,2,3.0,6.0,Cash,ERROR,2023-04-08
+TXN_5131404,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-06-18
+TXN_3480562,Coffee,5,2.0,10.0,,,2023-12-24
+TXN_6219454,Tea,1,1.5,1.5,Cash,In-store,2023-11-14
+TXN_2551378,Tea,2,1.5,3.0,,Takeaway,2023-10-27
+TXN_9024388,Salad,1,5.0,5.0,Cash,,2023-02-27
+TXN_3478329,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-10-29
+TXN_6308974,Cookie,4,1.0,4.0,ERROR,In-store,2023-10-02
+TXN_5571904,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-08-05
+TXN_6979356,Salad,2,5.0,10.0,,In-store,2023-09-21
+TXN_9171458,Cake,2,3.0,6.0,,,2023-03-29
+TXN_5537621,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-02-28
+TXN_9288156,Coffee,3,2.0,6.0,,,2023-11-05
+TXN_8626720,Juice,4,3.0,12.0,Cash,Takeaway,2023-06-02
+TXN_9181129,Sandwich,,4.0,20.0,Digital Wallet,In-store,2023-09-25
+TXN_5908362,Sandwich,5,4.0,20.0,Digital Wallet,,2023-10-03
+TXN_2086841,Salad,4,5.0,20.0,Credit Card,In-store,2023-03-16
+TXN_9944141,Juice,5,3.0,15.0,Credit Card,Takeaway,2023-07-18
+TXN_2438638,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-08-12
+TXN_4644790,UNKNOWN,1,4.0,4.0,Credit Card,,2023-09-19
+TXN_9216933,Cookie,4,1.0,4.0,,,2023-05-29
+TXN_8308356,Smoothie,1,4.0,UNKNOWN,Digital Wallet,,2023-11-21
+TXN_7933500,Tea,3,1.5,4.5,,In-store,2023-09-21
+TXN_1602123,Coffee,,2.0,2.0,Cash,,2023-04-11
+TXN_3321395,Tea,,1.5,1.5,Digital Wallet,Takeaway,2023-07-08
+TXN_7563589,Smoothie,5,4.0,20.0,Cash,,2023-09-19
+TXN_7864482,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-01-28
+TXN_7942343,Cookie,4,1.0,4.0,Digital Wallet,,2023-06-15
+TXN_1585329,Smoothie,4,4.0,16.0,Credit Card,,2023-07-16
+TXN_6550460,Sandwich,5,4.0,ERROR,,,2023-03-15
+TXN_3416466,Juice,2,3.0,6.0,Digital Wallet,,2023-09-13
+TXN_5125759,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-06-15
+TXN_7321946,Cake,3,3.0,9.0,Cash,Takeaway,2023-02-12
+TXN_4336291,Salad,5,5.0,25.0,Cash,In-store,2023-03-25
+TXN_5240229,Salad,1,5.0,5.0,ERROR,In-store,2023-06-10
+TXN_7854253,Coffee,4,2.0,8.0,Cash,,2023-07-26
+TXN_1971201,Smoothie,2,4.0,8.0,Digital Wallet,,2023-11-07
+TXN_2673104,Tea,1,1.5,1.5,,,2023-06-23
+TXN_7479695,Smoothie,5,4.0,20.0,Credit Card,,2023-12-12
+TXN_1084222,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-06-03
+TXN_1723062,Salad,1,5.0,5.0,ERROR,In-store,2023-09-21
+TXN_4987205,Tea,2,1.5,3.0,,Takeaway,2023-06-24
+TXN_8025478,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-01-24
+TXN_7529735,Coffee,3,2.0,6.0,,In-store,2023-08-12
+TXN_1598214,Juice,1,ERROR,3.0,Credit Card,Takeaway,2023-01-07
+TXN_7872478,Juice,4,3.0,12.0,Credit Card,In-store,2023-04-25
+TXN_9464398,Cake,4,3.0,12.0,Credit Card,,2023-09-25
+TXN_9319656,Tea,5,1.5,7.5,,,2023-12-22
+TXN_9212052,Salad,4,5.0,20.0,Cash,,2023-10-15
+TXN_2913107,UNKNOWN,4,ERROR,8.0,,In-store,2023-05-20
+TXN_2550923,Cake,2,3.0,6.0,Cash,Takeaway,2023-08-26
+TXN_3352028,ERROR,4,1.0,4.0,Credit Card,In-store,2023-08-26
+TXN_2682803,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-04-09
+TXN_1745182,Cookie,2,UNKNOWN,2.0,Digital Wallet,Takeaway,2023-09-26
+TXN_7608637,ERROR,1,5.0,5.0,Digital Wallet,,2023-04-08
+TXN_6388090,Juice,4,3.0,12.0,ERROR,,ERROR
+TXN_4335735,Coffee,2,2.0,4.0,,,2023-04-07
+TXN_9264301,Coffee,1,2.0,2.0,UNKNOWN,In-store,2023-10-24
+TXN_6547896,Coffee,3,2.0,ERROR,,,2023-03-02
+TXN_2414686,Cake,1,3.0,3.0,Cash,,ERROR
+TXN_9868114,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-11-12
+TXN_6127474,Cookie,5,ERROR,5.0,Cash,In-store,2023-09-17
+TXN_5549557,Cake,2,3.0,6.0,Cash,In-store,2023-02-27
+TXN_4668762,Smoothie,3,4.0,12.0,Digital Wallet,,2023-03-10
+TXN_1058466,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-12-07
+TXN_8892230,Coffee,5,2.0,10.0,,,2023-03-02
+TXN_3332915,Cookie,2,1.0,2.0,,Takeaway,2023-01-19
+TXN_9596023,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-11-30
+TXN_6122423,Salad,4,5.0,UNKNOWN,,In-store,2023-09-28
+TXN_8934637,Smoothie,1,4.0,4.0,,In-store,2023-01-07
+TXN_4846406,Cookie,3,1.0,3.0,Cash,In-store,2023-05-22
+TXN_8917300,Cookie,1,1.0,1.0,Cash,Takeaway,2023-03-04
+TXN_7742182,Tea,2,1.5,3.0,,,2023-11-09
+TXN_8131533,Cake,1,3.0,3.0,Cash,In-store,2023-07-18
+TXN_1836754,Tea,1,1.5,1.5,Credit Card,In-store,2023-09-10
+TXN_2531878,Salad,3,5.0,15.0,,,2023-01-06
+TXN_8126586,Sandwich,5,4.0,20.0,,In-store,2023-11-19
+TXN_4522292,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-07-12
+TXN_2896162,Cookie,2,1.0,2.0,Credit Card,In-store,
+TXN_4209377,Salad,2,5.0,10.0,,,2023-02-07
+TXN_9097321,Juice,2,3.0,6.0,Credit Card,,2023-10-02
+TXN_8258400,ERROR,5,5.0,25.0,UNKNOWN,,2023-10-09
+TXN_3267393,Sandwich,2,4.0,8.0,,In-store,2023-02-24
+TXN_2389110,Sandwich,2,4.0,8.0,Cash,In-store,2023-05-30
+TXN_2704452,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-09-05
+TXN_4892165,Juice,3,3.0,9.0,Cash,In-store,2023-07-27
+TXN_6588156,Cake,4,3.0,12.0,,In-store,2023-04-14
+TXN_4721830,Sandwich,3,4.0,12.0,UNKNOWN,,2023-11-15
+TXN_6941542,Sandwich,3,4.0,12.0,,In-store,2023-09-27
+TXN_5214986,Cookie,5,,5.0,Credit Card,In-store,2023-09-21
+TXN_3635874,Sandwich,2,4.0,8.0,Cash,UNKNOWN,2023-03-16
+TXN_1721910,Juice,4,3.0,12.0,Digital Wallet,,2023-03-21
+TXN_9615339,Sandwich,1,4.0,4.0,,In-store,
+TXN_1120969,Coffee,2,2.0,4.0,Credit Card,,2023-04-15
+TXN_4246000,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-07-09
+TXN_9253541,UNKNOWN,1,1.5,1.5,Digital Wallet,ERROR,2023-06-04
+TXN_9699174,Smoothie,3,4.0,UNKNOWN,,,2023-01-03
+TXN_6036409,Tea,5,1.5,7.5,Cash,Takeaway,2023-02-16
+TXN_5927258,Tea,5,1.5,7.5,,In-store,2023-10-18
+TXN_6027031,Juice,5,3.0,15.0,Credit Card,In-store,2023-11-15
+TXN_4449992,,3,1.0,3.0,Digital Wallet,UNKNOWN,2023-01-09
+TXN_3018211,Salad,4,5.0,20.0,,,ERROR
+TXN_1900906,Coffee,5,2.0,ERROR,Cash,,2023-01-31
+TXN_7171590,Coffee,3,2.0,6.0,Credit Card,In-store,2023-04-24
+TXN_5746203,Tea,5,1.5,7.5,Cash,,2023-07-08
+TXN_1696300,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-05-28
+TXN_1255476,Smoothie,1,4.0,4.0,,,2023-08-28
+TXN_9403115,Tea,1,1.5,1.5,,UNKNOWN,2023-04-17
+TXN_4476539,Salad,2,5.0,10.0,Cash,,2023-04-19
+TXN_5263133,Juice,2,3.0,6.0,,Takeaway,2023-05-22
+TXN_8473362,Juice,3,3.0,9.0,Digital Wallet,,2023-11-22
+TXN_8402606,Cookie,3,1.0,3.0,,Takeaway,2023-05-09
+TXN_6857799,Cookie,4,1.0,4.0,Cash,ERROR,2023-01-08
+TXN_9362993,Coffee,3,2.0,6.0,Cash,In-store,2023-10-22
+TXN_7458568,Smoothie,5,4.0,20.0,Digital Wallet,,2023-05-09
+TXN_7474617,Salad,3,5.0,15.0,Credit Card,Takeaway,ERROR
+TXN_1959082,Juice,5,3.0,15.0,Credit Card,,2023-06-08
+TXN_9630958,Smoothie,5,ERROR,20.0,Digital Wallet,In-store,2023-12-26
+TXN_4290475,Smoothie,1,4.0,4.0,,Takeaway,2023-04-20
+TXN_4561296,Salad,5,5.0,25.0,Cash,In-store,2023-11-22
+TXN_6422545,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-11-03
+TXN_6012728,Cake,4,3.0,12.0,Credit Card,In-store,2023-05-09
+TXN_8886678,Tea,5,1.5,7.5,Cash,,2023-03-27
+TXN_5424622,Tea,4,1.5,6.0,,In-store,2023-07-12
+TXN_1204426,Sandwich,,4.0,12.0,Credit Card,,2023-01-16
+TXN_1885495,Coffee,4,2.0,8.0,Cash,,2023-03-04
+TXN_3646359,Salad,2,5.0,10.0,Credit Card,,2023-07-23
+TXN_3284157,Tea,4,ERROR,6.0,Digital Wallet,,2023-05-17
+TXN_4533186,Tea,3,1.5,4.5,,Takeaway,2023-04-19
+TXN_3046567,Salad,2,5.0,10.0,Credit Card,In-store,2023-01-07
+TXN_3594827,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-03-09
+TXN_2883054,Cake,4,3.0,12.0,Cash,In-store,2023-11-17
+TXN_1744319,Smoothie,3,4.0,12.0,Cash,,2023-03-24
+TXN_6182856,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-04-02
+TXN_7341998,Cake,3,3.0,9.0,Digital Wallet,,2023-02-18
+TXN_5438422,Smoothie,3,4.0,,,In-store,2023-09-25
+TXN_7187128,Tea,5,1.5,7.5,,Takeaway,2023-08-24
+TXN_6499084,Cake,4,,12.0,Credit Card,Takeaway,2023-03-15
+TXN_5738243,Salad,5,ERROR,25.0,Credit Card,Takeaway,2023-08-30
+TXN_8946752,Tea,4,1.5,6.0,Cash,,2023-06-08
+TXN_5453217,Coffee,1,2.0,2.0,Credit Card,In-store,2023-07-11
+TXN_9340973,Cookie,4,1.0,4.0,Cash,,2023-03-07
+TXN_8562684,Tea,5,1.5,7.5,,Takeaway,2023-06-25
+TXN_2477021,Cookie,4,,4.0,Credit Card,In-store,UNKNOWN
+TXN_2030078,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-04-10
+TXN_9490465,,3,4.0,12.0,UNKNOWN,ERROR,2023-05-06
+TXN_6603668,Coffee,4,ERROR,8.0,Credit Card,Takeaway,2023-03-07
+TXN_7077961,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-09-19
+TXN_3343585,Cake,1,3.0,3.0,Cash,In-store,2023-09-17
+TXN_7896831,Coffee,5,2.0,10.0,Cash,Takeaway,2023-04-01
+TXN_2510233,ERROR,2,4.0,8.0,Credit Card,In-store,2023-11-04
+TXN_3541337,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-09-01
+TXN_2140056,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-12-07
+TXN_9629256,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-11-07
+TXN_8419985,Cake,3,3.0,9.0,,ERROR,2023-08-26
+TXN_6349916,Salad,1,5.0,5.0,Cash,,2023-07-09
+TXN_6568254,Salad,2,5.0,10.0,Credit Card,In-store,2023-02-09
+TXN_1730385,Cake,2,3.0,6.0,Credit Card,,2023-03-01
+TXN_7800576,Sandwich,ERROR,4.0,16.0,ERROR,,2023-07-13
+TXN_6935600,Coffee,3,2.0,6.0,UNKNOWN,,2023-01-02
+TXN_1851725,Cake,5,3.0,15.0,Cash,Takeaway,2023-02-19
+TXN_5691112,Juice,5,3.0,15.0,UNKNOWN,ERROR,2023-03-24
+TXN_9514836,Coffee,3,2.0,6.0,,In-store,2023-03-29
+TXN_4172649,Salad,4,5.0,20.0,Digital Wallet,,2023-05-19
+TXN_6504096,Salad,5,5.0,25.0,Cash,,2023-09-10
+TXN_9921708,Cake,1,3.0,3.0,Cash,Takeaway,2023-07-20
+TXN_6361661,Smoothie,2,4.0,8.0,Cash,,2023-11-05
+TXN_4329116,Cake,3,3.0,9.0,Credit Card,In-store,2023-09-29
+TXN_4142781,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-01-30
+TXN_6055428,Salad,5,5.0,ERROR,Cash,Takeaway,2023-02-25
+TXN_4359885,Cookie,2,1.0,2.0,Credit Card,In-store,2023-01-16
+TXN_4255116,Juice,4,3.0,12.0,Credit Card,In-store,2023-12-24
+TXN_6511482,Tea,3,1.5,4.5,Credit Card,ERROR,2023-03-17
+TXN_9672367,Cookie,2,1.0,2.0,,In-store,2023-12-21
+TXN_1514364,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-01-21
+TXN_1643122,Juice,3,3.0,9.0,,In-store,2023-05-15
+TXN_2252586,Tea,3,1.5,4.5,Cash,Takeaway,2023-09-08
+TXN_8853027,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-06-21
+TXN_1489200,ERROR,1,3.0,3.0,UNKNOWN,ERROR,2023-03-27
+TXN_2351890,Tea,4,1.5,6.0,,In-store,2023-02-27
+TXN_1026050,Cake,1,3.0,3.0,ERROR,,2023-04-23
+TXN_3882139,Smoothie,4,4.0,16.0,,UNKNOWN,2023-12-28
+TXN_6296806,Sandwich,2,4.0,8.0,,Takeaway,UNKNOWN
+TXN_6149247,Sandwich,3,4.0,12.0,,Takeaway,2023-09-21
+TXN_3371429,Salad,2,5.0,10.0,Credit Card,,2023-11-01
+TXN_5136479,Sandwich,1,,4.0,,In-store,2023-01-04
+TXN_5722175,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-03-01
+TXN_4075198,Salad,5,5.0,25.0,Cash,,2023-08-27
+TXN_3865627,Coffee,4,2.0,8.0,,In-store,2023-02-16
+TXN_2136226,Juice,2,ERROR,6.0,Digital Wallet,In-store,2023-12-12
+TXN_2920551,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-11-27
+TXN_9206923,Sandwich,1,4.0,4.0,,,2023-11-16
+TXN_6335909,Salad,4,5.0,20.0,,In-store,2023-06-21
+TXN_8107970,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-06-03
+TXN_3435561,,2,3.0,6.0,UNKNOWN,Takeaway,
+TXN_8079747,UNKNOWN,2,5.0,10.0,Digital Wallet,,2023-03-18
+TXN_2135358,Cake,5,3.0,15.0,Credit Card,,2023-05-28
+TXN_1313701,Cookie,2,1.0,2.0,,,2023-10-03
+TXN_4035669,Juice,3,3.0,9.0,Cash,ERROR,2023-04-21
+TXN_5900899,,4,1.0,4.0,,Takeaway,UNKNOWN
+TXN_4037502,Coffee,2,,4.0,Cash,Takeaway,2023-08-10
+TXN_6879752,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-10-07
+TXN_8708666,Cake,4,ERROR,12.0,,Takeaway,2023-01-10
+TXN_5535579,Coffee,5,2.0,10.0,Cash,In-store,2023-12-21
+TXN_2449402,Smoothie,5,4.0,20.0,Cash,,2023-01-29
+TXN_6097759,Smoothie,4,4.0,16.0,Cash,In-store,2023-06-18
+TXN_9579740,Cake,3,3.0,9.0,Digital Wallet,,2023-03-05
+TXN_3026936,Cake,5,3.0,15.0,,,2023-05-19
+TXN_2532519,Cake,2,3.0,6.0,Digital Wallet,,2023-04-10
+TXN_9959765,Juice,4,3.0,12.0,Cash,,2023-02-19
+TXN_9514996,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-07-25
+TXN_6757560,Cake,4,3.0,12.0,Cash,,2023-08-12
+TXN_2222893,Coffee,4,2.0,8.0,,Takeaway,2023-12-20
+TXN_4346607,Salad,2,5.0,10.0,Digital Wallet,,2023-03-17
+TXN_2586830,Juice,1,3.0,3.0,UNKNOWN,In-store,2023-02-12
+TXN_2706461,Salad,3,5.0,15.0,Credit Card,ERROR,2023-12-13
+TXN_1829391,Juice,4,3.0,12.0,Credit Card,,2023-10-06
+TXN_5022805,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-12-17
+TXN_6815801,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-03-15
+TXN_2541441,Cake,1,3.0,3.0,Cash,Takeaway,2023-09-21
+TXN_5189465,Cookie,4,1.0,4.0,,Takeaway,2023-10-04
+TXN_1217810,Cookie,1,1.0,1.0,Digital Wallet,,2023-07-06
+TXN_4894647,Salad,2,5.0,10.0,Cash,Takeaway,2023-12-26
+TXN_7622855,Sandwich,2,4.0,8.0,Credit Card,,2023-07-10
+TXN_3215610,UNKNOWN,2,3.0,6.0,Digital Wallet,Takeaway,2023-06-14
+TXN_9931637,Cake,2,3.0,6.0,Cash,Takeaway,2023-09-17
+TXN_6625294,Sandwich,2,4.0,8.0,Digital Wallet,,2023-03-05
+TXN_4577368,Cake,4,3.0,12.0,Cash,,2023-05-29
+TXN_4158904,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-01-31
+TXN_3444569,UNKNOWN,1,4.0,ERROR,Credit Card,Takeaway,2023-10-07
+TXN_1208926,Cookie,4,1.0,4.0,Credit Card,In-store,2023-12-07
+TXN_8090361,Coffee,1,2.0,2.0,,,2023-03-12
+TXN_8363628,Salad,1,5.0,ERROR,Digital Wallet,,2023-04-07
+TXN_4761088,Cake,4,3.0,12.0,Digital Wallet,,2023-08-27
+TXN_2672126,UNKNOWN,3,1.0,3.0,Cash,,2023-07-07
+TXN_3232279,UNKNOWN,4,ERROR,16.0,UNKNOWN,Takeaway,2023-05-30
+TXN_8526941,Sandwich,5,UNKNOWN,20.0,,Takeaway,2023-03-16
+TXN_2453194,Cake,4,3.0,12.0,Digital Wallet,ERROR,2023-11-18
+TXN_9970195,Coffee,2,2.0,4.0,,UNKNOWN,2023-11-10
+TXN_4458848,Cookie,2,1.0,2.0,,In-store,2023-10-30
+TXN_1606273,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-11-02
+TXN_8053946,Tea,1,1.5,1.5,,Takeaway,2023-09-18
+TXN_7963189,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-03-24
+TXN_9151273,Tea,2,1.5,3.0,Cash,,2023-04-09
+TXN_4702345,Salad,4,5.0,20.0,Digital Wallet,,2023-01-08
+TXN_7972349,Cake,,3.0,12.0,,In-store,2023-04-19
+TXN_4832452,Tea,5,1.5,ERROR,Cash,,2023-02-05
+TXN_9314690,Salad,2,5.0,10.0,Credit Card,UNKNOWN,2023-12-11
+TXN_3852141,Cake,5,3.0,15.0,Credit Card,In-store,2023-08-04
+TXN_4723529,Sandwich,2,4.0,8.0,ERROR,ERROR,2023-03-25
+TXN_9537106,UNKNOWN,,4.0,12.0,,,2023-10-11
+TXN_6039321,Salad,2,5.0,10.0,Credit Card,,2023-02-15
+TXN_5797307,Tea,5,1.5,7.5,,In-store,2023-03-16
+TXN_4832566,Sandwich,4,4.0,16.0,Digital Wallet,In-store,ERROR
+TXN_2262398,Tea,1,1.5,,Credit Card,Takeaway,2023-09-12
+TXN_9813095,Juice,2,3.0,,Cash,,2023-06-12
+TXN_8627869,Juice,1,3.0,3.0,,,2023-10-31
+TXN_1123346,Tea,3,1.5,4.5,,,2023-07-31
+TXN_6729852,Cookie,4,1.0,4.0,UNKNOWN,,2023-06-29
+TXN_9300618,Tea,3,1.5,4.5,Credit Card,,2023-03-06
+TXN_7832527,Cake,3,3.0,9.0,Cash,In-store,2023-01-26
+TXN_4703100,Sandwich,1,4.0,4.0,,,2023-01-26
+TXN_1650385,Sandwich,1,4.0,4.0,ERROR,,2023-07-24
+TXN_3632068,UNKNOWN,2,3.0,6.0,Cash,,2023-08-29
+TXN_2132434,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-06-03
+TXN_3847176,Sandwich,3,4.0,12.0,,Takeaway,2023-05-07
+TXN_9691955,Juice,3,3.0,9.0,Credit Card,In-store,2023-11-03
+TXN_4985415,Tea,4,1.5,6.0,Digital Wallet,,2023-08-01
+TXN_1172121,Coffee,5,2.0,10.0,Cash,Takeaway,2023-08-26
+TXN_2521185,Smoothie,2,4.0,8.0,Cash,Takeaway,2023-03-20
+TXN_6233021,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-12-22
+TXN_7498795,Cookie,2,1.0,2.0,Cash,Takeaway,2023-03-11
+TXN_6730130,Tea,2,1.5,3.0,,,2023-10-16
+TXN_8810855,Sandwich,4,4.0,16.0,,UNKNOWN,2023-04-30
+TXN_1599516,Juice,3,3.0,9.0,Cash,In-store,2023-05-11
+TXN_6888839,Tea,3,1.5,,Digital Wallet,Takeaway,2023-11-19
+TXN_5970304,,4,5.0,20.0,Credit Card,,2023-07-14
+TXN_4559065,Juice,1,3.0,3.0,Cash,In-store,2023-05-03
+TXN_7637325,Cookie,4,1.0,4.0,,,2023-05-03
+TXN_9685491,Coffee,4,2.0,8.0,Cash,,2023-09-20
+TXN_1767321,Sandwich,1,4.0,4.0,,In-store,2023-03-24
+TXN_9046415,Smoothie,2,4.0,8.0,,UNKNOWN,2023-06-06
+TXN_3785168,,3,3.0,9.0,,Takeaway,2023-05-01
+TXN_6859249,Cookie,UNKNOWN,,2.0,,UNKNOWN,
+TXN_2696377,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-04-11
+TXN_7754382,Sandwich,4,4.0,16.0,Credit Card,ERROR,2023-06-28
+TXN_4602865,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-09-27
+TXN_5966765,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-11-09
+TXN_4328228,Sandwich,5,4.0,20.0,UNKNOWN,,2023-01-08
+TXN_2462604,Tea,5,1.5,7.5,Credit Card,,2023-07-13
+TXN_2897354,Juice,4,3.0,12.0,,In-store,2023-06-22
+TXN_5280256,ERROR,5,1.0,5.0,,In-store,2023-07-12
+TXN_3283631,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-03-15
+TXN_8929329,Juice,4,3.0,12.0,,,2023-10-29
+TXN_1328953,Smoothie,3,4.0,12.0,,,2023-12-28
+TXN_4852852,Smoothie,2,4.0,8.0,UNKNOWN,,2023-10-06
+TXN_4977954,Juice,4,3.0,12.0,Cash,,
+TXN_3344089,Sandwich,4,4.0,16.0,Cash,In-store,2023-08-10
+TXN_2909634,Smoothie,1,UNKNOWN,4.0,,Takeaway,2023-10-02
+TXN_7551280,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-04-14
+TXN_5390533,Smoothie,3,4.0,12.0,,In-store,2023-11-18
+TXN_8487216,Tea,1,1.5,1.5,Cash,,2023-07-01
+TXN_3863163,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-10-12
+TXN_4260865,Smoothie,4,4.0,16.0,,,2023-02-25
+TXN_7922471,Cake,3,3.0,9.0,Cash,,2023-04-18
+TXN_3701660,Sandwich,1,4.0,4.0,Digital Wallet,,
+TXN_3653560,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-07-01
+TXN_4075817,Cookie,2,1.0,2.0,Cash,,2023-03-18
+TXN_3715065,Salad,3,5.0,15.0,Credit Card,ERROR,2023-03-17
+TXN_9549208,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-10-30
+TXN_2919952,Juice,,3.0,15.0,Digital Wallet,In-store,2023-02-17
+TXN_2670824,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-03-03
+TXN_7455953,Coffee,2,2.0,4.0,,ERROR,2023-05-01
+TXN_5926432,Smoothie,4,4.0,16.0,Cash,In-store,2023-06-29
+TXN_8235381,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-03-01
+TXN_6206679,Tea,1,1.5,1.5,,In-store,2023-05-01
+TXN_2954630,Salad,2,5.0,10.0,Credit Card,,2023-09-30
+TXN_1402641,Tea,3,1.5,ERROR,Credit Card,Takeaway,2023-09-12
+TXN_6405489,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-05-04
+TXN_3003311,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-08-01
+TXN_3273540,UNKNOWN,1,3.0,3.0,Credit Card,,2023-08-21
+TXN_4570881,,1,2.0,2.0,,,2023-09-14
+TXN_3421404,UNKNOWN,4,4.0,16.0,Credit Card,,2023-05-05
+TXN_8468509,ERROR,,4.0,12.0,Credit Card,ERROR,2023-06-13
+TXN_9436342,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-11-26
+TXN_3110245,Cake,5,ERROR,15.0,Cash,Takeaway,2023-04-21
+TXN_1999100,Smoothie,3,4.0,12.0,Digital Wallet,,2023-11-08
+TXN_3654203,Coffee,1,,2.0,UNKNOWN,,2023-04-21
+TXN_2406283,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-02-24
+TXN_8964166,Juice,5,3.0,15.0,Cash,,2023-11-10
+TXN_1354464,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-03-18
+TXN_5582443,Salad,3,5.0,15.0,Credit Card,In-store,2023-04-13
+TXN_6204081,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-12
+TXN_4428307,Salad,3,5.0,15.0,Cash,In-store,
+TXN_8647048,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-11-03
+TXN_1689024,Coffee,5,2.0,ERROR,Credit Card,In-store,2023-04-17
+TXN_5422928,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-09-20
+TXN_9855567,Cookie,3,1.0,3.0,Credit Card,,2023-05-25
+TXN_3311860,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-11-21
+TXN_4147675,Tea,2,1.5,3.0,Credit Card,In-store,2023-01-04
+TXN_7560178,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-08-17
+TXN_4677478,Cake,4,3.0,12.0,,In-store,2023-07-09
+TXN_3930990,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-02-27
+TXN_8675922,ERROR,4,5.0,20.0,ERROR,,2023-03-31
+TXN_6621596,Salad,2,5.0,10.0,Credit Card,UNKNOWN,2023-09-25
+TXN_8076942,Cookie,2,1.0,2.0,Cash,Takeaway,2023-04-29
+TXN_4367689,Cookie,2,1.0,2.0,Cash,,2023-09-30
+TXN_2941800,Salad,5,5.0,25.0,Cash,,2023-04-25
+TXN_7072581,Cookie,2,1.0,2.0,Credit Card,,2023-08-12
+TXN_7809506,Salad,2,5.0,10.0,,Takeaway,2023-06-05
+TXN_6884558,,1,3.0,ERROR,Cash,In-store,2023-08-14
+TXN_6864420,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-06-18
+TXN_3109057,Tea,4,1.5,6.0,Cash,,2023-11-26
+TXN_2257337,Cookie,4,1.0,ERROR,Cash,ERROR,2023-07-24
+TXN_9417344,Tea,3,1.5,4.5,,Takeaway,2023-11-09
+TXN_6503884,Juice,1,3.0,3.0,Cash,In-store,2023-05-28
+TXN_9868954,Smoothie,4,4.0,16.0,Credit Card,,
+TXN_2206639,Coffee,4,2.0,8.0,Cash,Takeaway,2023-06-29
+TXN_9337894,Tea,2,1.5,3.0,,,2023-12-30
+TXN_7068361,Juice,5,3.0,15.0,Credit Card,,2023-12-25
+TXN_1405124,,3,4.0,12.0,Digital Wallet,Takeaway,2023-08-03
+TXN_2395608,Tea,3,UNKNOWN,4.5,Cash,In-store,2023-03-16
+TXN_5423024,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-04-30
+TXN_2802630,Cookie,4,1.0,4.0,,Takeaway,2023-06-18
+TXN_3134595,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-02-25
+TXN_2251128,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-06-07
+TXN_4213071,Salad,1,5.0,5.0,,Takeaway,2023-04-10
+TXN_6220280,Tea,1,1.5,1.5,Credit Card,,2023-02-15
+TXN_4832163,Cake,4,3.0,12.0,Cash,Takeaway,2023-11-17
+TXN_6663451,Cake,1,3.0,3.0,Cash,,2023-08-05
+TXN_1443928,Cake,4,3.0,12.0,Cash,Takeaway,2023-12-03
+TXN_1670597,Coffee,2,2.0,4.0,Cash,Takeaway,2023-05-21
+TXN_3854210,Smoothie,1,4.0,4.0,Cash,,2023-12-30
+TXN_2165745,Coffee,4,2.0,8.0,Credit Card,In-store,2023-01-31
+TXN_3082888,Tea,1,1.5,1.5,Cash,In-store,2023-09-20
+TXN_2294397,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-02-25
+TXN_4160784,Cookie,5,1.0,5.0,ERROR,In-store,2023-05-20
+TXN_7248594,Coffee,3,2.0,6.0,Credit Card,In-store,2023-03-26
+TXN_5031020,Coffee,5,2.0,10.0,,,2023-11-25
+TXN_3059966,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-12-24
+TXN_9287780,Smoothie,2,ERROR,8.0,Cash,In-store,2023-09-02
+TXN_1022220,Juice,3,3.0,9.0,,Takeaway,2023-08-03
+TXN_7144740,Cake,4,3.0,12.0,,,2023-07-24
+TXN_7666945,Tea,5,1.5,7.5,,,2023-07-07
+TXN_7880000,Salad,3,5.0,15.0,Credit Card,In-store,2023-01-28
+TXN_4900574,Juice,3,3.0,9.0,,,2023-05-06
+TXN_7838576,Coffee,3,2.0,6.0,,In-store,2023-11-11
+TXN_1419188,Cake,5,3.0,15.0,Credit Card,,2023-11-26
+TXN_1767201,ERROR,5,5.0,25.0,Credit Card,UNKNOWN,2023-07-12
+TXN_2964794,Cake,2,3.0,6.0,,Takeaway,2023-03-09
+TXN_3936162,Cookie,1,1.0,1.0,ERROR,,2023-02-26
+TXN_4432082,Juice,5,3.0,15.0,,,2023-04-20
+TXN_9496791,Salad,4,5.0,20.0,Credit Card,In-store,2023-07-19
+TXN_4194115,Tea,5,1.5,7.5,,,2023-08-17
+TXN_7741707,Salad,3,5.0,15.0,ERROR,Takeaway,2023-05-09
+TXN_8854471,Cake,5,3.0,15.0,Credit Card,,
+TXN_4216055,Cookie,5,1.0,5.0,Digital Wallet,,2023-12-27
+TXN_2320493,Smoothie,1,4.0,4.0,Digital Wallet,In-store,2023-03-22
+TXN_4835929,Coffee,2,2.0,4.0,,In-store,2023-10-03
+TXN_6755791,Coffee,2,2.0,4.0,Cash,,2023-04-01
+TXN_9861432,Cookie,2,1.0,2.0,,Takeaway,2023-12-09
+TXN_8271278,Tea,1,1.5,1.5,,,2023-07-01
+TXN_2005032,Cookie,2,1.0,2.0,Digital Wallet,,2023-11-30
+TXN_4208919,,3,UNKNOWN,12.0,,Takeaway,2023-05-30
+TXN_9699083,Smoothie,1,UNKNOWN,4.0,Cash,In-store,2023-02-12
+TXN_5714767,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-03-02
+TXN_5844851,Smoothie,5,4.0,20.0,,,2023-02-15
+TXN_7243779,,1,1.0,1.0,,In-store,ERROR
+TXN_8141558,Cake,5,3.0,15.0,Credit Card,UNKNOWN,2023-12-05
+TXN_4314314,Cake,4,3.0,12.0,Cash,ERROR,2023-01-02
+TXN_4155001,Smoothie,1,4.0,4.0,,,2023-11-30
+TXN_1072678,Juice,2,3.0,UNKNOWN,Cash,,2023-05-30
+TXN_7981162,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-05-30
+TXN_2316206,Cookie,1,1.0,1.0,Credit Card,In-store,2023-01-23
+TXN_7343342,Cookie,2,1.0,2.0,Cash,Takeaway,2023-12-21
+TXN_4573096,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-08-13
+TXN_3577482,,4,3.0,12.0,Digital Wallet,,2023-06-01
+TXN_6370625,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-08-26
+TXN_7580803,Juice,4,3.0,12.0,Cash,In-store,2023-04-06
+TXN_8306028,Salad,1,5.0,5.0,,Takeaway,2023-02-27
+TXN_7530692,Coffee,1,2.0,2.0,Credit Card,,2023-06-30
+TXN_4383002,Coffee,1,2.0,2.0,,In-store,2023-12-18
+TXN_2939069,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-09-06
+TXN_2301001,Smoothie,1,4.0,4.0,,Takeaway,2023-01-06
+TXN_5009924,Cake,3,3.0,9.0,Digital Wallet,,2023-09-08
+TXN_9988801,Smoothie,5,4.0,20.0,Cash,,2023-10-20
+TXN_7895514,,4,3.0,12.0,Digital Wallet,Takeaway,2023-08-06
+TXN_8432045,Cake,3,3.0,9.0,Credit Card,,2023-11-09
+TXN_8127433,Sandwich,3,4.0,12.0,,Takeaway,2023-07-11
+TXN_7640914,Salad,1,5.0,5.0,Credit Card,,2023-02-12
+TXN_4374963,Juice,1,3.0,3.0,Cash,In-store,2023-07-04
+TXN_3212317,Salad,5,5.0,25.0,,Takeaway,2023-05-25
+TXN_7744874,Coffee,1,2.0,2.0,Cash,,2023-06-28
+TXN_7768350,Cookie,1,1.0,,Cash,In-store,2023-08-19
+TXN_9128859,Coffee,2,2.0,4.0,,Takeaway,2023-11-28
+TXN_9375649,Cookie,4,1.0,4.0,,In-store,2023-03-06
+TXN_4401563,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-09-20
+TXN_8502946,Smoothie,3,4.0,12.0,UNKNOWN,In-store,2023-09-15
+TXN_8687294,Smoothie,3,4.0,12.0,Credit Card,,2023-08-01
+TXN_2176821,UNKNOWN,3,5.0,15.0,Digital Wallet,,2023-05-05
+TXN_2529216,Tea,3,UNKNOWN,4.5,Credit Card,In-store,
+TXN_8443384,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-02-13
+TXN_5053064,Salad,3,5.0,15.0,,,2023-06-19
+TXN_7824739,Cookie,3,1.0,3.0,Digital Wallet,,2023-07-17
+TXN_7226406,Cake,1,3.0,3.0,Credit Card,,2023-02-11
+TXN_9793806,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-04-25
+TXN_8195843,Cookie,4,1.0,4.0,,,2023-06-02
+TXN_6027923,UNKNOWN,1,5.0,5.0,Digital Wallet,Takeaway,2023-07-23
+TXN_5438652,Sandwich,4,4.0,16.0,Cash,,2023-03-17
+TXN_8385625,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-12-23
+TXN_7814715,Cookie,5,1.0,5.0,Cash,,2023-04-24
+TXN_6532452,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-02-24
+TXN_9706608,Smoothie,1,4.0,4.0,Cash,UNKNOWN,2023-05-22
+TXN_5963749,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-11-04
+TXN_6885218,Salad,1,5.0,5.0,,In-store,2023-10-23
+TXN_3845871,Sandwich,1,4.0,4.0,,In-store,2023-10-29
+TXN_5767392,Cake,5,3.0,15.0,Credit Card,,2023-10-24
+TXN_3014967,Salad,ERROR,5.0,5.0,UNKNOWN,UNKNOWN,
+TXN_8685281,Tea,1,UNKNOWN,1.5,Digital Wallet,In-store,2023-07-30
+TXN_3205079,Cake,5,3.0,15.0,Credit Card,,2023-11-07
+TXN_1523626,Cake,4,3.0,12.0,UNKNOWN,Takeaway,2023-07-21
+TXN_8944202,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-06-08
+TXN_2402993,Cookie,5,1.0,5.0,Cash,Takeaway,2023-06-11
+TXN_1340358,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-06-09
+TXN_6959328,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-04-23
+TXN_1613996,Juice,2,3.0,6.0,,In-store,2023-10-12
+TXN_9285475,Tea,5,1.5,7.5,Digital Wallet,ERROR,2023-11-14
+TXN_8077929,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-08-06
+TXN_7899009,,1,2.0,2.0,Cash,,2023-03-08
+TXN_9213505,Sandwich,2,4.0,8.0,UNKNOWN,,2023-11-01
+TXN_8724602,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-06-26
+TXN_9067597,Salad,4,UNKNOWN,20.0,Cash,Takeaway,2023-11-02
+TXN_9714116,Sandwich,4,4.0,16.0,,In-store,2023-11-17
+TXN_8987697,Cookie,5,1.0,5.0,Cash,,2023-12-19
+TXN_1940778,Tea,2,1.5,3.0,Cash,In-store,2023-02-01
+TXN_1776070,Sandwich,3,4.0,12.0,,,
+TXN_4271502,ERROR,2,3.0,6.0,,,2023-07-03
+TXN_8124795,Salad,5,5.0,25.0,ERROR,In-store,2023-08-11
+TXN_7860953,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-09-10
+TXN_8164119,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-01-07
+TXN_6070523,,4,2.0,8.0,Cash,,ERROR
+TXN_7809290,Cake,1,3.0,3.0,Cash,Takeaway,2023-10-14
+TXN_5332538,Coffee,3,2.0,6.0,,,2023-01-15
+TXN_7375024,,1,1.0,1.0,Cash,In-store,2023-12-10
+TXN_5675095,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-05-18
+TXN_4197851,Salad,ERROR,5.0,15.0,Digital Wallet,In-store,2023-02-05
+TXN_7931086,Sandwich,3,4.0,12.0,Credit Card,,2023-06-25
+TXN_2536573,,2,,8.0,Cash,In-store,2023-06-24
+TXN_3374262,,2,1.5,3.0,,In-store,2023-04-14
+TXN_9110336,Cookie,5,1.0,5.0,Digital Wallet,ERROR,2023-04-06
+TXN_3901665,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-10-19
+TXN_9211917,Smoothie,4,4.0,,,In-store,2023-12-17
+TXN_7893709,ERROR,4,3.0,12.0,Credit Card,,2023-03-14
+TXN_4296023,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-10-08
+TXN_3403409,Cake,2,3.0,6.0,,,2023-02-22
+TXN_1398511,Coffee,5,2.0,10.0,,Takeaway,2023-12-19
+TXN_4350854,Cookie,2,1.0,2.0,Cash,In-store,2023-01-31
+TXN_1867158,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-05-16
+TXN_2662711,Juice,1,3.0,3.0,UNKNOWN,,2023-11-02
+TXN_4439660,Coffee,3,2.0,6.0,,,2023-02-06
+TXN_9417252,Sandwich,2,4.0,8.0,Credit Card,,2023-08-17
+TXN_7502558,UNKNOWN,5,3.0,15.0,,In-store,2023-02-23
+TXN_8453282,Cookie,3,1.0,3.0,Cash,,2023-03-08
+TXN_5921766,Smoothie,3,4.0,12.0,,In-store,2023-11-06
+TXN_7688029,Cake,5,3.0,15.0,Credit Card,In-store,2023-05-30
+TXN_2000331,,3,4.0,12.0,,Takeaway,2023-03-30
+TXN_3420633,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-04-11
+TXN_3431892,Cake,2,3.0,6.0,,In-store,2023-07-18
+TXN_5220527,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-08-06
+TXN_1205773,Salad,5,5.0,25.0,Cash,,2023-01-27
+TXN_3061405,Smoothie,5,4.0,20.0,,Takeaway,2023-12-01
+TXN_8696857,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-10-01
+TXN_9668265,Cookie,3,1.0,3.0,Credit Card,,2023-06-20
+TXN_3638761,Juice,5,3.0,15.0,,ERROR,UNKNOWN
+TXN_7463102,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-11-27
+TXN_5569954,Cookie,4,1.0,4.0,Credit Card,In-store,UNKNOWN
+TXN_4547294,Tea,1,1.5,1.5,ERROR,,2023-09-30
+TXN_8430882,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-06-17
+TXN_9114647,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-11-19
+TXN_9556442,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,
+TXN_5413433,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-06-03
+TXN_9388222,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-04-21
+TXN_6618750,Smoothie,5,4.0,20.0,Credit Card,,2023-03-07
+TXN_6712087,Cake,2,3.0,6.0,,In-store,2023-06-06
+TXN_1862184,Coffee,4,2.0,8.0,,In-store,2023-01-21
+TXN_6149800,Sandwich,4,4.0,16.0,Digital Wallet,,2023-05-05
+TXN_6433525,Smoothie,2,4.0,8.0,,,2023-09-02
+TXN_2642834,Salad,2,5.0,10.0,Cash,,2023-11-13
+TXN_6745398,Tea,4,1.5,6.0,,,2023-02-28
+TXN_5660949,Cookie,3,1.0,3.0,Credit Card,In-store,2023-01-10
+TXN_9540340,Sandwich,2,4.0,8.0,Cash,,2023-11-15
+TXN_5200292,ERROR,4,5.0,20.0,Cash,,2023-01-12
+TXN_4118960,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-09-24
+TXN_2265543,Salad,3,5.0,15.0,,Takeaway,2023-02-19
+TXN_7360979,Sandwich,1,4.0,,,In-store,2023-08-16
+TXN_1849597,Sandwich,2,4.0,8.0,Cash,,2023-11-01
+TXN_3214521,Tea,4,1.5,6.0,,,2023-06-30
+TXN_5107249,Smoothie,4,4.0,16.0,Cash,UNKNOWN,2023-03-20
+TXN_1941099,UNKNOWN,5,1.0,5.0,Cash,ERROR,2023-04-14
+TXN_3228646,Cookie,5,1.0,5.0,Credit Card,,2023-09-19
+TXN_3295578,ERROR,1,3.0,3.0,UNKNOWN,In-store,2023-05-04
+TXN_3717422,Salad,2,5.0,10.0,Cash,,2023-06-15
+TXN_5350735,Tea,2,1.5,3.0,Cash,UNKNOWN,2023-04-08
+TXN_1128577,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-11-23
+TXN_6533267,Tea,3,1.5,4.5,Cash,In-store,2023-07-14
+TXN_1413310,Smoothie,3,4.0,12.0,,Takeaway,2023-04-06
+TXN_4166020,UNKNOWN,4,3.0,12.0,Digital Wallet,In-store,2023-08-18
+TXN_9496018,,5,1.5,7.5,,Takeaway,2023-01-05
+TXN_5609139,,2,1.5,3.0,Digital Wallet,,2023-10-13
+TXN_5087453,Tea,3,1.5,4.5,Cash,Takeaway,2023-04-09
+TXN_3312088,Cake,ERROR,3.0,3.0,Digital Wallet,,2023-08-17
+TXN_2049313,UNKNOWN,4,1.5,6.0,Credit Card,,2023-12-25
+TXN_4001774,Tea,5,1.5,7.5,,Takeaway,2023-02-10
+TXN_9627891,Coffee,2,2.0,4.0,Credit Card,In-store,2023-01-09
+TXN_5584275,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-07-10
+TXN_1873800,Smoothie,3,4.0,12.0,,In-store,2023-02-01
+TXN_3602823,Coffee,4,2.0,8.0,,,2023-08-26
+TXN_5528426,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-06-01
+TXN_7626322,UNKNOWN,4,3.0,12.0,Cash,Takeaway,2023-12-21
+TXN_4432546,Coffee,2,2.0,4.0,Digital Wallet,UNKNOWN,2023-11-29
+TXN_6372031,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-08-11
+TXN_6874059,Salad,4,5.0,20.0,,Takeaway,2023-01-12
+TXN_3843111,Smoothie,2,4.0,8.0,,,2023-09-15
+TXN_8916446,Cookie,2,1.0,2.0,Cash,ERROR,2023-07-19
+TXN_1823906,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-06-26
+TXN_2927941,ERROR,4,4.0,16.0,Credit Card,Takeaway,2023-08-29
+TXN_5972836,,3,4.0,12.0,Cash,Takeaway,2023-02-14
+TXN_7484638,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-10-17
+TXN_2073647,UNKNOWN,3,4.0,12.0,UNKNOWN,In-store,2023-09-01
+TXN_1610137,Coffee,3,2.0,6.0,Cash,Takeaway,2023-04-02
+TXN_9094628,Coffee,2,2.0,4.0,,In-store,2023-02-13
+TXN_2262195,Smoothie,3,4.0,12.0,Cash,,2023-10-13
+TXN_8047234,Juice,3,3.0,ERROR,Credit Card,ERROR,2023-08-29
+TXN_7108012,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-12-31
+TXN_3272946,Salad,3,5.0,15.0,Credit Card,In-store,2023-09-06
+TXN_6896663,Cake,3,3.0,9.0,,In-store,2023-05-16
+TXN_7308096,Tea,2,1.5,3.0,Cash,Takeaway,2023-08-13
+TXN_3607778,Smoothie,2,4.0,8.0,Cash,UNKNOWN,2023-11-20
+TXN_7105069,Coffee,1,2.0,ERROR,Cash,Takeaway,2023-12-06
+TXN_7461544,Cookie,4,1.0,4.0,Credit Card,,2023-08-22
+TXN_5853281,Coffee,4,2.0,8.0,,,2023-08-29
+TXN_5488764,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-06-30
+TXN_4268746,Cake,5,3.0,15.0,Credit Card,In-store,2023-01-12
+TXN_1767872,Salad,2,5.0,10.0,Credit Card,In-store,2023-01-05
+TXN_9684822,Juice,1,3.0,3.0,,ERROR,2023-11-18
+TXN_7208983,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-09-28
+TXN_8704128,Juice,5,3.0,15.0,UNKNOWN,,2023-02-25
+TXN_7971660,Cookie,3,1.0,3.0,Cash,Takeaway,2023-10-02
+TXN_6179190,Coffee,1,2.0,2.0,,Takeaway,2023-07-23
+TXN_9271577,Cake,2,3.0,6.0,Credit Card,In-store,2023-04-13
+TXN_3016203,UNKNOWN,1,5.0,5.0,Cash,In-store,2023-06-16
+TXN_6440555,Smoothie,1,4.0,4.0,Cash,In-store,2023-07-11
+TXN_5635779,ERROR,5,3.0,15.0,Cash,In-store,2023-07-01
+TXN_1022126,Tea,ERROR,1.5,4.5,,UNKNOWN,UNKNOWN
+TXN_9839214,Juice,1,3.0,3.0,Digital Wallet,,2023-12-25
+TXN_7368194,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-10-29
+TXN_1328230,Sandwich,5,4.0,20.0,Cash,,2023-02-03
+TXN_9789310,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-05-09
+TXN_6425706,Juice,1,3.0,3.0,,Takeaway,2023-12-09
+TXN_5996973,Sandwich,5,4.0,20.0,,In-store,2023-05-02
+TXN_2561970,Sandwich,3,4.0,12.0,,In-store,2023-03-16
+TXN_7137256,Sandwich,2,4.0,UNKNOWN,Cash,ERROR,2023-06-22
+TXN_5926982,Coffee,4,2.0,8.0,,Takeaway,2023-05-16
+TXN_3398611,Sandwich,5,4.0,20.0,Cash,,2023-10-01
+TXN_4539758,Sandwich,3,4.0,12.0,,In-store,2023-06-01
+TXN_6259087,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-12-27
+TXN_8152941,Coffee,3,2.0,6.0,,Takeaway,ERROR
+TXN_2987590,Sandwich,5,4.0,20.0,,In-store,2023-02-17
+TXN_6687029,Sandwich,2,UNKNOWN,8.0,Credit Card,In-store,2023-08-23
+TXN_1199898,Smoothie,1,4.0,4.0,Credit Card,,2023-10-26
+TXN_4787990,Cookie,3,1.0,3.0,Digital Wallet,,2023-02-04
+TXN_9606045,Tea,2,1.5,3.0,Digital Wallet,,2023-10-14
+TXN_1569248,Tea,1,1.5,1.5,Credit Card,,2023-11-14
+TXN_1151605,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-05-02
+TXN_4602430,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-01-31
+TXN_3232043,Tea,2,1.5,3.0,,In-store,2023-07-05
+TXN_3251340,Salad,4,5.0,20.0,,In-store,2023-06-18
+TXN_7412782,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-03-28
+TXN_5663260,Sandwich,4,,16.0,Digital Wallet,,2023-10-08
+TXN_5570967,Coffee,1,2.0,2.0,Credit Card,In-store,2023-12-12
+TXN_8271541,Smoothie,2,4.0,8.0,ERROR,,2023-09-07
+TXN_2238658,Tea,UNKNOWN,1.5,4.5,,Takeaway,2023-08-11
+TXN_2564718,Salad,5,5.0,25.0,,Takeaway,2023-10-10
+TXN_9050127,Sandwich,ERROR,4.0,20.0,Credit Card,Takeaway,2023-02-26
+TXN_6533450,Smoothie,1,4.0,4.0,,In-store,2023-11-22
+TXN_8046891,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-02-24
+TXN_7770487,Smoothie,1,4.0,4.0,Cash,In-store,2023-08-09
+TXN_2279313,Cookie,2,,2.0,Digital Wallet,In-store,2023-08-23
+TXN_9943050,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-05-16
+TXN_2694605,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-11-09
+TXN_2161957,Cookie,2,1.0,2.0,,Takeaway,2023-05-19
+TXN_3647474,Coffee,4,2.0,8.0,,Takeaway,2023-05-05
+TXN_4877601,,2,1.0,2.0,UNKNOWN,ERROR,2023-07-14
+TXN_7868470,Juice,3,ERROR,9.0,Digital Wallet,UNKNOWN,2023-04-14
+TXN_1927704,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-01-05
+TXN_4819416,Salad,3,ERROR,15.0,,,2023-06-01
+TXN_8076152,Tea,4,1.5,6.0,Digital Wallet,ERROR,2023-12-18
+TXN_9409405,ERROR,3,2.0,6.0,Digital Wallet,In-store,2023-02-11
+TXN_4055876,UNKNOWN,3,5.0,15.0,Credit Card,In-store,2023-10-15
+TXN_1929398,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-02-23
+TXN_2131494,Salad,2,5.0,10.0,Cash,,2023-02-27
+TXN_3093284,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-01-01
+TXN_3679245,Smoothie,4,4.0,16.0,,In-store,2023-09-16
+TXN_2276426,Juice,5,3.0,15.0,Credit Card,In-store,2023-10-21
+TXN_9608095,Coffee,1,2.0,2.0,Credit Card,In-store,2023-12-07
+TXN_9587704,Juice,5,3.0,15.0,Cash,Takeaway,2023-07-29
+TXN_9863114,Juice,UNKNOWN,3.0,15.0,,Takeaway,2023-02-01
+TXN_2372348,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-01-05
+TXN_6660602,,4,5.0,20.0,,Takeaway,2023-05-20
+TXN_3386311,Juice,1,3.0,3.0,Cash,In-store,2023-11-30
+TXN_7049149,ERROR,4,4.0,16.0,,,2023-08-27
+TXN_4112230,Smoothie,5,4.0,20.0,,Takeaway,2023-11-19
+TXN_1675510,Sandwich,3,4.0,12.0,,,2023-09-09
+TXN_5853158,UNKNOWN,ERROR,4.0,16.0,Cash,Takeaway,2023-09-25
+TXN_4187673,Juice,2,3.0,6.0,Digital Wallet,,2023-04-02
+TXN_3017494,Tea,1,1.5,1.5,UNKNOWN,Takeaway,2023-11-21
+TXN_8086161,Sandwich,,4.0,8.0,Cash,In-store,2023-03-10
+TXN_5729112,Coffee,1,2.0,2.0,Credit Card,,2023-06-30
+TXN_4613595,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-07-07
+TXN_4152991,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-12-17
+TXN_1196324,Tea,4,1.5,6.0,Credit Card,In-store,2023-09-26
+TXN_5944318,Cookie,1,1.0,1.0,Cash,UNKNOWN,2023-01-23
+TXN_5148823,Juice,1,3.0,3.0,Digital Wallet,,2023-03-27
+TXN_2887528,,2,3.0,6.0,,,2023-04-23
+TXN_7312736,Cookie,2,1.0,2.0,Digital Wallet,,2023-12-02
+TXN_5775717,Tea,3,ERROR,4.5,,Takeaway,2023-08-02
+TXN_4442095,Salad,4,5.0,20.0,Digital Wallet,,2023-02-18
+TXN_6621007,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-03-05
+TXN_6740691,Tea,1,1.5,1.5,Cash,ERROR,2023-07-06
+TXN_2548742,Salad,5,5.0,25.0,Digital Wallet,,UNKNOWN
+TXN_4359568,Coffee,3,2.0,6.0,,,2023-12-21
+TXN_3941164,Coffee,4,2.0,8.0,,ERROR,2023-04-16
+TXN_5244931,Coffee,1,UNKNOWN,2.0,ERROR,UNKNOWN,2023-09-30
+TXN_8181326,Tea,5,1.5,7.5,Cash,,2023-02-28
+TXN_8912589,Smoothie,3,4.0,12.0,Cash,ERROR,2023-10-19
+TXN_1234390,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-06-02
+TXN_5336437,Tea,5,1.5,7.5,Credit Card,,2023-05-07
+TXN_6271633,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-03-07
+TXN_4805204,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-04-25
+TXN_3094786,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-01-16
+TXN_7082667,,4,5.0,20.0,Cash,In-store,2023-08-03
+TXN_4807049,Cookie,1,1.0,1.0,Credit Card,,2023-06-07
+TXN_1840584,Cake,5,3.0,15.0,Digital Wallet,,2023-05-28
+TXN_8030379,Salad,4,5.0,20.0,Cash,In-store,2023-07-21
+TXN_7746634,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-07-04
+TXN_2361290,Salad,4,5.0,20.0,Cash,,2023-07-16
+TXN_7133645,Sandwich,5,4.0,20.0,Credit Card,Takeaway,
+TXN_3654299,Coffee,1,UNKNOWN,2.0,Cash,Takeaway,2023-09-19
+TXN_8811945,ERROR,1,5.0,5.0,UNKNOWN,,2023-02-18
+TXN_8659963,Cake,4,3.0,12.0,Cash,Takeaway,2023-01-21
+TXN_3676131,Coffee,3,2.0,6.0,UNKNOWN,ERROR,2023-09-11
+TXN_2935758,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-09-03
+TXN_1711730,Juice,5,3.0,15.0,UNKNOWN,Takeaway,2023-06-01
+TXN_8659575,UNKNOWN,2,1.5,3.0,Digital Wallet,,2023-12-17
+TXN_5360210,Tea,5,1.5,7.5,Cash,Takeaway,2023-06-29
+TXN_7970325,Cake,2,3.0,6.0,,Takeaway,2023-03-13
+TXN_8521037,Sandwich,1,4.0,4.0,,In-store,2023-11-21
+TXN_5473680,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-12-24
+TXN_6830192,UNKNOWN,3,3.0,ERROR,Digital Wallet,,2023-08-02
+TXN_5999810,UNKNOWN,4,4.0,16.0,Credit Card,Takeaway,2023-06-19
+TXN_6677631,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-12-14
+TXN_9775900,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-08-29
+TXN_2097072,Tea,4,1.5,6.0,UNKNOWN,In-store,
+TXN_2408143,Coffee,2,2.0,4.0,Digital Wallet,,2023-11-15
+TXN_6383779,Coffee,1,2.0,2.0,,ERROR,2023-11-29
+TXN_1342359,Cake,4,3.0,12.0,Cash,Takeaway,2023-07-14
+TXN_6975499,Coffee,1,2.0,,Digital Wallet,In-store,2023-07-03
+TXN_9861083,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-01-21
+TXN_8100384,Sandwich,UNKNOWN,4.0,4.0,Cash,,2023-11-08
+TXN_3762778,Coffee,5,2.0,10.0,,,2023-06-14
+TXN_4548698,Salad,2,5.0,10.0,Cash,Takeaway,2023-03-04
+TXN_8735820,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-12-08
+TXN_8803798,Smoothie,4,4.0,16.0,,,2023-07-14
+TXN_1950008,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-07-24
+TXN_3894173,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-10-07
+TXN_3630892,ERROR,4,1.0,4.0,,Takeaway,2023-01-31
+TXN_7436097,,5,2.0,10.0,ERROR,,2023-10-25
+TXN_4307602,ERROR,4,1.0,4.0,Cash,In-store,2023-12-30
+TXN_2394502,Cookie,4,ERROR,4.0,Digital Wallet,In-store,2023-12-22
+TXN_5308047,Cookie,UNKNOWN,ERROR,1.0,Credit Card,,2023-10-28
+TXN_5929797,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-05-12
+TXN_1228927,Tea,2,1.5,3.0,Credit Card,,2023-11-28
+TXN_6486912,Tea,2,1.5,3.0,,,2023-05-10
+TXN_3447069,Juice,2,3.0,6.0,Credit Card,,2023-03-11
+TXN_8219298,Juice,5,3.0,15.0,Credit Card,,2023-09-01
+TXN_1010950,Cookie,ERROR,1.0,1.0,Digital Wallet,Takeaway,2023-01-07
+TXN_6376329,Cake,1,3.0,3.0,,Takeaway,2023-03-30
+TXN_1897783,Smoothie,3,4.0,12.0,Cash,,2023-02-02
+TXN_4831525,Cookie,3,UNKNOWN,3.0,,,2023-08-05
+TXN_2767034,Salad,4,5.0,20.0,Cash,,2023-08-12
+TXN_9365766,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-02-13
+TXN_5680396,Sandwich,2,4.0,8.0,Digital Wallet,,2023-12-21
+TXN_3071092,Coffee,ERROR,UNKNOWN,4.0,ERROR,,2023-09-08
+TXN_6205234,Cake,5,3.0,15.0,Digital Wallet,,2023-04-09
+TXN_4489757,Smoothie,5,4.0,20.0,Credit Card,,2023-05-03
+TXN_8362750,Salad,4,5.0,20.0,,In-store,2023-04-01
+TXN_2422584,Tea,1,1.5,1.5,Cash,In-store,2023-11-28
+TXN_3966911,Tea,3,1.5,4.5,Credit Card,,2023-07-16
+TXN_6880338,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-11-06
+TXN_9362958,Juice,1,3.0,3.0,Cash,In-store,2023-07-19
+TXN_6815741,Smoothie,2,ERROR,8.0,,,2023-03-13
+TXN_4032956,Coffee,5,2.0,10.0,Credit Card,,2023-03-15
+TXN_7894069,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-11-20
+TXN_5296578,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-04-15
+TXN_2522047,Salad,1,ERROR,5.0,UNKNOWN,Takeaway,2023-12-05
+TXN_8211303,Salad,5,5.0,25.0,,,2023-08-26
+TXN_8472252,Smoothie,1,4.0,4.0,,,2023-02-04
+TXN_2435025,Juice,1,3.0,3.0,Cash,In-store,2023-10-08
+TXN_5179156,Coffee,5,2.0,10.0,ERROR,In-store,2023-10-25
+TXN_4197090,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-11-17
+TXN_4209626,,5,4.0,20.0,Credit Card,,2023-07-04
+TXN_8639995,ERROR,3,4.0,12.0,Cash,ERROR,2023-04-18
+TXN_1777171,Coffee,2,2.0,4.0,,In-store,2023-08-17
+TXN_5706734,Juice,1,3.0,3.0,Cash,UNKNOWN,2023-09-09
+TXN_6228847,Smoothie,3,4.0,12.0,Cash,,2023-01-13
+TXN_6479368,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-09-08
+TXN_6991528,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-08-17
+TXN_2154866,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-08-11
+TXN_1333524,Cake,2,3.0,6.0,Credit Card,,2023-05-05
+TXN_4367044,Smoothie,,4.0,4.0,Cash,,2023-05-02
+TXN_8903514,Salad,4,5.0,20.0,,Takeaway,2023-09-14
+TXN_5762828,Tea,2,1.5,3.0,Digital Wallet,UNKNOWN,2023-03-23
+TXN_2099497,Juice,1,3.0,3.0,,Takeaway,2023-02-27
+TXN_5679935,Coffee,2,2.0,4.0,Credit Card,,2023-07-19
+TXN_5236861,Coffee,4,2.0,8.0,Cash,Takeaway,2023-10-27
+TXN_9433035,Sandwich,1,4.0,4.0,Cash,In-store,2023-03-26
+TXN_4239051,Juice,2,3.0,6.0,Cash,,2023-09-30
+TXN_2970600,Salad,1,5.0,5.0,Credit Card,In-store,2023-08-18
+TXN_6226412,Juice,3,3.0,9.0,,Takeaway,2023-03-20
+TXN_2634805,,4,1.0,4.0,Digital Wallet,Takeaway,2023-06-25
+TXN_7543525,Tea,4,1.5,6.0,Credit Card,Takeaway,
+TXN_2571835,Salad,3,5.0,15.0,,In-store,2023-03-03
+TXN_5376589,Coffee,5,2.0,10.0,Cash,Takeaway,ERROR
+TXN_3984842,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-03-22
+TXN_1191068,Salad,1,5.0,5.0,,,2023-05-19
+TXN_9154713,Coffee,4,,8.0,Credit Card,In-store,2023-03-13
+TXN_2897727,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-02-15
+TXN_3801179,Juice,2,3.0,6.0,Cash,In-store,2023-12-07
+TXN_7116267,Smoothie,4,4.0,16.0,UNKNOWN,,2023-07-29
+TXN_9878237,Cake,1,3.0,UNKNOWN,Credit Card,,2023-10-06
+TXN_2153838,Tea,4,1.5,ERROR,Digital Wallet,In-store,2023-12-19
+TXN_7835785,Salad,1,5.0,5.0,Cash,In-store,2023-10-12
+TXN_5335079,Cake,1,3.0,3.0,Cash,In-store,2023-02-20
+TXN_7521634,UNKNOWN,3,1.0,3.0,,Takeaway,2023-01-22
+TXN_2174821,Coffee,1,2.0,2.0,,,2023-11-08
+TXN_5951573,Salad,3,5.0,15.0,Cash,,2023-12-22
+TXN_4612146,Cake,3,3.0,9.0,Cash,ERROR,2023-12-31
+TXN_7954368,Cake,3,3.0,9.0,Credit Card,,2023-10-06
+TXN_7898391,Salad,4,5.0,20.0,Credit Card,UNKNOWN,2023-02-26
+TXN_5746800,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-07-04
+TXN_4630658,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-07-10
+TXN_6096492,Sandwich,5,4.0,20.0,UNKNOWN,Takeaway,2023-12-23
+TXN_8918905,Cookie,5,1.0,5.0,Digital Wallet,In-store,2023-06-05
+TXN_5906365,Cookie,1,1.0,1.0,,,2023-03-13
+TXN_3956062,Coffee,3,2.0,6.0,,Takeaway,2023-06-04
+TXN_6610487,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-09-18
+TXN_1381818,Juice,4,3.0,12.0,Credit Card,,UNKNOWN
+TXN_7821658,Coffee,5,2.0,10.0,,In-store,2023-09-03
+TXN_6396940,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-02-26
+TXN_2556368,Smoothie,1,4.0,4.0,Digital Wallet,,2023-10-26
+TXN_7655838,Juice,3,3.0,9.0,Digital Wallet,,2023-01-22
+TXN_7241859,Cookie,1,1.0,1.0,,,
+TXN_2807590,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-09-05
+TXN_7252860,Cookie,3,ERROR,3.0,Digital Wallet,Takeaway,2023-06-18
+TXN_5381129,Cookie,5,1.0,5.0,,ERROR,2023-04-20
+TXN_1474329,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-03-02
+TXN_5935394,Coffee,4,2.0,8.0,Digital Wallet,,2023-04-16
+TXN_1488458,Coffee,4,2.0,8.0,,,2023-08-21
+TXN_7964661,Cake,3,3.0,9.0,Cash,ERROR,2023-04-01
+TXN_2798736,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-01-15
+TXN_5007051,Salad,2,5.0,10.0,Digital Wallet,,2023-12-26
+TXN_2325141,Tea,3,1.5,4.5,Digital Wallet,,2023-08-26
+TXN_1489194,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-07-18
+TXN_9531201,Sandwich,2,4.0,8.0,,ERROR,2023-05-28
+TXN_7627772,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-10-22
+TXN_4349970,Cookie,5,1.0,5.0,UNKNOWN,In-store,2023-05-25
+TXN_3936883,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-09-08
+TXN_1817275,Salad,2,5.0,10.0,Cash,In-store,2023-09-02
+TXN_8018272,Smoothie,4,4.0,ERROR,,,2023-03-01
+TXN_3617989,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-09-29
+TXN_1566564,Cookie,3,1.0,3.0,Credit Card,Takeaway,2023-09-08
+TXN_5170047,Salad,4,5.0,20.0,Cash,,2023-12-15
+TXN_6513163,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-04-01
+TXN_7014478,Smoothie,5,4.0,20.0,Cash,,2023-04-26
+TXN_9929732,Sandwich,4,4.0,16.0,Credit Card,,2023-10-04
+TXN_2346362,Juice,4,3.0,12.0,,In-store,2023-12-30
+TXN_6748232,,2,4.0,8.0,Credit Card,In-store,ERROR
+TXN_9039882,Smoothie,4,4.0,16.0,,In-store,2023-08-31
+TXN_7440057,Juice,1,3.0,3.0,Credit Card,,2023-07-05
+TXN_9894831,Cake,5,3.0,15.0,ERROR,,2023-07-05
+TXN_2911863,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-07-09
+TXN_1991987,Cake,3,3.0,9.0,Credit Card,In-store,2023-10-22
+TXN_7232524,Cookie,3,1.0,3.0,Cash,In-store,2023-12-23
+TXN_5315665,Tea,3,1.5,4.5,Credit Card,,
+TXN_7476348,Coffee,2,2.0,4.0,ERROR,In-store,2023-10-09
+TXN_4165923,Sandwich,3,4.0,12.0,,Takeaway,2023-03-14
+TXN_1467367,Sandwich,3,4.0,12.0,,,2023-02-18
+TXN_2018943,Smoothie,UNKNOWN,4.0,20.0,,,2023-05-27
+TXN_4234636,Smoothie,1,4.0,ERROR,Credit Card,In-store,2023-01-30
+TXN_4750383,Coffee,2,2.0,4.0,Cash,,2023-06-30
+TXN_5100579,UNKNOWN,2,1.0,2.0,Cash,Takeaway,2023-10-08
+TXN_1701465,Cake,1,3.0,3.0,Cash,,2023-06-15
+TXN_8941409,Cake,3,3.0,9.0,ERROR,,2023-11-12
+TXN_9598764,Juice,ERROR,3.0,6.0,Credit Card,In-store,2023-09-06
+TXN_2834323,UNKNOWN,1,1.5,1.5,Digital Wallet,Takeaway,2023-05-13
+TXN_2480488,Juice,2,3.0,6.0,Cash,Takeaway,2023-03-01
+TXN_6158834,Coffee,2,2.0,4.0,Credit Card,ERROR,2023-09-23
+TXN_2345326,Cookie,,1.0,3.0,Digital Wallet,Takeaway,2023-01-29
+TXN_8872103,Smoothie,,4.0,12.0,Digital Wallet,In-store,2023-07-02
+TXN_9773646,Cake,4,3.0,ERROR,Credit Card,Takeaway,2023-04-01
+TXN_1442096,Cookie,3,1.0,3.0,Credit Card,In-store,2023-06-27
+TXN_2337888,Coffee,1,2.0,2.0,Credit Card,In-store,2023-02-10
+TXN_8297751,Salad,3,5.0,15.0,Cash,Takeaway,2023-04-08
+TXN_9675838,Cake,2,3.0,6.0,Digital Wallet,,2023-02-06
+TXN_9241048,Cake,4,3.0,12.0,Credit Card,In-store,2023-08-27
+TXN_1978687,Juice,2,3.0,6.0,,ERROR,2023-12-13
+TXN_7548260,Juice,2,3.0,6.0,Cash,Takeaway,2023-02-27
+TXN_7047040,Salad,2,5.0,10.0,UNKNOWN,,2023-02-16
+TXN_1234907,Juice,1,3.0,3.0,Credit Card,In-store,2023-05-02
+TXN_8821839,Sandwich,5,4.0,20.0,ERROR,Takeaway,2023-11-11
+TXN_7543765,Cake,1,3.0,3.0,,,2023-10-26
+TXN_7317475,Salad,4,5.0,20.0,Cash,Takeaway,2023-06-21
+TXN_9786525,Cake,5,3.0,15.0,,Takeaway,2023-02-19
+TXN_9874256,Juice,3,3.0,9.0,,,2023-02-17
+TXN_3120637,Sandwich,3,4.0,12.0,,Takeaway,2023-08-11
+TXN_6754546,Cake,3,3.0,9.0,ERROR,,2023-02-19
+TXN_1317114,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-11-06
+TXN_3897788,Juice,ERROR,3.0,15.0,Digital Wallet,In-store,2023-10-26
+TXN_8046087,Cake,2,3.0,6.0,,Takeaway,2023-04-15
+TXN_6655017,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-12-04
+TXN_6610162,Cake,,3.0,12.0,Digital Wallet,ERROR,2023-03-18
+TXN_7478306,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-06-14
+TXN_3163567,Salad,2,5.0,,Digital Wallet,Takeaway,2023-06-01
+TXN_6420900,Tea,3,1.5,4.5,,,2023-09-18
+TXN_2526267,Sandwich,UNKNOWN,4.0,20.0,Cash,In-store,2023-04-06
+TXN_3954378,Tea,4,1.5,6.0,Cash,ERROR,2023-08-21
+TXN_5138053,Sandwich,5,4.0,20.0,UNKNOWN,Takeaway,2023-02-16
+TXN_9890279,Smoothie,4,,16.0,,In-store,2023-09-06
+TXN_3456057,Sandwich,1,4.0,UNKNOWN,,Takeaway,ERROR
+TXN_9626920,,2,1.5,3.0,,In-store,2023-12-16
+TXN_7213830,,5,3.0,15.0,Credit Card,,2023-08-04
+TXN_4224350,Tea,2,1.5,3.0,,In-store,2023-07-09
+TXN_7763212,Sandwich,1,4.0,4.0,Credit Card,,2023-01-10
+TXN_6889357,Salad,1,5.0,5.0,Cash,Takeaway,2023-03-08
+TXN_8565218,Cake,1,3.0,3.0,Digital Wallet,UNKNOWN,2023-05-03
+TXN_8235675,Tea,1,1.5,1.5,Credit Card,,2023-08-08
+TXN_6323915,Tea,3,1.5,,Credit Card,In-store,2023-02-09
+TXN_4704321,Cake,3,3.0,,Cash,,ERROR
+TXN_3232227,Cookie,4,1.0,4.0,,Takeaway,2023-03-30
+TXN_2931403,Juice,2,3.0,6.0,Credit Card,In-store,2023-05-29
+TXN_8036247,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-09-29
+TXN_4143264,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-08-17
+TXN_3709117,Smoothie,5,4.0,UNKNOWN,Cash,,2023-02-04
+TXN_5124519,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-09-07
+TXN_1529845,Juice,3,3.0,9.0,Credit Card,In-store,2023-01-25
+TXN_4615245,Sandwich,4,4.0,16.0,,,2023-04-26
+TXN_1464694,Sandwich,1,4.0,ERROR,,In-store,2023-07-23
+TXN_2674372,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-11-14
+TXN_7215900,Coffee,3,2.0,6.0,Cash,Takeaway,2023-08-26
+TXN_5578380,Tea,ERROR,1.5,6.0,,In-store,ERROR
+TXN_6622980,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-09-26
+TXN_5744026,Salad,4,5.0,20.0,,,2023-04-03
+TXN_1759314,Salad,5,5.0,25.0,,,2023-08-23
+TXN_2050630,Cookie,3,1.0,3.0,,Takeaway,2023-01-18
+TXN_3447575,Sandwich,4,4.0,,Credit Card,Takeaway,2023-01-17
+TXN_1131785,Sandwich,1,4.0,4.0,Cash,,2023-12-19
+TXN_8572783,Salad,3,5.0,15.0,,,2023-03-29
+TXN_7928378,,3,UNKNOWN,12.0,Cash,,2023-07-04
+TXN_4284507,Smoothie,4,4.0,16.0,,UNKNOWN,2023-07-17
+TXN_9819697,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-05-16
+TXN_1731476,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-04-19
+TXN_4152262,UNKNOWN,2,5.0,10.0,Digital Wallet,In-store,2023-06-19
+TXN_1721342,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-08-23
+TXN_7278328,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-01-29
+TXN_6037924,Coffee,4,2.0,8.0,,Takeaway,2023-11-14
+TXN_7046631,ERROR,4,2.0,8.0,Digital Wallet,In-store,2023-05-18
+TXN_7979028,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-07-12
+TXN_2474395,Smoothie,4,4.0,16.0,Digital Wallet,Takeaway,2023-12-28
+TXN_9168898,Juice,2,3.0,6.0,Cash,Takeaway,2023-09-28
+TXN_9675940,Juice,5,3.0,15.0,Credit Card,In-store,2023-06-02
+TXN_3618603,Salad,4,5.0,20.0,Cash,,2023-03-19
+TXN_9653377,Sandwich,2,4.0,8.0,ERROR,Takeaway,2023-07-31
+TXN_1326993,Cookie,3,1.0,3.0,UNKNOWN,In-store,2023-12-30
+TXN_7427357,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-10-31
+TXN_5806624,Cookie,5,1.0,5.0,Credit Card,In-store,2023-07-09
+TXN_8329144,ERROR,2,4.0,8.0,Digital Wallet,In-store,2023-03-04
+TXN_6670371,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-05-01
+TXN_8708588,Coffee,5,2.0,10.0,Digital Wallet,,2023-06-03
+TXN_6755874,Smoothie,3,4.0,UNKNOWN,ERROR,In-store,2023-04-12
+TXN_7777864,Cookie,3,1.0,,,In-store,2023-02-06
+TXN_1309055,UNKNOWN,2,2.0,4.0,Credit Card,Takeaway,2023-11-09
+TXN_2250398,,3,3.0,9.0,Digital Wallet,,2023-05-31
+TXN_8698717,Coffee,4,2.0,8.0,Digital Wallet,,2023-05-11
+TXN_2302259,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-09-20
+TXN_7004494,Coffee,4,2.0,8.0,,Takeaway,2023-03-17
+TXN_1302920,Coffee,2,2.0,4.0,,,2023-08-16
+TXN_8175702,Tea,1,1.5,1.5,,Takeaway,2023-08-27
+TXN_4921865,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-02-06
+TXN_7755372,Juice,5,3.0,15.0,,Takeaway,2023-01-10
+TXN_7218134,Cake,5,3.0,ERROR,Cash,,2023-01-14
+TXN_2897794,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-01-29
+TXN_5743616,Cake,4,3.0,12.0,,UNKNOWN,2023-12-14
+TXN_4623642,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-09-12
+TXN_6047710,Smoothie,3,4.0,12.0,,Takeaway,2023-06-16
+TXN_2813872,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-05-01
+TXN_1891978,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-09-13
+TXN_6626928,Sandwich,2,4.0,8.0,,In-store,2023-05-10
+TXN_6320502,Juice,4,3.0,12.0,Credit Card,,2023-08-16
+TXN_1797690,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-08-10
+TXN_4587806,Cookie,4,1.0,,ERROR,,2023-07-27
+TXN_7735127,Smoothie,1,4.0,ERROR,,Takeaway,2023-02-22
+TXN_9831537,Cake,4,3.0,12.0,Credit Card,,2023-08-07
+TXN_7866805,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-03-14
+TXN_1760092,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-04-15
+TXN_1887555,Juice,2,3.0,6.0,Cash,In-store,2023-01-08
+TXN_9872258,Juice,4,3.0,12.0,Cash,Takeaway,2023-07-24
+TXN_2437725,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-01-27
+TXN_3240077,,4,4.0,16.0,Cash,,2023-12-14
+TXN_6581580,Coffee,3,2.0,6.0,,In-store,2023-06-18
+TXN_6440109,Cake,2,3.0,6.0,UNKNOWN,In-store,2023-09-09
+TXN_8790282,Coffee,3,2.0,6.0,UNKNOWN,,2023-10-18
+TXN_7581760,Coffee,3,2.0,6.0,,,2023-08-13
+TXN_2903973,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-12-26
+TXN_9107842,Tea,2,1.5,3.0,,Takeaway,2023-12-04
+TXN_8306630,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-04-26
+TXN_2194660,UNKNOWN,1,5.0,5.0,,,
+TXN_4612207,Juice,5,3.0,15.0,Digital Wallet,,2023-01-21
+TXN_1811216,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-01-18
+TXN_3739424,,1,3.0,3.0,Credit Card,,2023-06-03
+TXN_9487384,Cake,1,3.0,3.0,Credit Card,,2023-11-27
+TXN_2205690,Cookie,5,1.0,5.0,,In-store,2023-03-02
+TXN_9219961,Coffee,5,2.0,10.0,Credit Card,ERROR,2023-04-04
+TXN_6425954,Sandwich,2,4.0,8.0,,In-store,2023-03-28
+TXN_9131153,Smoothie,3,4.0,12.0,,Takeaway,2023-11-17
+TXN_1332623,Cookie,2,1.0,2.0,,Takeaway,2023-07-15
+TXN_9248370,ERROR,2,1.0,2.0,Credit Card,In-store,2023-02-17
+TXN_5549522,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-12-16
+TXN_4234750,Juice,2,3.0,6.0,Cash,,2023-09-03
+TXN_9694799,Tea,3,1.5,4.5,Cash,Takeaway,2023-04-14
+TXN_6733436,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-02-02
+TXN_4423879,Juice,5,UNKNOWN,15.0,ERROR,,2023-02-12
+TXN_8496788,Juice,4,3.0,12.0,Cash,,2023-06-14
+TXN_3131168,Sandwich,3,4.0,12.0,Cash,,2023-03-24
+TXN_1995528,Coffee,5,2.0,10.0,,In-store,2023-06-24
+TXN_2311707,Tea,5,ERROR,7.5,Cash,In-store,2023-08-03
+TXN_9617269,Coffee,1,2.0,2.0,Digital Wallet,,ERROR
+TXN_1727281,Juice,4,3.0,12.0,,Takeaway,2023-01-05
+TXN_2437112,Cookie,3,1.0,3.0,,,2023-04-06
+TXN_8240436,Salad,5,5.0,25.0,,In-store,2023-07-05
+TXN_4177796,Juice,4,3.0,ERROR,Cash,Takeaway,2023-04-17
+TXN_9761314,,4,4.0,16.0,Credit Card,,2023-12-14
+TXN_2905118,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-03-04
+TXN_8058105,Tea,3,1.5,4.5,Cash,,2023-03-07
+TXN_5005793,Sandwich,4,4.0,16.0,Credit Card,In-store,2023-01-21
+TXN_2840861,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-05-31
+TXN_1088497,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-07-05
+TXN_4083872,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-08-05
+TXN_5296083,Sandwich,3,4.0,12.0,,,2023-12-08
+TXN_3052953,Coffee,5,2.0,10.0,Digital Wallet,,2023-02-28
+TXN_2017793,Tea,,1.5,4.5,Digital Wallet,,2023-07-18
+TXN_4064326,Cookie,2,1.0,2.0,Cash,Takeaway,2023-01-07
+TXN_8749775,Cake,5,3.0,15.0,Cash,Takeaway,2023-10-30
+TXN_6541284,Tea,4,1.5,6.0,Cash,Takeaway,2023-03-01
+TXN_7937905,Salad,5,5.0,25.0,,,2023-10-15
+TXN_1311519,Smoothie,5,4.0,20.0,Cash,,2023-01-28
+TXN_8209509,Cookie,4,1.0,4.0,,Takeaway,2023-11-09
+TXN_3413156,Juice,1,3.0,3.0,Credit Card,In-store,2023-10-16
+TXN_3130302,Smoothie,3,4.0,12.0,Credit Card,In-store,UNKNOWN
+TXN_7418152,Cookie,4,1.0,4.0,Cash,Takeaway,2023-09-21
+TXN_7991782,Juice,2,3.0,6.0,,In-store,2023-01-11
+TXN_2822949,Smoothie,2,4.0,8.0,Digital Wallet,,2023-11-19
+TXN_5868082,Coffee,5,2.0,10.0,Credit Card,In-store,2023-10-22
+TXN_1559521,UNKNOWN,5,2.0,10.0,UNKNOWN,In-store,2023-07-05
+TXN_2250898,Smoothie,,4.0,12.0,Credit Card,,2023-12-23
+TXN_2947622,Smoothie,5,4.0,20.0,UNKNOWN,,2023-08-06
+TXN_1413335,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-05-17
+TXN_7086603,Cake,4,3.0,,Credit Card,,2023-03-18
+TXN_6919325,Cake,3,3.0,9.0,Cash,UNKNOWN,2023-02-05
+TXN_7286934,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-03-27
+TXN_5213014,Sandwich,3,4.0,ERROR,Credit Card,,2023-05-09
+TXN_3121483,Salad,2,5.0,10.0,,Takeaway,2023-01-06
+TXN_1670848,Cake,2,ERROR,6.0,Credit Card,ERROR,2023-08-04
+TXN_7595042,Salad,1,5.0,5.0,,Takeaway,2023-04-03
+TXN_3447594,ERROR,1,5.0,5.0,Digital Wallet,In-store,2023-02-24
+TXN_9250024,Cookie,2,1.0,2.0,Digital Wallet,,2023-03-21
+TXN_1353266,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-30
+TXN_3950331,Tea,5,1.5,7.5,Digital Wallet,,2023-03-02
+TXN_3766657,Smoothie,5,4.0,20.0,UNKNOWN,,2023-08-16
+TXN_6034596,ERROR,1,5.0,5.0,,Takeaway,2023-04-07
+TXN_7233393,Juice,5,3.0,15.0,Credit Card,In-store,2023-11-22
+TXN_8273645,Juice,2,3.0,6.0,Cash,Takeaway,2023-11-02
+TXN_2474286,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-12-09
+TXN_5145016,Sandwich,1,4.0,4.0,Cash,Takeaway,UNKNOWN
+TXN_6700141,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-04-12
+TXN_4006771,Cookie,3,1.0,3.0,Credit Card,UNKNOWN,2023-02-06
+TXN_4406290,Coffee,5,2.0,10.0,,In-store,2023-07-02
+TXN_2714524,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-01-02
+TXN_3585097,Coffee,3,2.0,6.0,,Takeaway,2023-05-31
+TXN_5432582,Juice,3,3.0,9.0,UNKNOWN,,2023-08-30
+TXN_5367923,Sandwich,4,4.0,16.0,,,2023-04-19
+TXN_4030519,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-01-22
+TXN_8716594,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-08-26
+TXN_5159483,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-05-24
+TXN_6347482,Tea,2,1.5,3.0,Digital Wallet,,2023-07-10
+TXN_4688236,Coffee,4,2.0,8.0,Cash,In-store,2023-07-05
+TXN_7021722,Tea,3,1.5,4.5,,Takeaway,2023-07-27
+TXN_1466002,ERROR,3,3.0,9.0,,,2023-11-23
+TXN_4878020,Cake,3,3.0,9.0,UNKNOWN,In-store,2023-03-17
+TXN_3158921,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-04-16
+TXN_8555334,Coffee,1,2.0,2.0,,In-store,2023-06-16
+TXN_9749790,Tea,3,,4.5,,Takeaway,2023-10-17
+TXN_7476268,Juice,2,3.0,6.0,Credit Card,,2023-06-07
+TXN_2741928,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-10-06
+TXN_8477945,Cookie,4,1.0,4.0,,In-store,2023-07-19
+TXN_2838958,Coffee,1,2.0,2.0,Cash,Takeaway,2023-03-10
+TXN_4937411,Juice,1,3.0,3.0,,Takeaway,2023-08-21
+TXN_1293509,Juice,3,3.0,9.0,Cash,In-store,UNKNOWN
+TXN_1124655,Salad,3,5.0,15.0,Cash,,2023-10-23
+TXN_1367723,Coffee,3,2.0,,Cash,In-store,2023-10-25
+TXN_1710476,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-05-22
+TXN_2248497,Salad,2,5.0,10.0,Cash,Takeaway,2023-03-07
+TXN_9403754,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-06-19
+TXN_2457189,,3,4.0,12.0,Digital Wallet,Takeaway,2023-08-28
+TXN_2495788,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-12-16
+TXN_7528294,Juice,3,3.0,9.0,Digital Wallet,,2023-09-27
+TXN_2844982,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-03-04
+TXN_9345439,Coffee,2,2.0,4.0,Cash,Takeaway,2023-08-07
+TXN_4558455,UNKNOWN,3,5.0,15.0,Credit Card,In-store,
+TXN_6347567,Juice,5,UNKNOWN,15.0,Cash,In-store,2023-03-31
+TXN_9710430,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-01-10
+TXN_8859035,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-01-19
+TXN_7131251,Tea,2,1.5,3.0,ERROR,In-store,2023-06-28
+TXN_9577339,Cake,2,3.0,6.0,Digital Wallet,,2023-03-10
+TXN_9206049,Cookie,1,1.0,1.0,Credit Card,In-store,2023-09-17
+TXN_8748070,Cookie,2,1.0,2.0,Credit Card,In-store,2023-07-31
+TXN_1079241,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-07-16
+TXN_8250845,Cookie,1,1.0,1.0,Cash,,2023-12-09
+TXN_7878520,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-08-29
+TXN_8990101,Smoothie,5,UNKNOWN,20.0,,In-store,2023-11-25
+TXN_8789137,Sandwich,1,4.0,4.0,,Takeaway,2023-09-25
+TXN_1236779,Juice,3,,9.0,Credit Card,In-store,2023-12-29
+TXN_6846861,Smoothie,4,4.0,16.0,,In-store,2023-11-26
+TXN_7682621,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-11-07
+TXN_2770536,Smoothie,2,4.0,8.0,,In-store,2023-11-03
+TXN_3291900,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-05-04
+TXN_1390917,Sandwich,1,4.0,4.0,Credit Card,,2023-01-16
+TXN_5406411,UNKNOWN,5,4.0,20.0,Credit Card,In-store,2023-04-14
+TXN_4628338,Coffee,,2.0,ERROR,Cash,,2023-12-25
+TXN_4532280,Coffee,ERROR,2.0,10.0,Credit Card,,2023-01-10
+TXN_2879543,Juice,5,3.0,15.0,ERROR,,2023-03-30
+TXN_7334418,Cookie,2,1.0,2.0,Digital Wallet,UNKNOWN,2023-03-24
+TXN_7927109,Tea,1,1.5,1.5,Cash,,2023-04-18
+TXN_9352814,Tea,4,1.5,6.0,Cash,UNKNOWN,2023-09-10
+TXN_8872984,Salad,5,,UNKNOWN,Credit Card,In-store,2023-08-23
+TXN_8305586,Coffee,4,2.0,8.0,Cash,,2023-01-06
+TXN_6501091,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-05-07
+TXN_8197935,Sandwich,5,ERROR,20.0,Cash,In-store,2023-03-28
+TXN_8349096,Cookie,5,1.0,5.0,,,2023-12-12
+TXN_1721366,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-04-09
+TXN_3924170,Tea,3,1.5,4.5,Credit Card,In-store,2023-08-07
+TXN_6206421,Sandwich,2,4.0,8.0,,In-store,2023-04-06
+TXN_3740465,Cookie,4,1.0,4.0,Digital Wallet,,2023-03-08
+TXN_5227798,Salad,4,5.0,20.0,Cash,,2023-09-02
+TXN_9374286,Coffee,5,2.0,10.0,Cash,In-store,2023-08-07
+TXN_6577619,Salad,3,5.0,15.0,Credit Card,In-store,2023-07-22
+TXN_5154112,Cake,3,3.0,9.0,Credit Card,Takeaway,
+TXN_5209716,UNKNOWN,,1.0,5.0,Cash,,2023-10-06
+TXN_6412590,Salad,1,5.0,5.0,Digital Wallet,,2023-06-12
+TXN_1577802,Juice,2,3.0,6.0,Credit Card,In-store,2023-11-29
+TXN_3202346,Salad,2,5.0,10.0,,In-store,2023-11-19
+TXN_2141924,Salad,5,5.0,25.0,Cash,In-store,2023-11-27
+TXN_6775972,Coffee,3,2.0,6.0,Credit Card,,2023-09-15
+TXN_8799599,Coffee,1,2.0,2.0,Credit Card,UNKNOWN,2023-09-10
+TXN_2866735,Cookie,4,1.0,4.0,Cash,Takeaway,2023-03-13
+TXN_2199500,Smoothie,1,4.0,4.0,Credit Card,,2023-04-04
+TXN_3402368,ERROR,2,1.5,3.0,,In-store,2023-02-01
+TXN_8279269,Smoothie,4,4.0,16.0,Digital Wallet,,2023-06-14
+TXN_2829951,Smoothie,4,4.0,16.0,Credit Card,,2023-06-28
+TXN_6748374,Salad,1,5.0,5.0,Credit Card,Takeaway,2023-07-24
+TXN_5056971,Tea,4,1.5,6.0,Cash,Takeaway,2023-08-22
+TXN_8675052,Cookie,3,1.0,3.0,Credit Card,,2023-11-23
+TXN_6481150,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-03-30
+TXN_2371827,Cookie,5,1.0,5.0,Cash,In-store,2023-04-03
+TXN_3677109,Cake,5,3.0,15.0,Digital Wallet,,2023-12-02
+TXN_5457767,Cake,3,3.0,9.0,Cash,In-store,2023-08-14
+TXN_1704642,,5,3.0,15.0,Digital Wallet,In-store,ERROR
+TXN_3661311,Juice,2,3.0,6.0,Digital Wallet,,2023-04-30
+TXN_5520841,Cake,1,3.0,3.0,,Takeaway,2023-09-04
+TXN_6443522,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-06-22
+TXN_4907008,Coffee,3,2.0,6.0,,In-store,2023-10-30
+TXN_9833793,Cookie,1,ERROR,1.0,,Takeaway,2023-12-01
+TXN_6297375,Coffee,5,2.0,,,,2023-07-16
+TXN_1641000,Sandwich,2,4.0,8.0,Cash,,2023-08-19
+TXN_8588174,,3,5.0,15.0,,In-store,2023-02-07
+TXN_1228888,Cookie,1,1.0,1.0,Credit Card,In-store,2023-10-05
+TXN_2917349,Tea,4,1.5,ERROR,,,2023-01-15
+TXN_8099578,Coffee,3,2.0,6.0,ERROR,Takeaway,2023-03-02
+TXN_9949241,Salad,1,5.0,5.0,,In-store,2023-07-26
+TXN_5662517,Tea,2,,3.0,Credit Card,Takeaway,2023-01-05
+TXN_3221795,Sandwich,5,4.0,20.0,Cash,,2023-10-01
+TXN_8432624,Juice,3,3.0,9.0,Cash,Takeaway,2023-06-24
+TXN_1883231,Juice,5,3.0,15.0,ERROR,In-store,2023-10-21
+TXN_2490699,Coffee,1,2.0,2.0,Cash,,2023-10-05
+TXN_1898102,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-10-17
+TXN_9614646,Coffee,ERROR,2.0,6.0,,In-store,2023-03-18
+TXN_6142529,Tea,5,1.5,7.5,Credit Card,In-store,2023-07-21
+TXN_9279935,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-06-02
+TXN_3233211,Tea,2,1.5,3.0,,Takeaway,2023-06-07
+TXN_1607650,Cookie,2,1.0,2.0,,UNKNOWN,2023-04-27
+TXN_1873852,,3,3.0,9.0,Digital Wallet,Takeaway,2023-07-07
+TXN_2501656,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-07-02
+TXN_6125085,UNKNOWN,3,3.0,9.0,,Takeaway,2023-05-24
+TXN_8917809,Salad,5,5.0,25.0,Cash,,2023-07-29
+TXN_8850815,Smoothie,5,4.0,20.0,,,2023-07-23
+TXN_6959065,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-05-05
+TXN_4784154,Tea,ERROR,1.5,7.5,Credit Card,In-store,2023-09-06
+TXN_1893337,Cake,2,3.0,6.0,,Takeaway,2023-05-16
+TXN_4865947,Tea,2,1.5,3.0,Cash,Takeaway,UNKNOWN
+TXN_5468350,Salad,4,5.0,20.0,Credit Card,In-store,
+TXN_6907555,Tea,2,1.5,3.0,Credit Card,,2023-09-21
+TXN_2437751,Sandwich,1,4.0,4.0,,In-store,2023-03-18
+TXN_8285283,Juice,5,3.0,15.0,Digital Wallet,,2023-09-21
+TXN_4795208,Sandwich,UNKNOWN,4.0,8.0,Digital Wallet,Takeaway,2023-05-03
+TXN_5426405,Tea,5,1.5,7.5,,In-store,2023-11-26
+TXN_6794035,Sandwich,1,4.0,4.0,Digital Wallet,,2023-11-04
+TXN_6265760,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-06-21
+TXN_9905396,Salad,1,5.0,5.0,,,2023-08-20
+TXN_1955127,Juice,5,3.0,15.0,,In-store,2023-02-18
+TXN_1296879,Cake,1,3.0,3.0,,Takeaway,2023-11-17
+TXN_8882176,Cookie,4,1.0,4.0,Cash,Takeaway,2023-03-28
+TXN_7052672,Juice,1,3.0,3.0,ERROR,In-store,2023-06-29
+TXN_3492861,Cookie,5,1.0,5.0,Cash,,2023-11-09
+TXN_3655322,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-10-03
+TXN_7584389,Coffee,4,ERROR,8.0,Cash,,2023-03-09
+TXN_5734319,Coffee,5,2.0,10.0,Cash,Takeaway,2023-06-01
+TXN_2535662,Juice,1,3.0,3.0,Cash,ERROR,2023-05-01
+TXN_8436360,Juice,2,3.0,6.0,,,2023-12-16
+TXN_1370465,Cookie,4,1.0,UNKNOWN,Digital Wallet,,2023-03-25
+TXN_7343660,Salad,5,5.0,25.0,Credit Card,In-store,2023-08-06
+TXN_7777602,Salad,1,5.0,5.0,Cash,,2023-04-26
+TXN_3430805,Juice,4,3.0,12.0,Credit Card,,2023-11-12
+TXN_3886176,Cookie,4,1.0,4.0,Cash,,
+TXN_8219472,Cookie,4,1.0,4.0,Credit Card,,2023-11-09
+TXN_7171303,Sandwich,1,4.0,4.0,,,2023-04-30
+TXN_2330694,Salad,3,5.0,15.0,Cash,In-store,2023-05-31
+TXN_4476076,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-03-26
+TXN_4183749,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-01-25
+TXN_8132145,Tea,1,1.5,1.5,Digital Wallet,,2023-08-04
+TXN_9286960,Cookie,3,1.0,3.0,Cash,,2023-12-26
+TXN_6901619,Tea,2,1.5,,Digital Wallet,In-store,2023-10-16
+TXN_6699343,Juice,ERROR,3.0,9.0,,Takeaway,2023-10-31
+TXN_4461853,Cake,5,3.0,15.0,Credit Card,In-store,UNKNOWN
+TXN_2184573,Tea,4,1.5,6.0,,Takeaway,2023-04-26
+TXN_4779439,,4,3.0,12.0,,In-store,2023-08-23
+TXN_1789504,,1,5.0,5.0,Credit Card,,2023-06-12
+TXN_6337189,Cake,1,3.0,3.0,,,2023-04-11
+TXN_6071905,Cake,1,3.0,3.0,,In-store,2023-11-06
+TXN_7847913,Smoothie,3,4.0,UNKNOWN,Digital Wallet,In-store,2023-05-17
+TXN_1792405,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-07-06
+TXN_6101067,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-09-05
+TXN_2260070,Salad,1,5.0,5.0,Cash,,2023-10-06
+TXN_5641209,Salad,,5.0,15.0,,Takeaway,2023-12-03
+TXN_3994585,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-07-24
+TXN_5202752,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-05-08
+TXN_8714850,Juice,5,3.0,15.0,Cash,In-store,2023-04-30
+TXN_3504925,Smoothie,5,4.0,,Cash,,2023-09-21
+TXN_4919285,Coffee,4,2.0,8.0,Cash,Takeaway,2023-10-15
+TXN_4876398,Salad,2,5.0,10.0,Cash,,2023-04-21
+TXN_5456362,Smoothie,4,4.0,16.0,Credit Card,,2023-07-06
+TXN_4377249,Coffee,3,2.0,6.0,Digital Wallet,,2023-07-26
+TXN_6566716,Coffee,ERROR,2.0,2.0,Credit Card,,2023-01-01
+TXN_1571824,Cookie,4,1.0,4.0,Cash,Takeaway,2023-10-16
+TXN_3920273,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-09-05
+TXN_8222593,Sandwich,4,4.0,16.0,Credit Card,,2023-05-11
+TXN_5054719,Sandwich,2,4.0,8.0,Credit Card,UNKNOWN,2023-04-17
+TXN_2242015,Tea,2,1.5,3.0,Cash,ERROR,2023-08-26
+TXN_5208377,UNKNOWN,2,1.5,3.0,,Takeaway,2023-03-06
+TXN_1322520,ERROR,5,5.0,25.0,Cash,,2023-07-12
+TXN_7268387,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-04-09
+TXN_6268823,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-04-18
+TXN_5578828,Cookie,4,1.0,4.0,Cash,In-store,2023-05-12
+TXN_5727550,Coffee,3,2.0,6.0,Digital Wallet,,2023-10-11
+TXN_9597063,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-07-20
+TXN_6867132,Cake,2,3.0,6.0,Cash,In-store,2023-02-01
+TXN_1971865,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-04-11
+TXN_6067546,Tea,5,,7.5,Digital Wallet,Takeaway,2023-08-25
+TXN_3699636,UNKNOWN,3,5.0,15.0,Digital Wallet,ERROR,2023-01-12
+TXN_6724588,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-10-16
+TXN_2929426,Salad,5,5.0,25.0,Cash,Takeaway,2023-01-29
+TXN_9669749,Salad,4,5.0,20.0,Credit Card,,2023-03-26
+TXN_9105374,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-01-25
+TXN_6553641,Salad,1,5.0,5.0,Cash,In-store,UNKNOWN
+TXN_3346749,Tea,2,1.5,3.0,,,2023-05-06
+TXN_5594043,Cake,4,3.0,12.0,Cash,,2023-06-22
+TXN_1170807,Smoothie,5,4.0,20.0,,In-store,2023-09-15
+TXN_2882571,Cake,1,3.0,3.0,Credit Card,In-store,2023-05-24
+TXN_6640488,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-04-01
+TXN_7621512,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-07-24
+TXN_9529846,Smoothie,5,4.0,20.0,,,2023-09-23
+TXN_3338458,Cake,5,3.0,15.0,Cash,,2023-10-27
+TXN_3104867,Juice,3,3.0,9.0,Digital Wallet,,2023-03-28
+TXN_9286019,Smoothie,4,4.0,ERROR,Cash,Takeaway,2023-05-28
+TXN_1923263,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-03-12
+TXN_3172621,Sandwich,4,4.0,16.0,,Takeaway,2023-10-15
+TXN_5830991,Cookie,4,1.0,4.0,ERROR,Takeaway,2023-11-07
+TXN_8719561,ERROR,3,3.0,9.0,ERROR,ERROR,2023-09-13
+TXN_7396497,ERROR,5,4.0,20.0,Credit Card,In-store,2023-02-10
+TXN_7629728,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-12-15
+TXN_2831842,Cake,2,3.0,6.0,,ERROR,2023-05-20
+TXN_8903958,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-11-12
+TXN_8951525,Juice,3,3.0,9.0,,,2023-06-08
+TXN_7511261,Juice,3,3.0,9.0,ERROR,,2023-03-26
+TXN_3896128,Cake,1,3.0,UNKNOWN,,In-store,2023-01-04
+TXN_6554101,Smoothie,3,4.0,12.0,,,2023-02-15
+TXN_3500571,Juice,3,3.0,9.0,,Takeaway,2023-05-03
+TXN_6761273,Juice,5,3.0,UNKNOWN,Digital Wallet,UNKNOWN,2023-10-13
+TXN_6076602,Tea,4,1.5,6.0,Credit Card,In-store,2023-02-07
+TXN_9196658,Cookie,1,UNKNOWN,1.0,,Takeaway,2023-06-12
+TXN_7330330,Cookie,2,1.0,2.0,,In-store,2023-10-16
+TXN_8953489,Juice,5,3.0,15.0,,In-store,
+TXN_2340643,Salad,5,5.0,25.0,Cash,In-store,2023-01-05
+TXN_4397349,Sandwich,2,4.0,8.0,UNKNOWN,,2023-06-08
+TXN_1072984,Tea,4,1.5,6.0,Digital Wallet,,2023-01-11
+TXN_3238759,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-07-20
+TXN_9802771,Smoothie,2,4.0,8.0,ERROR,,2023-02-11
+TXN_3858607,Salad,5,5.0,25.0,Digital Wallet,,2023-12-02
+TXN_3585602,Juice,2,3.0,6.0,Cash,In-store,2023-04-17
+TXN_8096618,Coffee,4,2.0,UNKNOWN,Digital Wallet,In-store,2023-02-20
+TXN_8363711,Smoothie,2,4.0,8.0,,In-store,2023-05-21
+TXN_2639283,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-08-13
+TXN_1505837,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-12-15
+TXN_2566299,Juice,2,3.0,6.0,Cash,,2023-08-20
+TXN_7292790,Cookie,4,1.0,4.0,Cash,In-store,2023-06-13
+TXN_7631496,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-11-05
+TXN_6251282,Juice,4,3.0,12.0,Cash,,2023-11-15
+TXN_6266750,Sandwich,1,4.0,4.0,Cash,,2023-04-21
+TXN_6770844,Juice,1,3.0,3.0,Digital Wallet,In-store,2023-05-08
+TXN_4152460,Sandwich,,4.0,12.0,Cash,Takeaway,2023-05-01
+TXN_4699911,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-07-21
+TXN_3472433,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-10-29
+TXN_7179827,Juice,4,3.0,12.0,Credit Card,In-store,2023-06-28
+TXN_7568112,Salad,ERROR,5.0,25.0,Cash,,2023-06-29
+TXN_9800351,Tea,3,1.5,4.5,Cash,ERROR,2023-06-16
+TXN_4216821,Tea,2,1.5,3.0,,,2023-07-02
+TXN_6378070,ERROR,3,4.0,12.0,Digital Wallet,,2023-09-26
+TXN_2889185,UNKNOWN,2,4.0,8.0,ERROR,,2023-10-21
+TXN_5188872,Cake,3,3.0,9.0,,In-store,2023-07-21
+TXN_9927220,Juice,5,3.0,15.0,Cash,,2023-09-14
+TXN_5118799,Cookie,2,ERROR,ERROR,Cash,Takeaway,2023-04-23
+TXN_2110490,ERROR,1,5.0,5.0,Cash,In-store,2023-08-29
+TXN_7187578,Salad,5,5.0,25.0,,In-store,2023-11-20
+TXN_4914203,,1,2.0,2.0,Credit Card,,2023-12-02
+TXN_6046363,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-03-20
+TXN_2920578,Smoothie,4,4.0,16.0,Cash,,2023-09-06
+TXN_7117210,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-09-25
+TXN_5823330,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-10-19
+TXN_8155540,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-03-19
+TXN_2418609,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-09-06
+TXN_8570149,Tea,1,1.5,1.5,Credit Card,,2023-06-03
+TXN_4382802,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-07-17
+TXN_9970964,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-07-07
+TXN_5946779,Sandwich,1,4.0,4.0,Cash,In-store,2023-05-25
+TXN_2253622,Sandwich,5,ERROR,ERROR,Digital Wallet,Takeaway,2023-09-30
+TXN_8982328,Juice,1,3.0,3.0,Credit Card,In-store,2023-10-20
+TXN_9969706,Cake,5,3.0,15.0,,In-store,2023-03-17
+TXN_1915046,Sandwich,5,4.0,20.0,,,2023-04-12
+TXN_4624019,Cookie,1,1.0,1.0,Cash,UNKNOWN,2023-02-12
+TXN_1773856,Cake,2,3.0,6.0,,ERROR,2023-08-11
+TXN_6667083,Cake,1,3.0,3.0,Cash,,2023-03-19
+TXN_8639879,ERROR,2,5.0,10.0,,Takeaway,2023-03-09
+TXN_5144090,Coffee,5,2.0,10.0,Digital Wallet,UNKNOWN,2023-05-15
+TXN_1322421,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-03-05
+TXN_4474441,Coffee,4,2.0,8.0,Credit Card,,2023-08-23
+TXN_6598343,Juice,4,3.0,12.0,,,2023-07-10
+TXN_1297663,Smoothie,5,,20.0,Credit Card,,2023-09-12
+TXN_4972634,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-07-22
+TXN_7362776,Cookie,,1.0,5.0,,In-store,2023-01-26
+TXN_8159772,Cake,1,3.0,3.0,Credit Card,In-store,2023-10-02
+TXN_7137800,Tea,1,1.5,1.5,ERROR,Takeaway,2023-02-22
+TXN_4360970,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-06-28
+TXN_6529863,Salad,3,5.0,15.0,,Takeaway,2023-08-16
+TXN_3886583,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-05-03
+TXN_9315004,Sandwich,5,ERROR,20.0,Digital Wallet,In-store,2023-12-21
+TXN_1624458,Tea,ERROR,1.5,6.0,Digital Wallet,,
+TXN_4039864,Cake,2,3.0,6.0,Cash,In-store,2023-07-24
+TXN_8901988,ERROR,5,1.5,UNKNOWN,Digital Wallet,In-store,2023-01-21
+TXN_8103754,Salad,5,5.0,25.0,Cash,Takeaway,2023-01-29
+TXN_6318017,Tea,3,1.5,4.5,Cash,In-store,2023-06-23
+TXN_9608271,Coffee,2,2.0,4.0,,,2023-10-24
+TXN_4583009,Salad,5,5.0,25.0,Credit Card,In-store,2023-01-08
+TXN_2536821,Salad,5,5.0,25.0,,Takeaway,2023-12-01
+TXN_5820621,Cookie,5,1.0,UNKNOWN,,In-store,2023-12-01
+TXN_2878994,Sandwich,1,4.0,4.0,,,2023-05-19
+TXN_8014973,,3,5.0,15.0,,In-store,2023-08-09
+TXN_6492477,Coffee,5,2.0,10.0,,ERROR,2023-02-03
+TXN_8549600,Coffee,,2.0,6.0,Digital Wallet,Takeaway,2023-11-19
+TXN_4496616,Salad,5,5.0,25.0,,Takeaway,2023-10-07
+TXN_3190538,Coffee,2,2.0,4.0,Digital Wallet,,2023-06-03
+TXN_8863649,Cookie,1,1.0,1.0,Credit Card,In-store,2023-03-05
+TXN_8078312,Cookie,1,1.0,1.0,,,2023-09-24
+TXN_6306644,ERROR,2,3.0,6.0,Digital Wallet,,2023-06-15
+TXN_9836829,Cookie,,1.0,5.0,,Takeaway,2023-10-15
+TXN_8942829,Salad,5,5.0,25.0,Cash,,2023-03-11
+TXN_1604072,Coffee,2,2.0,4.0,,,2023-01-01
+TXN_3673322,UNKNOWN,2,5.0,10.0,Credit Card,Takeaway,2023-04-24
+TXN_1830432,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-11-02
+TXN_4314504,Cake,1,3.0,3.0,,In-store,2023-06-01
+TXN_2880516,Tea,1,1.5,1.5,Cash,In-store,2023-03-26
+TXN_4649079,Cookie,4,1.0,4.0,,Takeaway,2023-07-26
+TXN_6383336,Cake,2,3.0,6.0,,Takeaway,2023-01-21
+TXN_7605163,Salad,1,5.0,5.0,,Takeaway,2023-08-15
+TXN_2294603,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-09-02
+TXN_7097760,Coffee,3,2.0,6.0,Digital Wallet,,2023-10-24
+TXN_1998357,Cake,2,3.0,6.0,Digital Wallet,,ERROR
+TXN_1220061,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-09-03
+TXN_9944500,Smoothie,UNKNOWN,4.0,ERROR,Cash,In-store,2023-01-03
+TXN_1329167,Tea,5,1.5,7.5,,Takeaway,2023-01-14
+TXN_3463337,Juice,5,3.0,15.0,Credit Card,In-store,2023-09-20
+TXN_8016623,Tea,2,1.5,3.0,Cash,Takeaway,2023-05-09
+TXN_9525078,Salad,5,5.0,25.0,ERROR,Takeaway,2023-07-23
+TXN_2841233,Cookie,1,1.0,1.0,Cash,Takeaway,2023-12-01
+TXN_1458905,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-02-19
+TXN_3977520,Coffee,5,2.0,10.0,UNKNOWN,,2023-08-08
+TXN_3330279,Cake,1,3.0,3.0,Credit Card,,2023-11-13
+TXN_6234882,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-01-01
+TXN_9970653,UNKNOWN,5,4.0,20.0,Digital Wallet,Takeaway,2023-12-30
+TXN_4185160,UNKNOWN,2,2.0,4.0,Credit Card,In-store,2023-05-04
+TXN_6093955,Tea,5,1.5,,UNKNOWN,Takeaway,2023-01-01
+TXN_2074343,,3,4.0,12.0,Digital Wallet,In-store,2023-05-30
+TXN_7994903,Smoothie,4,4.0,16.0,Credit Card,In-store,2023-01-09
+TXN_3109161,Sandwich,3,4.0,12.0,Digital Wallet,ERROR,2023-09-11
+TXN_2185727,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-10-08
+TXN_8971366,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-08-24
+TXN_3669866,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-05-10
+TXN_9395223,Cookie,4,1.0,4.0,Credit Card,In-store,2023-12-29
+TXN_7963892,Salad,1,ERROR,5.0,,Takeaway,2023-08-15
+TXN_6325639,Juice,3,3.0,ERROR,UNKNOWN,In-store,2023-07-19
+TXN_3856510,Smoothie,5,UNKNOWN,20.0,Cash,,2023-10-21
+TXN_4779192,Cookie,5,1.0,5.0,Digital Wallet,,2023-11-06
+TXN_4163126,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,ERROR
+TXN_5808719,Juice,1,3.0,3.0,Cash,In-store,2023-10-01
+TXN_2817210,Cake,4,3.0,12.0,,,2023-11-10
+TXN_1985396,Sandwich,3,4.0,12.0,Cash,In-store,2023-01-23
+TXN_7625340,,2,1.0,2.0,Credit Card,In-store,2023-01-20
+TXN_1533652,Tea,3,1.5,4.5,Cash,In-store,2023-08-17
+TXN_6345619,Cake,5,3.0,15.0,Digital Wallet,Takeaway,2023-12-09
+TXN_3218971,Sandwich,5,4.0,20.0,Credit Card,ERROR,2023-06-13
+TXN_8127681,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-09-02
+TXN_7328604,Salad,2,5.0,10.0,Credit Card,,2023-02-25
+TXN_4574757,Juice,2,3.0,6.0,ERROR,In-store,2023-08-05
+TXN_9505924,Cake,4,3.0,12.0,,,2023-03-17
+TXN_9482559,Cookie,1,1.0,1.0,,In-store,2023-08-04
+TXN_7705153,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-01-25
+TXN_7037557,Salad,4,5.0,20.0,Cash,,2023-05-02
+TXN_9517548,Coffee,3,2.0,6.0,Cash,Takeaway,2023-01-25
+TXN_4467046,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-09-27
+TXN_5074212,Juice,5,3.0,15.0,UNKNOWN,,2023-05-14
+TXN_8167530,Cake,3,3.0,9.0,Cash,In-store,2023-03-08
+TXN_2158361,UNKNOWN,2,3.0,6.0,,,2023-07-27
+TXN_5492822,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-12-16
+TXN_8538125,Cake,5,3.0,15.0,Digital Wallet,,2023-05-30
+TXN_1091115,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-11-04
+TXN_5350286,Sandwich,5,4.0,20.0,Credit Card,,2023-02-18
+TXN_1534223,Cake,3,3.0,9.0,Credit Card,,2023-01-30
+TXN_6403951,Tea,UNKNOWN,1.5,4.5,Credit Card,Takeaway,2023-07-13
+TXN_7961171,Juice,3,3.0,9.0,Cash,In-store,2023-01-27
+TXN_6312039,Cake,ERROR,3.0,15.0,,In-store,2023-09-29
+TXN_6177334,Juice,1,3.0,3.0,Credit Card,In-store,2023-02-15
+TXN_7466297,Cookie,1,1.0,1.0,Digital Wallet,,2023-07-13
+TXN_2693278,Tea,3,1.5,4.5,,,2023-11-26
+TXN_3561149,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-05-20
+TXN_2227825,Sandwich,5,4.0,20.0,Credit Card,,2023-06-05
+TXN_9965686,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-10-02
+TXN_5303413,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-06-21
+TXN_5328814,Tea,3,1.5,4.5,Cash,,2023-10-18
+TXN_9658354,ERROR,3,1.5,4.5,Credit Card,In-store,2023-11-12
+TXN_8538315,Coffee,UNKNOWN,2.0,2.0,Digital Wallet,,2023-07-27
+TXN_2334962,Juice,5,3.0,15.0,,,2023-01-31
+TXN_9321776,Cake,1,3.0,3.0,,UNKNOWN,2023-04-23
+TXN_2574545,Coffee,UNKNOWN,2.0,4.0,,In-store,
+TXN_7625537,Juice,3,3.0,9.0,,Takeaway,2023-12-09
+TXN_8722491,Smoothie,4,4.0,16.0,Cash,,2023-04-24
+TXN_4129569,Cookie,4,ERROR,4.0,Digital Wallet,UNKNOWN,2023-08-27
+TXN_6018020,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-01-12
+TXN_3305132,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-01-30
+TXN_7951885,Salad,3,5.0,15.0,Credit Card,,2023-12-08
+TXN_9090875,Cake,2,3.0,6.0,ERROR,In-store,2023-04-19
+TXN_9175684,Tea,3,1.5,4.5,,,2023-09-16
+TXN_1640649,Cookie,4,1.0,4.0,,In-store,2023-12-05
+TXN_9845746,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-09-23
+TXN_1547704,Coffee,5,2.0,10.0,Cash,In-store,2023-02-14
+TXN_3422774,UNKNOWN,2,4.0,8.0,Digital Wallet,In-store,2023-07-09
+TXN_8477415,Salad,2,5.0,10.0,Credit Card,UNKNOWN,2023-05-01
+TXN_1039367,Sandwich,3,4.0,,Cash,,2023-03-12
+TXN_5433982,Salad,5,5.0,25.0,Digital Wallet,,2023-07-07
+TXN_4469550,,3,3.0,9.0,Credit Card,In-store,2023-05-10
+TXN_2838588,Coffee,2,2.0,4.0,,In-store,2023-01-28
+TXN_6135727,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-12-15
+TXN_3660227,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-05-13
+TXN_5640232,Sandwich,4,,16.0,Digital Wallet,UNKNOWN,2023-04-08
+TXN_4064310,Tea,4,1.5,6.0,Cash,Takeaway,2023-07-24
+TXN_7418562,Sandwich,4,4.0,UNKNOWN,,,2023-01-15
+TXN_2978326,Smoothie,3,4.0,12.0,Cash,,2023-12-02
+TXN_9616828,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-12-20
+TXN_1522122,Cookie,5,1.0,5.0,Credit Card,In-store,2023-02-14
+TXN_2360229,Sandwich,1,4.0,4.0,Digital Wallet,,2023-06-18
+TXN_7840510,UNKNOWN,4,3.0,12.0,,Takeaway,2023-08-07
+TXN_5285666,Coffee,5,2.0,10.0,Cash,,2023-03-20
+TXN_5029453,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-06-24
+TXN_6117421,Cake,2,3.0,6.0,Cash,,2023-05-04
+TXN_8759461,Tea,2,1.5,3.0,Cash,In-store,2023-01-31
+TXN_2962728,Salad,4,5.0,20.0,Credit Card,,2023-12-05
+TXN_6527482,Juice,1,3.0,3.0,UNKNOWN,Takeaway,2023-08-27
+TXN_4256200,Tea,5,1.5,7.5,,,2023-06-29
+TXN_6276679,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-11-08
+TXN_2507188,Coffee,1,2.0,2.0,Credit Card,,2023-02-04
+TXN_9386165,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-06-01
+TXN_6064232,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-04-09
+TXN_3604017,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-09-21
+TXN_3486548,Tea,1,1.5,1.5,Digital Wallet,,2023-07-08
+TXN_1465584,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-04-29
+TXN_9285925,ERROR,5,3.0,15.0,Cash,In-store,2023-06-20
+TXN_7662502,Cake,1,3.0,3.0,,In-store,2023-03-06
+TXN_3212505,Sandwich,3,4.0,12.0,Credit Card,,2023-07-15
+TXN_7331903,UNKNOWN,1,5.0,5.0,,Takeaway,2023-05-23
+TXN_2311188,Cake,2,3.0,6.0,Digital Wallet,UNKNOWN,2023-09-07
+TXN_6344806,Juice,3,3.0,9.0,Credit Card,,2023-05-08
+TXN_4891221,Cookie,5,1.0,5.0,,Takeaway,2023-12-09
+TXN_1316036,ERROR,2,3.0,6.0,Cash,Takeaway,2023-10-27
+TXN_7419274,Juice,2,3.0,6.0,Cash,Takeaway,2023-12-18
+TXN_2178059,Sandwich,4,4.0,16.0,,In-store,2023-03-24
+TXN_2205071,Coffee,5,2.0,10.0,Credit Card,In-store,2023-11-23
+TXN_5790078,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-04-16
+TXN_4119210,Tea,3,1.5,4.5,Cash,In-store,2023-05-02
+TXN_2349072,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-09-06
+TXN_3670103,Tea,2,1.5,3.0,,In-store,2023-04-30
+TXN_1933628,UNKNOWN,2,3.0,6.0,Cash,In-store,2023-08-27
+TXN_6444911,Juice,5,3.0,15.0,Credit Card,,2023-02-11
+TXN_4186842,Juice,5,3.0,15.0,UNKNOWN,Takeaway,2023-10-29
+TXN_2194305,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-09-16
+TXN_2002049,Coffee,5,2.0,10.0,ERROR,,2023-03-17
+TXN_4837447,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-11-06
+TXN_5517185,Smoothie,3,4.0,12.0,Digital Wallet,,2023-11-05
+TXN_9658905,ERROR,5,1.5,7.5,Cash,Takeaway,2023-05-16
+TXN_3373997,Salad,4,5.0,20.0,,,2023-02-01
+TXN_1950343,Cookie,2,1.0,2.0,ERROR,,2023-07-25
+TXN_4477016,Sandwich,4,4.0,,,In-store,2023-04-12
+TXN_2644403,Tea,4,1.5,6.0,ERROR,,2023-12-22
+TXN_7006741,Sandwich,UNKNOWN,4.0,8.0,Digital Wallet,,2023-12-30
+TXN_7246698,Sandwich,3,4.0,12.0,,In-store,2023-06-22
+TXN_8063016,Cookie,1,1.0,UNKNOWN,Cash,,2023-02-27
+TXN_9215670,Coffee,3,,6.0,Cash,Takeaway,2023-05-04
+TXN_6780463,Tea,3,1.5,4.5,,,2023-10-26
+TXN_5975573,,1,1.0,1.0,,Takeaway,2023-01-20
+TXN_5560669,Salad,5,5.0,25.0,Credit Card,,2023-06-30
+TXN_4046095,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-10-12
+TXN_6559598,Juice,1,3.0,3.0,Digital Wallet,,2023-05-08
+TXN_9707159,Cake,5,3.0,15.0,Credit Card,In-store,2023-11-10
+TXN_9983518,Tea,2,1.5,3.0,Credit Card,In-store,2023-07-18
+TXN_1714348,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-12-31
+TXN_8211288,Smoothie,1,4.0,4.0,Cash,In-store,2023-04-23
+TXN_7035067,Salad,2,UNKNOWN,10.0,Cash,,2023-09-29
+TXN_6335423,Coffee,2,2.0,4.0,Credit Card,In-store,2023-06-18
+TXN_9475783,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-02-11
+TXN_4108869,Smoothie,5,4.0,20.0,,,2023-05-02
+TXN_6011341,Juice,4,3.0,12.0,,In-store,2023-12-21
+TXN_5257531,Tea,2,1.5,3.0,,UNKNOWN,2023-04-10
+TXN_1645743,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-07-02
+TXN_8167311,Salad,1,5.0,5.0,UNKNOWN,Takeaway,2023-10-09
+TXN_2377667,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-10-27
+TXN_9554670,,4,3.0,12.0,Credit Card,In-store,2023-06-20
+TXN_3312574,Cookie,2,1.0,2.0,UNKNOWN,,2023-11-03
+TXN_9208629,Cake,1,3.0,3.0,,Takeaway,2023-03-30
+TXN_6846085,Cookie,4,1.0,4.0,Digital Wallet,,2023-02-26
+TXN_5430200,Sandwich,UNKNOWN,4.0,12.0,Credit Card,Takeaway,2023-11-12
+TXN_5135172,ERROR,4,5.0,20.0,Digital Wallet,In-store,2023-12-10
+TXN_2282416,Tea,UNKNOWN,1.5,6.0,,Takeaway,2023-04-29
+TXN_6716151,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-01-26
+TXN_5303258,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-09-28
+TXN_2947683,Cake,3,3.0,9.0,,In-store,2023-05-14
+TXN_8831659,Sandwich,1,4.0,4.0,Credit Card,,2023-01-29
+TXN_8980495,UNKNOWN,UNKNOWN,4.0,16.0,Credit Card,Takeaway,2023-11-17
+TXN_9129298,ERROR,1,2.0,2.0,,,2023-12-19
+TXN_2188342,Coffee,3,2.0,6.0,Cash,,2023-09-10
+TXN_3843943,Tea,5,1.5,7.5,,Takeaway,2023-07-01
+TXN_4989644,Juice,5,UNKNOWN,15.0,Digital Wallet,,2023-11-13
+TXN_9456357,Cake,3,3.0,9.0,Credit Card,,2023-02-21
+TXN_9549021,Salad,2,5.0,10.0,,,2023-11-25
+TXN_9263030,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-07-03
+TXN_9732454,Smoothie,5,,20.0,,In-store,2023-07-28
+TXN_4129476,Coffee,2,2.0,4.0,Cash,,2023-10-24
+TXN_7060691,Salad,5,5.0,25.0,Credit Card,,2023-10-25
+TXN_8048357,Salad,4,5.0,20.0,,In-store,ERROR
+TXN_5528787,Juice,2,3.0,6.0,Digital Wallet,,2023-10-22
+TXN_8952145,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-01-28
+TXN_8062811,Coffee,2,2.0,UNKNOWN,Cash,Takeaway,2023-04-07
+TXN_9710982,UNKNOWN,4,,16.0,,,2023-03-03
+TXN_2020445,Smoothie,2,4.0,8.0,Cash,,2023-03-06
+TXN_7855761,Cookie,1,1.0,1.0,Cash,In-store,2023-01-10
+TXN_9455977,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-03-10
+TXN_6684056,Smoothie,2,4.0,,,ERROR,2023-09-14
+TXN_6085326,Cake,2,3.0,6.0,,,2023-08-22
+TXN_4528522,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-12-04
+TXN_7049861,Cake,5,3.0,15.0,Cash,In-store,2023-01-20
+TXN_7312448,Tea,1,1.5,1.5,,ERROR,2023-01-16
+TXN_2201857,Smoothie,UNKNOWN,4.0,4.0,,Takeaway,2023-02-19
+TXN_4982382,Salad,1,5.0,5.0,Cash,,2023-01-05
+TXN_9001844,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-08-02
+TXN_9104710,Salad,5,5.0,25.0,Cash,Takeaway,2023-03-20
+TXN_8266662,Coffee,5,2.0,10.0,Credit Card,,2023-04-09
+TXN_9178213,ERROR,2,2.0,4.0,Digital Wallet,Takeaway,2023-02-27
+TXN_7755216,Salad,5,5.0,25.0,,In-store,2023-02-03
+TXN_2241162,Juice,3,3.0,UNKNOWN,UNKNOWN,,2023-08-09
+TXN_5757933,Tea,1,1.5,1.5,Cash,,2023-02-20
+TXN_8859144,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-01-15
+TXN_8740257,Cake,5,3.0,15.0,Digital Wallet,,2023-06-09
+TXN_4271034,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-02-28
+TXN_2741424,Tea,4,1.5,6.0,Credit Card,In-store,2023-05-03
+TXN_4709135,Sandwich,2,4.0,8.0,Credit Card,Takeaway,UNKNOWN
+TXN_6676143,Sandwich,5,4.0,20.0,Cash,In-store,2023-05-21
+TXN_2199647,Salad,1,5.0,5.0,Cash,,2023-05-05
+TXN_3016079,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-09-24
+TXN_3140950,Juice,5,3.0,15.0,Credit Card,,ERROR
+TXN_6881662,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-07-10
+TXN_4238818,Coffee,2,2.0,4.0,Digital Wallet,UNKNOWN,2023-04-05
+TXN_2146829,Salad,4,5.0,20.0,Cash,,2023-12-26
+TXN_8131537,Smoothie,2,4.0,8.0,Credit Card,,2023-12-03
+TXN_9812021,Tea,5,1.5,7.5,Credit Card,In-store,2023-02-12
+TXN_7947711,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-12-06
+TXN_6774688,Salad,1,5.0,5.0,Credit Card,UNKNOWN,2023-01-18
+TXN_3949676,Juice,4,3.0,12.0,Credit Card,In-store,2023-12-21
+TXN_4283693,Salad,2,5.0,10.0,Cash,In-store,2023-01-05
+TXN_2274945,Sandwich,4,4.0,16.0,Cash,In-store,2023-03-29
+TXN_5757196,Juice,5,3.0,UNKNOWN,,In-store,
+TXN_6787259,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-08-18
+TXN_7062893,Smoothie,2,4.0,UNKNOWN,Digital Wallet,In-store,2023-10-15
+TXN_7482834,Sandwich,UNKNOWN,4.0,20.0,,In-store,2023-05-16
+TXN_8533584,Cookie,2,1.0,2.0,Cash,Takeaway,2023-03-11
+TXN_4311369,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-08-18
+TXN_7123353,Cookie,4,1.0,4.0,ERROR,In-store,2023-02-08
+TXN_8230414,Sandwich,4,4.0,16.0,Cash,,2023-11-20
+TXN_3738314,Sandwich,4,4.0,16.0,,ERROR,2023-08-06
+TXN_3200434,Cake,4,3.0,12.0,,ERROR,2023-02-18
+TXN_7485706,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-11-15
+TXN_9908225,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-01-04
+TXN_7163533,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-08-17
+TXN_6867995,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-10-15
+TXN_9563685,Salad,1,5.0,5.0,Credit Card,,2023-07-28
+TXN_3345675,Cookie,4,1.0,4.0,UNKNOWN,,2023-09-23
+TXN_9890734,Smoothie,4,4.0,16.0,,Takeaway,2023-04-17
+TXN_7697294,Smoothie,3,4.0,12.0,UNKNOWN,,2023-01-17
+TXN_5256055,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-02-07
+TXN_3399674,Smoothie,5,,20.0,Digital Wallet,ERROR,2023-12-09
+TXN_6067979,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-07-29
+TXN_4340811,Cake,5,3.0,15.0,ERROR,In-store,2023-04-15
+TXN_6515226,Juice,1,3.0,3.0,Digital Wallet,,2023-01-05
+TXN_6069730,Juice,1,3.0,3.0,Cash,In-store,2023-02-05
+TXN_2396191,Juice,4,3.0,12.0,Credit Card,,2023-05-12
+TXN_5223162,Juice,3,3.0,9.0,Digital Wallet,,2023-10-29
+TXN_4224401,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-12-18
+TXN_9298882,Sandwich,3,4.0,12.0,,,2023-01-13
+TXN_1048616,Tea,1,1.5,,Cash,,2023-10-10
+TXN_5896141,Smoothie,5,4.0,20.0,,In-store,2023-03-08
+TXN_8549341,Cake,5,3.0,15.0,Cash,Takeaway,
+TXN_6929664,Coffee,1,2.0,2.0,,Takeaway,2023-03-05
+TXN_1570632,Sandwich,5,4.0,UNKNOWN,Digital Wallet,,2023-02-28
+TXN_4650811,Tea,5,1.5,7.5,Cash,,2023-09-26
+TXN_9858152,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-01-28
+TXN_2666773,Juice,3,3.0,9.0,Credit Card,,2023-06-29
+TXN_1387062,,5,4.0,20.0,Credit Card,,2023-08-22
+TXN_4060332,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-07-10
+TXN_2780349,Coffee,5,2.0,10.0,Cash,,2023-11-12
+TXN_5923474,Cake,4,3.0,12.0,,In-store,ERROR
+TXN_2905218,Smoothie,5,4.0,20.0,Cash,In-store,2023-09-03
+TXN_2041190,Juice,1,3.0,3.0,Digital Wallet,,2023-11-04
+TXN_8269366,Sandwich,1,4.0,4.0,,,2023-10-31
+TXN_8277583,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-08-15
+TXN_3785049,Sandwich,4,4.0,16.0,,,2023-11-26
+TXN_8819928,Coffee,5,2.0,10.0,,,2023-06-03
+TXN_2078317,Tea,1,1.5,1.5,Cash,In-store,2023-09-21
+TXN_8657361,UNKNOWN,4,2.0,8.0,,Takeaway,2023-01-24
+TXN_4442954,Coffee,2,2.0,4.0,Cash,,2023-12-15
+TXN_8076449,Juice,3,3.0,9.0,,Takeaway,UNKNOWN
+TXN_1560873,Cookie,2,1.0,2.0,UNKNOWN,Takeaway,2023-07-19
+TXN_7057481,Smoothie,3,4.0,12.0,Cash,In-store,2023-07-11
+TXN_6869767,Smoothie,2,4.0,ERROR,Digital Wallet,Takeaway,2023-06-06
+TXN_3705445,Cookie,5,UNKNOWN,,Cash,In-store,2023-09-13
+TXN_9714665,Salad,1,5.0,5.0,,Takeaway,2023-11-11
+TXN_4155770,Salad,5,5.0,25.0,,In-store,2023-09-20
+TXN_1828494,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-07-21
+TXN_5992635,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,
+TXN_6011304,Cake,4,3.0,,Cash,,2023-11-20
+TXN_6223157,Salad,1,5.0,5.0,ERROR,Takeaway,2023-09-13
+TXN_8526084,Cake,5,3.0,15.0,,Takeaway,2023-03-05
+TXN_3509609,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-12-25
+TXN_4276442,Cake,4,3.0,12.0,Credit Card,In-store,2023-01-25
+TXN_4532475,Coffee,ERROR,2.0,2.0,Digital Wallet,,2023-04-23
+TXN_7956243,Cake,4,3.0,12.0,Cash,Takeaway,2023-05-23
+TXN_4798335,Sandwich,5,4.0,20.0,,Takeaway,2023-02-16
+TXN_9336674,Salad,4,5.0,20.0,,,2023-01-18
+TXN_5257169,Juice,4,3.0,12.0,Credit Card,,2023-01-12
+TXN_5929633,Cake,3,3.0,9.0,,In-store,2023-02-27
+TXN_9323014,Cookie,3,1.0,3.0,,In-store,2023-08-15
+TXN_5764902,Tea,ERROR,1.5,7.5,UNKNOWN,Takeaway,2023-03-22
+TXN_1473693,Smoothie,4,4.0,16.0,,Takeaway,2023-05-14
+TXN_3827851,Coffee,1,2.0,2.0,,,2023-01-09
+TXN_9087746,Coffee,4,2.0,,Digital Wallet,,2023-04-03
+TXN_3709853,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-08-21
+TXN_9665245,ERROR,1,1.0,1.0,UNKNOWN,Takeaway,2023-10-17
+TXN_9486849,Cake,ERROR,3.0,3.0,Cash,Takeaway,2023-03-17
+TXN_7581536,Smoothie,2,,8.0,Cash,,2023-12-29
+TXN_1408709,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-04-14
+TXN_6494850,Coffee,,2.0,4.0,Cash,,2023-07-08
+TXN_4003040,Cookie,4,1.0,4.0,Credit Card,In-store,2023-09-12
+TXN_1021087,Sandwich,1,4.0,4.0,,ERROR,2023-11-01
+TXN_1082717,ERROR,UNKNOWN,,9.0,Digital Wallet,In-store,2023-12-13
+TXN_2530326,Sandwich,5,4.0,20.0,,In-store,2023-05-06
+TXN_1309653,Salad,2,5.0,10.0,Cash,In-store,
+TXN_9781679,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-09-08
+TXN_8208915,Juice,UNKNOWN,3.0,6.0,Cash,,2023-05-09
+TXN_5499117,Salad,4,5.0,20.0,Digital Wallet,UNKNOWN,2023-07-16
+TXN_8566499,Salad,,5.0,25.0,Digital Wallet,In-store,2023-12-27
+TXN_8510450,,4,3.0,12.0,UNKNOWN,,2023-01-04
+TXN_9370771,Juice,5,3.0,15.0,Cash,In-store,2023-08-21
+TXN_5914284,Coffee,2,2.0,4.0,Credit Card,Takeaway,2023-06-25
+TXN_9590819,Coffee,3,2.0,6.0,,In-store,2023-11-21
+TXN_9878649,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-09-18
+TXN_5909816,Juice,5,3.0,15.0,Cash,Takeaway,2023-09-19
+TXN_9461980,Salad,1,5.0,5.0,Credit Card,In-store,2023-04-14
+TXN_8090470,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-11-18
+TXN_9041473,Smoothie,2,4.0,8.0,Digital Wallet,,ERROR
+TXN_6052534,Salad,4,5.0,20.0,Cash,,2023-02-19
+TXN_1392546,Cake,ERROR,3.0,6.0,Digital Wallet,In-store,2023-12-06
+TXN_8128146,UNKNOWN,2,3.0,6.0,Cash,In-store,2023-05-16
+TXN_2119325,Cake,5,3.0,15.0,,In-store,2023-11-13
+TXN_9067752,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-04-24
+TXN_8211133,Tea,2,1.5,3.0,,Takeaway,2023-08-31
+TXN_2331025,Cookie,2,1.0,2.0,Cash,,2023-04-28
+TXN_3543133,Tea,2,1.5,3.0,,,2023-04-08
+TXN_2640771,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-01-27
+TXN_1103883,Cookie,5,1.0,5.0,Credit Card,UNKNOWN,2023-08-09
+TXN_8593064,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-03-12
+TXN_1803599,UNKNOWN,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-30
+TXN_2873573,Coffee,3,2.0,6.0,,In-store,2023-01-11
+TXN_9223045,Tea,5,,7.5,Credit Card,In-store,2023-10-29
+TXN_9502424,,4,3.0,12.0,Cash,ERROR,2023-09-06
+TXN_8659330,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-08-20
+TXN_5615754,Smoothie,5,ERROR,20.0,Digital Wallet,Takeaway,2023-04-16
+TXN_2898571,Smoothie,3,4.0,12.0,,,2023-05-10
+TXN_1584851,Smoothie,1,4.0,4.0,Credit Card,,2023-04-10
+TXN_9430262,Coffee,5,2.0,10.0,,,2023-03-16
+TXN_9042309,Coffee,2,2.0,4.0,Cash,,2023-12-03
+TXN_4816652,Sandwich,1,4.0,4.0,UNKNOWN,UNKNOWN,2023-07-17
+TXN_8127929,UNKNOWN,5,1.0,5.0,Credit Card,Takeaway,2023-10-08
+TXN_8567172,Coffee,3,2.0,,,In-store,2023-02-05
+TXN_2317867,Tea,5,1.5,7.5,Cash,In-store,2023-01-23
+TXN_4416436,Coffee,3,2.0,6.0,Digital Wallet,,2023-05-17
+TXN_7467621,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-01-28
+TXN_5005999,Salad,4,5.0,20.0,Cash,,2023-01-09
+TXN_8664295,Smoothie,2,4.0,8.0,Credit Card,,2023-02-23
+TXN_4831311,UNKNOWN,2,2.0,4.0,Cash,Takeaway,2023-07-15
+TXN_2528186,UNKNOWN,2,2.0,4.0,Cash,,2023-06-17
+TXN_4971093,Smoothie,4,4.0,16.0,UNKNOWN,Takeaway,2023-03-27
+TXN_3602272,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-02-15
+TXN_4913329,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-10-30
+TXN_8830809,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-07-31
+TXN_7223387,Juice,3,3.0,9.0,Cash,,2023-12-17
+TXN_1629092,Cookie,3,1.0,3.0,Credit Card,,2023-02-13
+TXN_4363360,Smoothie,1,4.0,ERROR,Credit Card,,2023-12-22
+TXN_9689507,Salad,3,5.0,,Cash,In-store,2023-06-10
+TXN_3317406,Sandwich,3,4.0,12.0,UNKNOWN,Takeaway,2023-01-04
+TXN_9662632,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-08-10
+TXN_1364211,Salad,2,5.0,10.0,ERROR,In-store,2023-03-08
+TXN_1102876,Cookie,1,1.0,1.0,Cash,,UNKNOWN
+TXN_2673294,Coffee,3,2.0,UNKNOWN,Cash,,2023-11-11
+TXN_2112848,Cookie,4,1.0,4.0,Credit Card,In-store,2023-10-16
+TXN_1801691,Salad,1,5.0,5.0,,Takeaway,2023-05-18
+TXN_6424195,Coffee,3,2.0,6.0,,Takeaway,2023-09-14
+TXN_7854162,Cake,5,3.0,15.0,Digital Wallet,,UNKNOWN
+TXN_6923480,Coffee,3,2.0,6.0,Cash,Takeaway,2023-10-27
+TXN_7416669,Tea,3,1.5,4.5,,,2023-09-28
+TXN_3693990,Cookie,2,1.0,2.0,,In-store,2023-07-19
+TXN_8652632,Tea,1,1.5,,Digital Wallet,,2023-01-12
+TXN_4141765,Cake,5,3.0,15.0,,,2023-12-17
+TXN_8180793,Cookie,4,1.0,4.0,Digital Wallet,,2023-11-17
+TXN_8875195,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-08-21
+TXN_9928552,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-06-13
+TXN_3456748,Juice,2,3.0,6.0,Cash,In-store,2023-01-30
+TXN_5680687,Salad,4,5.0,UNKNOWN,Credit Card,,2023-11-22
+TXN_9349736,Sandwich,5,4.0,20.0,Cash,,2023-03-18
+TXN_7558010,Juice,4,3.0,12.0,,,2023-03-27
+TXN_8172897,Cookie,3,1.0,3.0,,Takeaway,2023-03-14
+TXN_8540794,Cake,4,3.0,12.0,Cash,,2023-04-06
+TXN_5966744,Tea,3,1.5,4.5,,In-store,2023-12-13
+TXN_3132921,Tea,UNKNOWN,1.5,7.5,Credit Card,In-store,2023-01-10
+TXN_7029719,,2,5.0,10.0,Digital Wallet,,2023-06-18
+TXN_3912440,Tea,2,1.5,3.0,,In-store,2023-05-21
+TXN_4276702,UNKNOWN,1,1.0,1.0,Credit Card,In-store,2023-11-17
+TXN_7657615,Juice,3,3.0,,Credit Card,,2023-07-17
+TXN_4020074,Cookie,3,1.0,3.0,,,2023-03-01
+TXN_8942747,Cookie,5,1.0,5.0,,Takeaway,2023-12-14
+TXN_3902815,Juice,5,3.0,15.0,,,2023-06-28
+TXN_8235042,UNKNOWN,1,4.0,4.0,Credit Card,,ERROR
+TXN_6218380,Cookie,4,1.0,4.0,Cash,In-store,2023-02-07
+TXN_6905143,Coffee,5,UNKNOWN,ERROR,Cash,ERROR,2023-08-09
+TXN_3839691,Coffee,4,2.0,8.0,Credit Card,In-store,2023-02-13
+TXN_4866254,Salad,4,5.0,20.0,Cash,UNKNOWN,2023-03-18
+TXN_8935781,Coffee,2,2.0,4.0,,,2023-09-10
+TXN_2559020,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-20
+TXN_8607376,Coffee,5,2.0,10.0,Cash,In-store,2023-06-13
+TXN_5858713,Cookie,2,1.0,2.0,Credit Card,In-store,2023-03-05
+TXN_7064604,Coffee,,2.0,6.0,Digital Wallet,,2023-03-26
+TXN_3312690,Cookie,3,1.0,3.0,Credit Card,In-store,2023-03-01
+TXN_1547555,Smoothie,3,4.0,,,Takeaway,
+TXN_8687088,Cookie,2,1.0,2.0,Credit Card,In-store,2023-05-11
+TXN_3440487,UNKNOWN,5,2.0,10.0,Cash,UNKNOWN,2023-10-22
+TXN_9618881,Coffee,5,2.0,10.0,,,2023-02-15
+TXN_5139074,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-11-16
+TXN_2799785,Juice,1,3.0,3.0,Cash,,2023-01-25
+TXN_4466681,,ERROR,2.0,4.0,Cash,Takeaway,2023-01-12
+TXN_9292025,,2,5.0,10.0,Digital Wallet,In-store,2023-03-25
+TXN_8155535,Cake,1,3.0,3.0,,Takeaway,2023-03-13
+TXN_5301926,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-11-13
+TXN_3307518,Juice,5,3.0,,Cash,Takeaway,UNKNOWN
+TXN_2379467,Coffee,5,2.0,10.0,,,2023-04-01
+TXN_1837617,Juice,3,3.0,9.0,,,2023-01-16
+TXN_3454881,Salad,1,5.0,5.0,Cash,In-store,2023-11-29
+TXN_4472969,Juice,1,3.0,3.0,Credit Card,,2023-09-15
+TXN_1905459,Smoothie,3,4.0,12.0,Digital Wallet,,2023-08-18
+TXN_8799945,Coffee,2,,4.0,Cash,,2023-11-24
+TXN_4361614,Smoothie,2,4.0,8.0,,Takeaway,2023-04-28
+TXN_1665056,Salad,5,5.0,25.0,Cash,,2023-01-05
+TXN_2904046,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-12-11
+TXN_9743274,Tea,5,1.5,7.5,,ERROR,2023-01-25
+TXN_5518232,Salad,3,5.0,15.0,,Takeaway,2023-05-01
+TXN_3770267,Cake,2,3.0,6.0,,UNKNOWN,2023-10-21
+TXN_7177709,Juice,5,,15.0,,Takeaway,2023-03-08
+TXN_6246494,Coffee,3,ERROR,6.0,,In-store,2023-03-31
+TXN_6540200,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-10-23
+TXN_7486118,Sandwich,4,4.0,16.0,,Takeaway,2023-05-22
+TXN_5424614,Cake,1,3.0,3.0,,In-store,2023-11-12
+TXN_6271598,Juice,5,3.0,15.0,Cash,,2023-08-18
+TXN_7562313,Cake,2,3.0,6.0,,ERROR,2023-12-15
+TXN_9188774,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-04-14
+TXN_9685716,Cookie,2,1.0,2.0,Digital Wallet,,2023-02-26
+TXN_7493800,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-08-16
+TXN_6833564,Smoothie,5,4.0,20.0,,,2023-04-21
+TXN_9411395,Coffee,5,2.0,10.0,,,2023-05-12
+TXN_8413251,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-08-18
+TXN_6990331,Juice,1,3.0,3.0,Digital Wallet,,2023-07-30
+TXN_6007721,UNKNOWN,4,4.0,16.0,Cash,In-store,2023-08-21
+TXN_2107161,Cookie,4,1.0,4.0,Credit Card,,UNKNOWN
+TXN_2715086,Juice,2,3.0,6.0,Cash,,2023-11-03
+TXN_1444932,Smoothie,1,4.0,4.0,Cash,In-store,2023-05-24
+TXN_2747156,Cookie,1,1.0,1.0,,In-store,2023-01-29
+TXN_6901094,Salad,1,5.0,5.0,Cash,In-store,ERROR
+TXN_5065748,Cake,5,3.0,15.0,Credit Card,In-store,2023-07-19
+TXN_8014645,Cake,2,3.0,6.0,Cash,Takeaway,2023-07-06
+TXN_2910247,Smoothie,4,4.0,16.0,Digital Wallet,,2023-12-02
+TXN_2111973,Tea,4,1.5,6.0,Digital Wallet,In-store,UNKNOWN
+TXN_3251591,Sandwich,UNKNOWN,4.0,12.0,UNKNOWN,Takeaway,2023-01-26
+TXN_4549977,Cookie,1,1.0,1.0,Cash,,2023-08-21
+TXN_1736294,Coffee,3,2.0,6.0,Digital Wallet,,2023-09-06
+TXN_1698600,Salad,4,5.0,20.0,Cash,Takeaway,2023-07-31
+TXN_3463568,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-04-12
+TXN_6773319,Tea,4,1.5,,,Takeaway,2023-05-03
+TXN_5504920,Cake,5,ERROR,15.0,Cash,Takeaway,2023-09-30
+TXN_8392086,Smoothie,4,4.0,16.0,,,2023-07-12
+TXN_9968926,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-03-15
+TXN_4719069,Juice,2,3.0,6.0,Digital Wallet,,2023-01-04
+TXN_3809941,Cookie,4,1.0,4.0,Credit Card,,2023-11-01
+TXN_1935119,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-07-15
+TXN_8246369,Juice,1,3.0,UNKNOWN,Credit Card,,2023-10-16
+TXN_2009782,Salad,5,5.0,25.0,Credit Card,ERROR,2023-05-11
+TXN_4635230,Sandwich,3,4.0,12.0,,In-store,2023-06-10
+TXN_9583176,Cookie,5,1.0,5.0,,In-store,2023-05-03
+TXN_6784478,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-12-21
+TXN_9349471,Coffee,3,2.0,6.0,Digital Wallet,,UNKNOWN
+TXN_3866162,Cake,5,3.0,15.0,Cash,Takeaway,2023-06-08
+TXN_7612056,Cookie,5,1.0,5.0,Credit Card,,2023-03-08
+TXN_5349355,,2,5.0,10.0,Digital Wallet,In-store,2023-05-10
+TXN_9259900,Salad,4,5.0,20.0,Digital Wallet,,2023-08-07
+TXN_4650834,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-07-14
+TXN_6576987,Salad,3,ERROR,15.0,Credit Card,Takeaway,2023-03-12
+TXN_1192970,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-06-17
+TXN_7645464,Tea,5,1.5,7.5,Cash,Takeaway,2023-08-17
+TXN_4205860,Salad,5,5.0,25.0,,,2023-09-10
+TXN_9495855,Juice,2,3.0,6.0,Cash,In-store,2023-04-18
+TXN_5712248,Sandwich,5,4.0,20.0,,Takeaway,2023-03-02
+TXN_4582966,Juice,2,3.0,6.0,,,2023-10-28
+TXN_4203885,Tea,3,1.5,4.5,Cash,,2023-05-11
+TXN_1887083,Juice,1,3.0,3.0,Digital Wallet,,2023-05-05
+TXN_5602640,Smoothie,5,4.0,20.0,,Takeaway,2023-04-01
+TXN_8285410,Coffee,4,2.0,8.0,Credit Card,,2023-09-10
+TXN_5654663,Juice,ERROR,3.0,3.0,ERROR,Takeaway,2023-07-31
+TXN_6687699,Salad,4,5.0,20.0,Cash,In-store,2023-09-11
+TXN_4331281,Cake,ERROR,3.0,9.0,Digital Wallet,Takeaway,2023-02-03
+TXN_2390146,Coffee,3,2.0,6.0,,,2023-06-24
+TXN_9478033,Cake,2,3.0,6.0,,In-store,2023-04-08
+TXN_8546777,Cake,4,3.0,12.0,,In-store,2023-03-16
+TXN_6433362,Cookie,2,1.0,2.0,Cash,In-store,2023-12-07
+TXN_4991594,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-12-08
+TXN_9016451,Cookie,3,1.0,3.0,,,2023-10-16
+TXN_3516296,Sandwich,3,4.0,12.0,,In-store,2023-05-29
+TXN_9464961,Sandwich,4,4.0,,Cash,In-store,2023-11-23
+TXN_7445257,Coffee,1,2.0,2.0,,,2023-04-02
+TXN_4463677,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-02-27
+TXN_4886990,Salad,3,5.0,15.0,,Takeaway,2023-12-17
+TXN_4962147,Cake,2,3.0,6.0,,,2023-02-07
+TXN_5575420,Smoothie,3,4.0,12.0,ERROR,In-store,2023-06-26
+TXN_1687822,Salad,4,5.0,20.0,Credit Card,Takeaway,ERROR
+TXN_3628566,Coffee,5,2.0,10.0,,,2023-08-17
+TXN_5297746,Coffee,3,2.0,6.0,Credit Card,In-store,2023-07-11
+TXN_5230719,Cake,5,3.0,15.0,Credit Card,,2023-03-23
+TXN_9244886,Coffee,1,2.0,2.0,,Takeaway,2023-02-09
+TXN_8145813,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-02-10
+TXN_4179797,Tea,2,1.5,3.0,,,2023-11-06
+TXN_7485379,Juice,1,3.0,3.0,Credit Card,,2023-03-27
+TXN_3171150,ERROR,1,3.0,3.0,Digital Wallet,,2023-02-06
+TXN_7988991,Tea,4,1.5,6.0,Digital Wallet,In-store,UNKNOWN
+TXN_3801485,Coffee,5,2.0,10.0,Credit Card,In-store,2023-11-10
+TXN_2312908,Coffee,3,2.0,6.0,Cash,In-store,2023-02-07
+TXN_6826342,,2,3.0,6.0,Credit Card,,2023-03-30
+TXN_3620213,Coffee,2,2.0,4.0,Credit Card,In-store,2023-09-09
+TXN_4030181,Smoothie,5,4.0,20.0,Credit Card,ERROR,2023-09-20
+TXN_1664563,Smoothie,3,4.0,12.0,Cash,,2023-04-28
+TXN_2002730,Smoothie,2,4.0,8.0,UNKNOWN,Takeaway,2023-09-27
+TXN_9662827,Tea,1,1.5,1.5,ERROR,UNKNOWN,2023-09-30
+TXN_9579691,Cookie,5,1.0,5.0,Credit Card,In-store,2023-01-16
+TXN_4131020,Sandwich,2,4.0,8.0,Credit Card,,2023-06-15
+TXN_3462602,Cake,3,3.0,9.0,Credit Card,In-store,2023-08-27
+TXN_1149624,Cake,3,3.0,ERROR,,,2023-09-14
+TXN_2628157,Coffee,UNKNOWN,2.0,8.0,Digital Wallet,,2023-10-26
+TXN_9152120,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-03-28
+TXN_9018195,Cake,5,3.0,15.0,Cash,,2023-10-07
+TXN_7799711,Smoothie,5,UNKNOWN,20.0,Digital Wallet,Takeaway,2023-12-03
+TXN_6697374,Smoothie,2,4.0,8.0,,,2023-07-31
+TXN_9014681,UNKNOWN,,4.0,12.0,UNKNOWN,In-store,2023-01-03
+TXN_4366417,Sandwich,3,4.0,12.0,,Takeaway,2023-10-10
+TXN_3930313,Cookie,3,1.0,3.0,Credit Card,Takeaway,ERROR
+TXN_7511351,Tea,4,1.5,6.0,Cash,Takeaway,2023-10-07
+TXN_5205595,Juice,1,3.0,3.0,ERROR,In-store,2023-03-01
+TXN_8276063,Coffee,1,2.0,2.0,Credit Card,,2023-01-06
+TXN_1020478,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-03-09
+TXN_5176767,Smoothie,4,4.0,16.0,,Takeaway,2023-05-03
+TXN_6043396,Sandwich,3,4.0,12.0,,In-store,2023-10-07
+TXN_4975029,Smoothie,4,4.0,16.0,Cash,In-store,2023-04-23
+TXN_9493077,Cake,4,3.0,12.0,Credit Card,,2023-01-10
+TXN_3493771,Cake,2,3.0,6.0,,,2023-02-13
+TXN_8640673,Juice,2,3.0,6.0,Cash,In-store,2023-09-11
+TXN_4793771,Cake,4,3.0,12.0,Cash,,2023-12-26
+TXN_8107005,Juice,3,3.0,9.0,,,2023-09-15
+TXN_7857126,Cookie,4,1.0,4.0,Cash,Takeaway,2023-08-21
+TXN_2940613,Juice,4,3.0,12.0,Cash,,2023-06-28
+TXN_2407379,Smoothie,4,4.0,16.0,Digital Wallet,,2023-03-13
+TXN_3376952,Tea,2,,3.0,ERROR,Takeaway,2023-10-23
+TXN_4083004,Sandwich,5,4.0,20.0,,Takeaway,2023-03-06
+TXN_3635628,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-10-28
+TXN_3554772,Tea,3,1.5,4.5,Credit Card,,2023-10-06
+TXN_9454387,Salad,2,5.0,10.0,Cash,Takeaway,2023-01-02
+TXN_9660362,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-08-16
+TXN_9281939,ERROR,3,1.5,4.5,Cash,In-store,2023-05-22
+TXN_2347248,Salad,1,5.0,5.0,Credit Card,ERROR,2023-11-11
+TXN_3732426,Sandwich,2,4.0,8.0,Digital Wallet,ERROR,2023-03-07
+TXN_8675558,Tea,5,1.5,7.5,,In-store,2023-05-23
+TXN_1963345,Smoothie,4,4.0,16.0,,In-store,2023-10-12
+TXN_6332405,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-12-03
+TXN_8946323,Tea,2,ERROR,3.0,Cash,,2023-08-23
+TXN_1529961,Smoothie,4,4.0,16.0,Credit Card,UNKNOWN,2023-09-29
+TXN_8860052,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-07-18
+TXN_6732833,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-07-21
+TXN_1983705,,3,3.0,9.0,Cash,Takeaway,ERROR
+TXN_6232398,Juice,2,3.0,6.0,Cash,In-store,2023-07-05
+TXN_2391245,ERROR,4,2.0,8.0,Digital Wallet,In-store,2023-04-13
+TXN_7670296,Juice,2,3.0,6.0,Cash,Takeaway,2023-01-25
+TXN_6128086,Tea,4,,6.0,Digital Wallet,Takeaway,2023-12-26
+TXN_1141405,Cookie,1,1.0,1.0,,,ERROR
+TXN_4898346,Smoothie,2,4.0,8.0,Cash,,2023-05-07
+TXN_2807324,Sandwich,2,4.0,8.0,Cash,,2023-11-13
+TXN_4428486,Smoothie,1,4.0,4.0,UNKNOWN,,2023-07-28
+TXN_4430772,Coffee,5,2.0,10.0,Credit Card,,2023-01-11
+TXN_7251108,ERROR,UNKNOWN,3.0,9.0,Credit Card,In-store,2023-10-04
+TXN_3987718,Tea,4,1.5,6.0,,,2023-12-24
+TXN_6658070,Juice,2,3.0,6.0,Cash,Takeaway,2023-11-03
+TXN_6007437,Juice,1,3.0,3.0,Credit Card,,2023-11-22
+TXN_6030518,Sandwich,3,4.0,12.0,ERROR,In-store,2023-12-20
+TXN_4228838,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-09-22
+TXN_3303518,Juice,4,3.0,12.0,,In-store,2023-06-30
+TXN_9719921,Salad,5,5.0,25.0,Credit Card,,2023-07-28
+TXN_1272118,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-04-21
+TXN_4060215,Salad,3,5.0,15.0,Credit Card,In-store,2023-01-12
+TXN_2569119,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-08-04
+TXN_2894945,Coffee,2,2.0,4.0,,,2023-02-28
+TXN_7992512,Sandwich,5,4.0,20.0,Credit Card,In-store,2023-07-17
+TXN_2771512,ERROR,4,3.0,12.0,Digital Wallet,Takeaway,2023-12-23
+TXN_6109953,ERROR,3,3.0,9.0,Digital Wallet,Takeaway,2023-04-22
+TXN_5728193,Sandwich,1,4.0,4.0,Credit Card,In-store,UNKNOWN
+TXN_2417271,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-02-01
+TXN_8156455,Cake,2,3.0,6.0,Cash,,2023-02-12
+TXN_7063005,Cake,1,3.0,3.0,,,2023-01-18
+TXN_9425096,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-06-12
+TXN_6236737,Juice,5,3.0,15.0,Cash,In-store,2023-03-19
+TXN_9691364,Cookie,3,1.0,3.0,Credit Card,In-store,2023-03-02
+TXN_4688280,UNKNOWN,1,1.5,1.5,,,2023-02-16
+TXN_1770648,Sandwich,4,4.0,16.0,Credit Card,,2023-09-30
+TXN_1524602,UNKNOWN,3,2.0,6.0,Cash,Takeaway,2023-05-11
+TXN_5289658,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,
+TXN_2602732,Salad,4,5.0,20.0,Digital Wallet,UNKNOWN,2023-06-09
+TXN_5132482,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-12-21
+TXN_3281605,UNKNOWN,1,1.5,1.5,,Takeaway,2023-07-27
+TXN_9969836,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-04-06
+TXN_7938279,Tea,3,1.5,4.5,Cash,Takeaway,2023-03-17
+TXN_8712307,,5,3.0,15.0,Cash,In-store,2023-04-10
+TXN_8595386,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-08-04
+TXN_6398450,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-11-19
+TXN_3042552,UNKNOWN,1,3.0,3.0,Cash,,2023-09-08
+TXN_7084298,Cake,3,3.0,9.0,,Takeaway,2023-02-18
+TXN_8384428,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-08-11
+TXN_6541329,Cookie,2,1.0,2.0,Cash,Takeaway,2023-09-28
+TXN_7667139,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-12-05
+TXN_1268811,Salad,1,5.0,5.0,,,2023-01-04
+TXN_9190025,Tea,4,1.5,6.0,Digital Wallet,UNKNOWN,UNKNOWN
+TXN_5056808,Juice,1,3.0,UNKNOWN,Credit Card,,2023-02-25
+TXN_9191048,Cake,5,3.0,15.0,Digital Wallet,ERROR,2023-09-18
+TXN_5105810,Cookie,5,,5.0,UNKNOWN,Takeaway,2023-01-17
+TXN_3272613,Cookie,2,1.0,2.0,Cash,,2023-03-30
+TXN_3690903,Coffee,3,2.0,6.0,,In-store,2023-10-22
+TXN_1938413,Smoothie,4,4.0,16.0,Digital Wallet,,2023-04-01
+TXN_1396019,Coffee,4,2.0,8.0,Cash,In-store,2023-12-03
+TXN_6989000,Tea,2,1.5,3.0,,Takeaway,2023-02-24
+TXN_4811225,Tea,5,1.5,7.5,Cash,Takeaway,2023-11-01
+TXN_2193333,Coffee,4,2.0,8.0,,Takeaway,2023-07-21
+TXN_4564220,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-05-09
+TXN_5414186,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-04-24
+TXN_1740742,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-10-06
+TXN_2547084,Sandwich,1,4.0,4.0,Cash,,2023-12-16
+TXN_8879936,Cake,5,3.0,15.0,,Takeaway,2023-07-25
+TXN_1605677,Tea,5,1.5,7.5,ERROR,,2023-01-15
+TXN_6070787,Sandwich,3,4.0,12.0,,In-store,2023-02-26
+TXN_3441457,Salad,2,ERROR,10.0,Digital Wallet,,2023-10-20
+TXN_1236759,Coffee,1,2.0,2.0,Credit Card,In-store,2023-01-26
+TXN_9239309,Salad,4,5.0,ERROR,ERROR,,UNKNOWN
+TXN_7196144,Smoothie,3,4.0,12.0,,,2023-03-28
+TXN_3981406,Salad,4,5.0,20.0,,,2023-04-17
+TXN_2152054,Cake,2,3.0,6.0,Digital Wallet,,2023-05-11
+TXN_9339037,Cookie,2,1.0,2.0,,Takeaway,2023-07-21
+TXN_7308629,Salad,4,5.0,20.0,ERROR,Takeaway,2023-11-24
+TXN_9407636,Smoothie,4,4.0,16.0,Cash,,2023-10-01
+TXN_4755860,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-10-28
+TXN_6118079,Coffee,1,2.0,2.0,UNKNOWN,Takeaway,2023-07-01
+TXN_6415784,Salad,3,5.0,15.0,,,2023-08-16
+TXN_1755817,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-07-17
+TXN_4417326,Sandwich,3,4.0,12.0,Digital Wallet,,UNKNOWN
+TXN_2090061,Smoothie,4,4.0,UNKNOWN,,,2023-06-23
+TXN_8128656,Smoothie,5,4.0,20.0,,In-store,2023-04-24
+TXN_6714749,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-08-02
+TXN_1103495,Juice,1,3.0,3.0,Cash,Takeaway,UNKNOWN
+TXN_8099424,Cake,4,3.0,12.0,,Takeaway,2023-04-02
+TXN_5103036,Juice,2,3.0,6.0,UNKNOWN,Takeaway,2023-12-04
+TXN_6013024,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-09-06
+TXN_8065852,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-07-17
+TXN_2035283,ERROR,3,4.0,12.0,,,2023-01-14
+TXN_3695238,Salad,5,5.0,25.0,Cash,Takeaway,2023-04-20
+TXN_1336727,Smoothie,2,,8.0,,In-store,2023-10-18
+TXN_5724548,Cake,5,3.0,15.0,,,2023-08-12
+TXN_3521791,Coffee,1,2.0,2.0,,Takeaway,2023-06-11
+TXN_2678484,Coffee,1,2.0,2.0,UNKNOWN,,2023-03-27
+TXN_6696619,Cake,3,3.0,9.0,,Takeaway,2023-03-19
+TXN_2734718,Tea,2,1.5,3.0,,UNKNOWN,2023-08-16
+TXN_7465693,,UNKNOWN,4.0,12.0,Digital Wallet,,2023-09-04
+TXN_8241649,Tea,5,1.5,7.5,ERROR,,2023-03-15
+TXN_6125646,Cookie,2,1.0,2.0,,,2023-06-12
+TXN_8639973,Cookie,5,1.0,5.0,,,2023-07-06
+TXN_1349640,Juice,2,3.0,6.0,Credit Card,In-store,2023-06-17
+TXN_3719842,Cake,3,3.0,9.0,Cash,UNKNOWN,2023-05-05
+TXN_3863940,Salad,2,5.0,10.0,,,2023-06-18
+TXN_9660030,Cake,5,3.0,15.0,Credit Card,In-store,2023-11-24
+TXN_9649503,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-01-02
+TXN_6618160,Tea,5,1.5,7.5,Cash,Takeaway,2023-03-13
+TXN_9121241,Sandwich,5,4.0,20.0,,Takeaway,2023-03-18
+TXN_4419474,Juice,2,3.0,6.0,,In-store,2023-02-04
+TXN_5639485,Cookie,3,1.0,3.0,Credit Card,,2023-07-02
+TXN_9997263,Cookie,2,1.0,2.0,,,2023-03-05
+TXN_4590013,Tea,5,1.5,7.5,Cash,Takeaway,2023-04-19
+TXN_4958354,Sandwich,4,UNKNOWN,16.0,Credit Card,Takeaway,2023-05-01
+TXN_9240476,Coffee,5,2.0,10.0,UNKNOWN,,2023-04-29
+TXN_2457961,Coffee,2,2.0,4.0,Credit Card,In-store,2023-06-08
+TXN_6494145,Cookie,2,1.0,2.0,Cash,,2023-08-18
+TXN_2142941,Cookie,5,1.0,5.0,Digital Wallet,,2023-11-03
+TXN_2405666,ERROR,2,3.0,6.0,Cash,Takeaway,2023-04-20
+TXN_4125871,Juice,4,3.0,12.0,,,2023-12-16
+TXN_7102166,Coffee,4,2.0,8.0,,,2023-12-08
+TXN_1492585,Sandwich,ERROR,4.0,12.0,Cash,Takeaway,2023-01-17
+TXN_2208949,Cake,4,3.0,12.0,Cash,Takeaway,2023-08-05
+TXN_9815454,Juice,5,3.0,15.0,Digital Wallet,,2023-12-05
+TXN_6806968,Cookie,4,1.0,4.0,Cash,Takeaway,2023-07-03
+TXN_3751420,Sandwich,5,4.0,20.0,,Takeaway,2023-11-20
+TXN_3439155,Salad,3,5.0,15.0,,Takeaway,2023-07-30
+TXN_5564198,Cake,4,3.0,12.0,Cash,,2023-06-06
+TXN_3446643,Smoothie,1,4.0,4.0,,,2023-06-01
+TXN_1770073,Cookie,2,1.0,2.0,,Takeaway,2023-12-03
+TXN_7328209,Sandwich,3,4.0,12.0,Credit Card,,2023-03-01
+TXN_4252608,Juice,3,3.0,9.0,Credit Card,In-store,2023-08-23
+TXN_7221831,Coffee,3,2.0,6.0,Credit Card,ERROR,2023-03-26
+TXN_4548565,Juice,4,3.0,12.0,,In-store,2023-02-17
+TXN_7400015,Juice,4,ERROR,12.0,Cash,,2023-01-27
+TXN_4749986,Tea,5,1.5,7.5,,Takeaway,2023-05-26
+TXN_1917336,Sandwich,3,4.0,12.0,Cash,In-store,2023-04-12
+TXN_5238755,Cookie,3,1.0,3.0,UNKNOWN,Takeaway,2023-06-01
+TXN_1822234,Salad,2,ERROR,10.0,Cash,,2023-10-15
+TXN_1342487,Juice,3,3.0,9.0,Credit Card,,2023-09-21
+TXN_7413282,Cake,5,3.0,15.0,,,2023-10-13
+TXN_5713298,Smoothie,2,4.0,8.0,Credit Card,,2023-07-14
+TXN_3045673,Smoothie,3,4.0,12.0,Digital Wallet,,2023-06-24
+TXN_2662720,Juice,5,3.0,15.0,,,2023-09-18
+TXN_8966922,Juice,4,3.0,12.0,,Takeaway,2023-11-10
+TXN_7311815,Cookie,4,1.0,4.0,,Takeaway,2023-05-11
+TXN_8211198,Juice,3,3.0,9.0,Credit Card,,2023-01-24
+TXN_6476719,Juice,5,3.0,15.0,Cash,Takeaway,2023-06-04
+TXN_1556480,Tea,5,1.5,,,,2023-02-06
+TXN_3009994,UNKNOWN,5,1.0,5.0,Credit Card,In-store,2023-09-13
+TXN_8992377,Cake,4,,12.0,Credit Card,Takeaway,2023-07-12
+TXN_5504130,Cake,3,3.0,9.0,UNKNOWN,,2023-06-24
+TXN_7153455,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-07-02
+TXN_8821579,Smoothie,4,4.0,16.0,,Takeaway,2023-12-06
+TXN_6873127,Cookie,1,1.0,1.0,UNKNOWN,In-store,2023-02-02
+TXN_9923952,Cookie,4,1.0,4.0,,Takeaway,2023-08-08
+TXN_7383137,Coffee,2,2.0,4.0,Credit Card,In-store,2023-12-02
+TXN_4766317,Cookie,2,1.0,2.0,,Takeaway,2023-09-23
+TXN_6335297,Cake,3,3.0,9.0,,,2023-10-16
+TXN_9334593,Sandwich,3,4.0,12.0,Cash,,2023-04-23
+TXN_2441029,Cake,5,3.0,15.0,Cash,In-store,2023-05-18
+TXN_8260461,Cookie,2,ERROR,2.0,Digital Wallet,,2023-10-29
+TXN_4801947,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-01-01
+TXN_4323120,Coffee,5,2.0,10.0,,,2023-08-29
+TXN_5947264,Salad,1,5.0,5.0,,In-store,2023-03-07
+TXN_9072628,Salad,4,5.0,20.0,Digital Wallet,ERROR,2023-12-29
+TXN_8282744,Tea,2,1.5,3.0,,Takeaway,2023-06-16
+TXN_2547156,Cookie,3,1.0,3.0,Digital Wallet,Takeaway,2023-08-18
+TXN_2428781,Salad,ERROR,5.0,UNKNOWN,,In-store,2023-05-09
+TXN_8621278,Salad,2,5.0,10.0,Cash,Takeaway,2023-02-01
+TXN_2616353,Smoothie,3,4.0,12.0,Cash,Takeaway,2023-06-24
+TXN_9731999,Sandwich,ERROR,4.0,16.0,,Takeaway,2023-11-26
+TXN_3608237,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-11-26
+TXN_2423167,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-06-29
+TXN_5742202,Salad,2,5.0,10.0,Cash,Takeaway,UNKNOWN
+TXN_6695451,Salad,1,5.0,5.0,Credit Card,ERROR,2023-07-28
+TXN_6098702,Coffee,3,2.0,6.0,Credit Card,ERROR,2023-10-15
+TXN_8972184,Juice,ERROR,3.0,12.0,,,2023-08-17
+TXN_2010507,Cake,3,3.0,9.0,,,2023-05-23
+TXN_1390754,Cake,2,3.0,6.0,,Takeaway,2023-11-08
+TXN_4925291,Smoothie,2,4.0,,Digital Wallet,,2023-09-22
+TXN_8345383,Tea,5,1.5,7.5,,Takeaway,2023-10-14
+TXN_3910293,Cake,4,3.0,12.0,Cash,In-store,2023-01-30
+TXN_4696969,Salad,1,5.0,5.0,Credit Card,,2023-09-29
+TXN_4568379,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-05-28
+TXN_8745942,Cookie,3,1.0,3.0,Cash,ERROR,2023-05-03
+TXN_1827937,Coffee,1,2.0,2.0,,Takeaway,UNKNOWN
+TXN_2496907,Coffee,2,2.0,4.0,Credit Card,,2023-11-28
+TXN_3043371,Smoothie,1,4.0,4.0,UNKNOWN,,2023-12-04
+TXN_2687149,Coffee,5,2.0,10.0,,,2023-03-24
+TXN_9752207,Sandwich,4,4.0,16.0,,In-store,2023-10-15
+TXN_7223850,Salad,2,5.0,10.0,Credit Card,,2023-02-05
+TXN_5421917,Tea,5,1.5,7.5,,,2023-05-03
+TXN_3812053,Coffee,5,2.0,10.0,,In-store,2023-04-03
+TXN_8437195,Cake,1,3.0,3.0,Cash,,2023-12-10
+TXN_3880494,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-12-17
+TXN_2755642,Cake,,3.0,9.0,Digital Wallet,In-store,2023-03-24
+TXN_9320353,Salad,5,5.0,25.0,Cash,In-store,2023-01-10
+TXN_8837015,Juice,3,3.0,9.0,Credit Card,In-store,2023-06-11
+TXN_1856538,Coffee,3,2.0,6.0,Cash,,2023-11-01
+TXN_2933439,Salad,4,5.0,20.0,Digital Wallet,,2023-04-14
+TXN_2667131,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-10-10
+TXN_5536056,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-12-22
+TXN_3846628,Juice,1,3.0,3.0,,Takeaway,2023-10-16
+TXN_9043894,Cake,1,3.0,3.0,Digital Wallet,,2023-07-28
+TXN_9354349,Juice,1,UNKNOWN,3.0,Credit Card,,2023-02-12
+TXN_3655950,Cookie,1,1.0,1.0,,In-store,2023-11-25
+TXN_4483585,Smoothie,5,4.0,20.0,,Takeaway,2023-12-26
+TXN_2332364,Cake,2,3.0,6.0,Credit Card,,2023-08-10
+TXN_5878649,Salad,3,5.0,15.0,UNKNOWN,Takeaway,2023-02-15
+TXN_2716940,Coffee,1,2.0,2.0,,,2023-11-27
+TXN_2496249,Juice,4,3.0,12.0,Cash,Takeaway,ERROR
+TXN_9020641,Cake,4,3.0,12.0,Credit Card,In-store,2023-06-27
+TXN_5931551,Sandwich,4,4.0,,,In-store,2023-03-28
+TXN_5812552,Cake,1,UNKNOWN,3.0,,,2023-09-17
+TXN_8899417,,3,5.0,15.0,Digital Wallet,,UNKNOWN
+TXN_2259102,Sandwich,2,4.0,ERROR,,,2023-02-19
+TXN_7041367,Cookie,4,1.0,4.0,,ERROR,2023-01-04
+TXN_1005377,Cake,5,UNKNOWN,15.0,Digital Wallet,Takeaway,2023-06-03
+TXN_7262554,Salad,3,5.0,15.0,Credit Card,,2023-07-08
+TXN_9705971,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-09-02
+TXN_4809626,Coffee,5,2.0,10.0,Cash,Takeaway,2023-02-18
+TXN_5171248,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-06-14
+TXN_2201235,Tea,1,1.5,1.5,Digital Wallet,,2023-12-17
+TXN_2907979,Juice,3,3.0,9.0,Cash,,2023-06-18
+TXN_7229918,Coffee,2,ERROR,4.0,Digital Wallet,Takeaway,2023-03-24
+TXN_5179245,Juice,3,3.0,9.0,Credit Card,,2023-04-17
+TXN_5010968,Smoothie,2,4.0,8.0,Digital Wallet,,2023-12-03
+TXN_6294315,Cookie,2,1.0,2.0,Digital Wallet,,2023-04-04
+TXN_8487985,Juice,5,3.0,15.0,,Takeaway,2023-05-09
+TXN_8552898,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-11-06
+TXN_1307428,,4,1.5,6.0,Credit Card,,
+TXN_4787754,Juice,2,3.0,6.0,Digital Wallet,Takeaway,2023-08-31
+TXN_9176533,Cake,3,3.0,9.0,Credit Card,,2023-10-14
+TXN_1228474,Smoothie,4,4.0,UNKNOWN,,In-store,2023-11-20
+TXN_9376428,UNKNOWN,1,5.0,5.0,Credit Card,Takeaway,2023-10-30
+TXN_3678804,,3,2.0,6.0,Digital Wallet,,2023-10-20
+TXN_6021363,Sandwich,2,4.0,8.0,Credit Card,Takeaway,2023-01-11
+TXN_8518812,Cookie,3,1.0,3.0,,In-store,2023-06-22
+TXN_5573436,Coffee,1,ERROR,2.0,ERROR,Takeaway,2023-02-22
+TXN_3274591,Juice,5,3.0,15.0,UNKNOWN,Takeaway,2023-04-09
+TXN_2477650,Cookie,1,1.0,1.0,Cash,Takeaway,2023-10-24
+TXN_4987376,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-08-20
+TXN_3099819,UNKNOWN,4,2.0,8.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_9196694,Cake,4,3.0,12.0,,In-store,2023-03-23
+TXN_2735598,Tea,5,ERROR,7.5,Credit Card,Takeaway,2023-06-30
+TXN_7362526,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-09-16
+TXN_3584252,Salad,,5.0,10.0,Digital Wallet,Takeaway,2023-12-19
+TXN_4854751,UNKNOWN,3,5.0,15.0,Credit Card,,UNKNOWN
+TXN_6324687,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-03-03
+TXN_2716377,Juice,4,3.0,12.0,Cash,,2023-01-03
+TXN_4002142,Cake,5,3.0,15.0,,,2023-06-27
+TXN_9417438,Salad,1,5.0,5.0,ERROR,In-store,2023-01-05
+TXN_4757873,Tea,1,1.5,1.5,Credit Card,In-store,2023-09-12
+TXN_6283718,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-07-20
+TXN_2019127,Salad,1,5.0,5.0,Cash,,2023-08-03
+TXN_2007652,Juice,2,3.0,6.0,Digital Wallet,UNKNOWN,2023-12-09
+TXN_3048882,Juice,2,3.0,6.0,Cash,Takeaway,2023-12-30
+TXN_3241510,Tea,5,1.5,7.5,Credit Card,ERROR,2023-10-05
+TXN_1978239,Salad,4,5.0,20.0,,In-store,2023-09-20
+TXN_3286168,Smoothie,5,4.0,20.0,Digital Wallet,,2023-06-25
+TXN_5922981,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-11-10
+TXN_4108567,Coffee,2,2.0,4.0,Cash,Takeaway,2023-08-14
+TXN_5217434,Coffee,1,2.0,2.0,,Takeaway,2023-09-22
+TXN_6691792,UNKNOWN,3,3.0,9.0,,Takeaway,2023-06-21
+TXN_4822216,Cake,1,3.0,3.0,,,2023-09-03
+TXN_9246986,Tea,4,1.5,6.0,Cash,Takeaway,2023-09-08
+TXN_3931393,Sandwich,2,4.0,8.0,Digital Wallet,,2023-11-18
+TXN_1429325,Smoothie,2,4.0,8.0,Cash,ERROR,2023-04-20
+TXN_2888655,Cookie,ERROR,1.0,4.0,Digital Wallet,UNKNOWN,2023-12-17
+TXN_3648160,Coffee,5,2.0,10.0,,Takeaway,2023-12-03
+TXN_5832513,Juice,4,3.0,12.0,Cash,In-store,2023-11-02
+TXN_6053755,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-01-18
+TXN_4437520,Smoothie,3,4.0,12.0,Credit Card,,2023-07-28
+TXN_4995281,Salad,4,5.0,20.0,Credit Card,,2023-02-25
+TXN_6105807,Smoothie,3,ERROR,ERROR,Credit Card,Takeaway,2023-01-18
+TXN_8384699,UNKNOWN,3,UNKNOWN,15.0,,In-store,2023-12-16
+TXN_3549667,Sandwich,ERROR,4.0,12.0,Digital Wallet,Takeaway,2023-01-29
+TXN_2566211,Tea,2,1.5,3.0,Cash,ERROR,2023-09-26
+TXN_3206842,UNKNOWN,4,5.0,20.0,Cash,,2023-04-30
+TXN_8970135,Juice,4,3.0,12.0,,In-store,2023-03-26
+TXN_3222612,UNKNOWN,3,3.0,UNKNOWN,Cash,Takeaway,2023-01-25
+TXN_6361593,Sandwich,4,4.0,16.0,Digital Wallet,Takeaway,2023-08-29
+TXN_9375445,Smoothie,2,ERROR,8.0,,In-store,2023-10-22
+TXN_4943552,,5,3.0,15.0,,Takeaway,2023-04-14
+TXN_1532390,Tea,5,1.5,7.5,Digital Wallet,ERROR,2023-04-08
+TXN_8020606,Cake,4,3.0,,,Takeaway,2023-10-10
+TXN_2729959,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-02-01
+TXN_4582054,,2,5.0,10.0,Digital Wallet,Takeaway,2023-08-27
+TXN_2134763,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-03-28
+TXN_1633607,Juice,1,3.0,3.0,Cash,Takeaway,2023-03-13
+TXN_5124999,Coffee,5,2.0,10.0,Digital Wallet,,2023-04-11
+TXN_7647190,Salad,ERROR,5.0,25.0,Credit Card,Takeaway,2023-02-22
+TXN_3514890,Smoothie,5,4.0,20.0,,In-store,2023-08-02
+TXN_2921765,Tea,2,1.5,3.0,Credit Card,Takeaway,ERROR
+TXN_5845583,Tea,4,1.5,6.0,Cash,In-store,2023-10-19
+TXN_6692318,Tea,2,1.5,3.0,Cash,In-store,2023-08-20
+TXN_9571019,Coffee,2,2.0,4.0,Cash,In-store,2023-06-22
+TXN_6451595,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-03-26
+TXN_4797429,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-11-07
+TXN_7255755,Sandwich,5,4.0,20.0,,,2023-10-19
+TXN_6925284,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-01-21
+TXN_2925996,Cake,3,3.0,9.0,Cash,Takeaway,2023-04-11
+TXN_3944582,Tea,5,1.5,7.5,UNKNOWN,In-store,2023-10-21
+TXN_7653452,Sandwich,1,4.0,4.0,Credit Card,,UNKNOWN
+TXN_5750248,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-07-20
+TXN_1020983,Juice,1,3.0,3.0,Digital Wallet,,2023-03-23
+TXN_9072817,Cookie,5,1.0,5.0,,Takeaway,2023-07-18
+TXN_1732639,Cookie,4,1.0,4.0,,In-store,UNKNOWN
+TXN_7416196,Smoothie,2,4.0,8.0,Cash,In-store,2023-10-20
+TXN_7276452,Coffee,3,2.0,6.0,Digital Wallet,,2023-06-05
+TXN_2610195,Cake,2,3.0,6.0,,,2023-10-25
+TXN_7971761,Salad,1,5.0,5.0,Credit Card,In-store,UNKNOWN
+TXN_9281392,Cookie,2,1.0,2.0,Digital Wallet,,2023-08-06
+TXN_8386253,Tea,4,1.5,6.0,Cash,,2023-05-11
+TXN_7995960,Juice,1,3.0,3.0,Digital Wallet,,2023-01-11
+TXN_7663739,Cookie,5,1.0,5.0,Credit Card,,2023-03-27
+TXN_3936339,,5,3.0,15.0,Digital Wallet,In-store,2023-09-08
+TXN_7784608,Coffee,5,2.0,10.0,,,2023-06-01
+TXN_7132021,Smoothie,2,4.0,8.0,Credit Card,In-store,ERROR
+TXN_6438980,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-11-10
+TXN_2196926,Juice,2,3.0,6.0,Digital Wallet,UNKNOWN,2023-07-27
+TXN_9582506,Cookie,2,1.0,2.0,Credit Card,,2023-04-28
+TXN_2424839,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-09-28
+TXN_5215704,Sandwich,5,4.0,20.0,Credit Card,,2023-10-31
+TXN_1982031,Cookie,4,1.0,4.0,Cash,Takeaway,2023-02-03
+TXN_3060286,Tea,2,1.5,3.0,Cash,Takeaway,2023-08-10
+TXN_7878231,ERROR,UNKNOWN,5.0,5.0,Cash,ERROR,2023-05-15
+TXN_9329112,Smoothie,3,4.0,12.0,,,ERROR
+TXN_1643029,Cookie,3,1.0,3.0,,,2023-09-11
+TXN_2764625,Tea,1,1.5,1.5,Cash,In-store,2023-12-03
+TXN_6086123,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-11-17
+TXN_1796259,Juice,1,3.0,3.0,,In-store,2023-04-29
+TXN_4078284,Coffee,1,2.0,2.0,Credit Card,,2023-05-14
+TXN_4389662,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-08-09
+TXN_1992699,Cookie,2,1.0,2.0,,Takeaway,2023-05-08
+TXN_9389300,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-01-14
+TXN_5409951,Coffee,3,2.0,6.0,,,2023-06-23
+TXN_2147448,Coffee,4,2.0,8.0,Credit Card,In-store,2023-11-27
+TXN_9826170,Juice,2,3.0,6.0,,,2023-12-06
+TXN_4949509,Smoothie,4,4.0,16.0,,,2023-04-20
+TXN_9857832,Tea,3,1.5,4.5,Cash,In-store,2023-03-31
+TXN_5038122,Salad,1,5.0,UNKNOWN,,,2023-08-11
+TXN_8984085,Salad,1,5.0,5.0,,,2023-08-17
+TXN_8830264,Salad,1,5.0,5.0,Cash,ERROR,2023-11-23
+TXN_9696074,Coffee,4,2.0,8.0,,Takeaway,2023-06-24
+TXN_9579637,Tea,4,1.5,6.0,Digital Wallet,,2023-06-26
+TXN_7907786,Tea,5,ERROR,7.5,Cash,,2023-09-20
+TXN_5316852,Coffee,2,2.0,4.0,Digital Wallet,,2023-04-08
+TXN_1292430,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-03-09
+TXN_5226399,ERROR,4,3.0,12.0,,Takeaway,2023-01-19
+TXN_2470530,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-03-21
+TXN_6498718,Coffee,4,2.0,8.0,,,2023-03-18
+TXN_1602435,Smoothie,1,4.0,4.0,Cash,ERROR,2023-12-01
+TXN_1434598,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-11-18
+TXN_9871036,Smoothie,1,4.0,4.0,,Takeaway,2023-07-02
+TXN_2073001,Coffee,2,2.0,4.0,Digital Wallet,,2023-11-22
+TXN_9284622,UNKNOWN,1,2.0,ERROR,Credit Card,,2023-05-15
+TXN_7815076,Juice,5,3.0,UNKNOWN,Cash,,2023-12-16
+TXN_6897172,Coffee,4,2.0,8.0,Digital Wallet,,2023-12-08
+TXN_3783903,Tea,4,1.5,6.0,,,2023-06-25
+TXN_4378637,Cookie,1,1.0,1.0,,Takeaway,2023-05-12
+TXN_7514047,ERROR,1,5.0,,Cash,UNKNOWN,2023-03-08
+TXN_4375708,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-08-01
+TXN_9775984,Juice,2,3.0,6.0,Credit Card,In-store,2023-10-09
+TXN_1708928,Smoothie,1,4.0,4.0,ERROR,,UNKNOWN
+TXN_2352685,Cookie,1,1.0,1.0,Cash,Takeaway,UNKNOWN
+TXN_1625754,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-08-03
+TXN_9567915,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-06-30
+TXN_4062634,Salad,2,5.0,10.0,Credit Card,In-store,2023-04-05
+TXN_6624397,Juice,4,3.0,12.0,Cash,Takeaway,2023-04-30
+TXN_2991733,Tea,5,1.5,7.5,Credit Card,,2023-04-13
+TXN_8978924,Salad,5,5.0,25.0,Cash,ERROR,2023-10-09
+TXN_2404800,Sandwich,5,4.0,20.0,Cash,In-store,2023-01-28
+TXN_4501915,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-12-04
+TXN_6273431,,2,3.0,6.0,,In-store,2023-04-05
+TXN_7166936,Cookie,ERROR,1.0,4.0,,In-store,2023-09-25
+TXN_7645250,Juice,2,3.0,6.0,,,2023-10-09
+TXN_9231480,Cookie,4,1.0,4.0,Cash,,2023-08-28
+TXN_4247105,Coffee,5,2.0,10.0,Cash,In-store,2023-04-14
+TXN_8732935,Cookie,4,1.0,4.0,Credit Card,Takeaway,2023-08-06
+TXN_5108867,,ERROR,3.0,9.0,Cash,Takeaway,2023-03-19
+TXN_3270584,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-01-10
+TXN_8258798,Coffee,3,,6.0,Cash,In-store,2023-10-18
+TXN_7412012,Coffee,1,2.0,2.0,Cash,In-store,2023-08-02
+TXN_1927324,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-08-29
+TXN_9159655,Cookie,5,1.0,5.0,Cash,UNKNOWN,2023-03-21
+TXN_1293057,Tea,2,1.5,3.0,Digital Wallet,,2023-07-03
+TXN_8829698,Cake,2,3.0,,Cash,,2023-03-19
+TXN_5056351,Juice,1,3.0,3.0,,Takeaway,2023-04-24
+TXN_4431264,Smoothie,2,4.0,8.0,,,2023-11-14
+TXN_7371782,Tea,3,1.5,4.5,Cash,In-store,2023-02-26
+TXN_7631505,Sandwich,4,4.0,16.0,Cash,In-store,2023-07-08
+TXN_4331770,Salad,4,5.0,20.0,,,2023-06-04
+TXN_2593909,Juice,2,3.0,6.0,Cash,In-store,2023-02-25
+TXN_9728062,Coffee,1,2.0,2.0,Cash,,2023-05-01
+TXN_7664606,Cookie,2,1.0,2.0,Digital Wallet,ERROR,2023-07-05
+TXN_3359911,Cookie,4,1.0,4.0,,In-store,2023-06-18
+TXN_3745153,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-06-30
+TXN_2019258,Juice,4,3.0,12.0,Credit Card,,2023-02-03
+TXN_8153957,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-10-12
+TXN_3437948,Smoothie,2,4.0,8.0,Cash,,2023-11-02
+TXN_6874195,Juice,3,3.0,9.0,Cash,Takeaway,2023-04-22
+TXN_3234146,Juice,1,3.0,3.0,UNKNOWN,Takeaway,2023-11-14
+TXN_5172383,Juice,3,3.0,9.0,Cash,In-store,2023-03-28
+TXN_9288999,Cookie,3,1.0,3.0,Credit Card,In-store,2023-05-01
+TXN_4205407,Smoothie,5,4.0,20.0,Digital Wallet,,2023-04-27
+TXN_8325722,Sandwich,2,4.0,8.0,,Takeaway,2023-05-27
+TXN_3050797,Sandwich,3,4.0,12.0,Credit Card,,2023-09-28
+TXN_8731991,Salad,UNKNOWN,5.0,20.0,,In-store,2023-01-20
+TXN_7387416,Juice,3,3.0,9.0,Cash,,2023-12-15
+TXN_2244418,Salad,5,5.0,25.0,Cash,Takeaway,2023-10-15
+TXN_2638644,ERROR,1,1.5,1.5,,UNKNOWN,2023-03-08
+TXN_3886177,Cake,3,3.0,9.0,,Takeaway,2023-07-17
+TXN_2334047,Tea,1,1.5,1.5,,Takeaway,2023-11-08
+TXN_3888864,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-10-13
+TXN_6972491,Sandwich,1,4.0,4.0,,Takeaway,2023-07-02
+TXN_8886791,Tea,2,1.5,3.0,Cash,,2023-07-09
+TXN_4356114,Juice,2,3.0,6.0,Cash,Takeaway,2023-05-05
+TXN_2097023,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-11-10
+TXN_2726749,Juice,4,3.0,12.0,,Takeaway,2023-05-19
+TXN_3357336,Cake,4,3.0,12.0,,In-store,2023-02-20
+TXN_3529354,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-09-06
+TXN_9738339,Juice,1,3.0,3.0,UNKNOWN,In-store,2023-07-09
+TXN_9389963,ERROR,5,4.0,ERROR,,Takeaway,2023-02-28
+TXN_6837879,ERROR,5,3.0,15.0,Digital Wallet,,2023-04-09
+TXN_1046659,Smoothie,3,4.0,12.0,,Takeaway,2023-12-14
+TXN_2032049,Salad,2,5.0,10.0,Credit Card,UNKNOWN,2023-10-12
+TXN_1444479,,1,3.0,3.0,Credit Card,,2023-12-10
+TXN_7251037,Salad,3,5.0,15.0,Credit Card,In-store,2023-08-17
+TXN_9891576,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-04-28
+TXN_5315818,Salad,1,5.0,5.0,Digital Wallet,,2023-02-06
+TXN_9830755,Cookie,5,1.0,5.0,Digital Wallet,Takeaway,2023-06-24
+TXN_8833319,Salad,1,5.0,ERROR,ERROR,Takeaway,2023-10-01
+TXN_4353750,Cake,2,3.0,6.0,Credit Card,,2023-03-02
+TXN_8809659,Juice,2,3.0,6.0,Cash,Takeaway,2023-01-16
+TXN_2104550,Coffee,4,2.0,UNKNOWN,Credit Card,In-store,2023-09-08
+TXN_7554731,Cake,1,3.0,3.0,Credit Card,In-store,2023-02-02
+TXN_8743142,Cookie,1,1.0,1.0,Digital Wallet,In-store,
+TXN_8652021,Cake,1,3.0,3.0,Credit Card,In-store,2023-09-23
+TXN_3744962,Salad,1,5.0,5.0,,In-store,2023-07-26
+TXN_7312277,Juice,4,3.0,12.0,,In-store,2023-09-07
+TXN_2342308,Cookie,5,,5.0,Digital Wallet,,2023-05-20
+TXN_7797507,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-06-06
+TXN_3121360,Cake,3,3.0,9.0,Digital Wallet,,2023-01-21
+TXN_5568416,Cake,5,3.0,15.0,Credit Card,UNKNOWN,2023-09-06
+TXN_7032922,Sandwich,4,4.0,16.0,,,2023-08-18
+TXN_5734186,Juice,3,3.0,9.0,Cash,,2023-04-03
+TXN_5107025,Tea,2,ERROR,3.0,,In-store,2023-02-19
+TXN_7975387,Smoothie,UNKNOWN,4.0,8.0,Credit Card,Takeaway,2023-03-23
+TXN_5209346,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-02-22
+TXN_8947660,Coffee,1,2.0,2.0,,In-store,2023-09-03
+TXN_6752053,Smoothie,4,4.0,16.0,,,2023-05-13
+TXN_6571385,Tea,4,1.5,6.0,Cash,Takeaway,2023-01-06
+TXN_6430534,Tea,5,1.5,7.5,Cash,Takeaway,2023-01-29
+TXN_6467414,Tea,3,1.5,4.5,Cash,,2023-01-06
+TXN_2861912,Coffee,3,2.0,6.0,,In-store,2023-03-25
+TXN_8347965,Salad,1,UNKNOWN,5.0,Cash,Takeaway,2023-03-17
+TXN_9693344,Tea,4,1.5,6.0,Credit Card,Takeaway,2023-01-15
+TXN_9801552,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-04-20
+TXN_1929109,Sandwich,5,4.0,20.0,,,ERROR
+TXN_8082317,Juice,3,3.0,9.0,Cash,Takeaway,2023-08-18
+TXN_1569729,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-07-16
+TXN_8126049,Sandwich,3,4.0,12.0,ERROR,,ERROR
+TXN_2644962,Smoothie,2,4.0,,UNKNOWN,,2023-04-09
+TXN_8991609,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-06-19
+TXN_5000665,Cake,3,3.0,9.0,Digital Wallet,In-store,2023-11-28
+TXN_2161255,Sandwich,3,4.0,12.0,,,2023-06-08
+TXN_6549359,UNKNOWN,3,1.5,4.5,Cash,,2023-04-21
+TXN_8833173,Smoothie,4,4.0,16.0,Digital Wallet,,2023-03-14
+TXN_8449081,Cookie,2,1.0,2.0,,In-store,2023-02-24
+TXN_7153321,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-12-19
+TXN_2935761,Smoothie,4,4.0,16.0,Digital Wallet,,2023-04-01
+TXN_7328705,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-09-09
+TXN_1419790,Sandwich,3,4.0,12.0,,,2023-01-06
+TXN_8970187,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-03-13
+TXN_4385632,Tea,5,1.5,7.5,,Takeaway,2023-06-18
+TXN_4343133,Cookie,4,1.0,4.0,Digital Wallet,,2023-03-04
+TXN_7712544,Cookie,3,ERROR,3.0,Cash,,2023-05-06
+TXN_6904952,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-04-04
+TXN_4023091,Smoothie,3,4.0,12.0,Credit Card,,2023-07-24
+TXN_6005707,Juice,4,3.0,,Cash,UNKNOWN,2023-02-06
+TXN_9824238,Tea,5,1.5,7.5,Cash,In-store,2023-07-14
+TXN_2867795,Cookie,1,1.0,1.0,Credit Card,UNKNOWN,2023-06-26
+TXN_8434259,Tea,2,1.5,3.0,Digital Wallet,,UNKNOWN
+TXN_5437961,Sandwich,3,UNKNOWN,12.0,,In-store,2023-06-30
+TXN_3440463,Cake,1,3.0,UNKNOWN,Credit Card,Takeaway,2023-04-04
+TXN_1242840,Smoothie,1,4.0,4.0,Credit Card,,2023-08-26
+TXN_2997717,Cake,4,3.0,12.0,Credit Card,,2023-10-19
+TXN_4440412,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-04-15
+TXN_9897583,Coffee,2,UNKNOWN,4.0,Digital Wallet,Takeaway,2023-01-20
+TXN_9772498,Cake,4,3.0,12.0,Cash,,2023-08-21
+TXN_7908929,Tea,2,1.5,3.0,Digital Wallet,,2023-11-18
+TXN_6411390,Juice,1,3.0,ERROR,Cash,,2023-09-07
+TXN_5784400,Cake,4,3.0,12.0,Digital Wallet,,2023-11-25
+TXN_9660737,Cookie,UNKNOWN,1.0,5.0,Cash,,2023-05-19
+TXN_9719954,Tea,1,1.5,1.5,Digital Wallet,,UNKNOWN
+TXN_3287282,UNKNOWN,2,1.5,3.0,Digital Wallet,Takeaway,2023-09-23
+TXN_7368518,UNKNOWN,3,3.0,9.0,UNKNOWN,,2023-03-14
+TXN_6068074,Smoothie,2,4.0,8.0,Cash,In-store,2023-06-01
+TXN_2265329,Cake,5,3.0,15.0,Credit Card,,2023-12-23
+TXN_8500316,Sandwich,4,4.0,16.0,,,2023-03-10
+TXN_4235472,Salad,5,5.0,25.0,,Takeaway,2023-12-22
+TXN_1701798,Coffee,2,2.0,4.0,Cash,Takeaway,2023-07-24
+TXN_4352950,Coffee,1,2.0,2.0,Digital Wallet,,2023-02-06
+TXN_4807899,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-07-03
+TXN_4916085,Juice,1,3.0,3.0,Digital Wallet,,2023-03-03
+TXN_2764819,UNKNOWN,1,3.0,3.0,Credit Card,Takeaway,2023-02-23
+TXN_2102950,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-12-07
+TXN_5530180,Cookie,5,1.0,5.0,,In-store,2023-09-06
+TXN_6774559,Cookie,2,1.0,2.0,,,2023-02-18
+TXN_7914312,Sandwich,5,4.0,20.0,,In-store,2023-06-06
+TXN_5282804,Sandwich,1,4.0,4.0,Credit Card,,2023-12-01
+TXN_6526078,Sandwich,5,4.0,20.0,Cash,,2023-11-07
+TXN_4070040,Cake,1,3.0,3.0,,UNKNOWN,UNKNOWN
+TXN_7668576,UNKNOWN,2,3.0,6.0,,,2023-11-08
+TXN_2210019,Sandwich,3,4.0,12.0,Cash,In-store,2023-12-05
+TXN_4727260,Tea,2,1.5,3.0,,,2023-01-30
+TXN_2617632,Smoothie,4,4.0,16.0,Digital Wallet,,2023-10-17
+TXN_5585601,Cake,4,3.0,12.0,,Takeaway,2023-05-28
+TXN_8019306,Juice,1,3.0,3.0,Credit Card,,2023-05-21
+TXN_6469563,Juice,5,3.0,15.0,Credit Card,UNKNOWN,2023-03-04
+TXN_4059695,Salad,3,5.0,15.0,Cash,Takeaway,2023-12-30
+TXN_2393287,UNKNOWN,2,3.0,6.0,Cash,,2023-04-14
+TXN_3799280,Coffee,5,2.0,10.0,Cash,,2023-09-23
+TXN_1454024,Cookie,5,1.0,5.0,Digital Wallet,,
+TXN_2749862,Salad,4,5.0,,Digital Wallet,,2023-07-19
+TXN_3863625,Salad,5,,25.0,Cash,In-store,2023-09-04
+TXN_2928676,Cookie,1,1.0,1.0,Credit Card,,2023-06-09
+TXN_4030763,Salad,2,5.0,10.0,UNKNOWN,Takeaway,2023-06-17
+TXN_6853830,UNKNOWN,5,1.5,7.5,,In-store,2023-07-13
+TXN_3877643,Juice,4,3.0,12.0,Cash,In-store,2023-11-15
+TXN_9395554,,4,2.0,8.0,Cash,Takeaway,2023-03-31
+TXN_3755657,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-03-24
+TXN_6987232,Juice,5,3.0,15.0,Digital Wallet,,2023-06-02
+TXN_8045032,Juice,4,3.0,12.0,ERROR,In-store,2023-02-20
+TXN_3288233,Juice,5,3.0,15.0,Cash,,2023-12-24
+TXN_4231121,Coffee,4,2.0,8.0,ERROR,UNKNOWN,2023-09-01
+TXN_8932087,UNKNOWN,UNKNOWN,3.0,3.0,Digital Wallet,Takeaway,2023-10-30
+TXN_6189486,UNKNOWN,5,4.0,20.0,,Takeaway,2023-03-23
+TXN_2489067,Juice,2,3.0,6.0,,Takeaway,2023-07-05
+TXN_7293600,Cake,3,3.0,ERROR,Digital Wallet,,2023-10-28
+TXN_3147874,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_5279293,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-11-11
+TXN_3488082,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-04-12
+TXN_3342106,Sandwich,1,4.0,4.0,Credit Card,In-store,2023-01-14
+TXN_3713880,Salad,5,5.0,25.0,,In-store,2023-06-30
+TXN_1967032,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-01-12
+TXN_6587151,Smoothie,4,ERROR,16.0,Credit Card,,2023-10-07
+TXN_2630698,Sandwich,2,4.0,8.0,UNKNOWN,Takeaway,2023-08-22
+TXN_3632558,Coffee,2,ERROR,4.0,Cash,Takeaway,2023-08-10
+TXN_8228500,Tea,3,1.5,4.5,,In-store,2023-04-15
+TXN_9708632,Coffee,5,2.0,10.0,,In-store,
+TXN_3543930,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-10-10
+TXN_1037464,UNKNOWN,5,4.0,20.0,Digital Wallet,,2023-02-14
+TXN_3508619,Smoothie,4,4.0,16.0,,ERROR,2023-09-04
+TXN_4553403,Coffee,5,2.0,10.0,,In-store,2023-06-20
+TXN_5747509,Cookie,2,1.0,2.0,Cash,In-store,2023-10-30
+TXN_7910572,Sandwich,4,4.0,16.0,,Takeaway,2023-07-07
+TXN_9012517,Coffee,2,2.0,4.0,Credit Card,In-store,2023-10-21
+TXN_8237192,Sandwich,3,4.0,12.0,,,2023-10-03
+TXN_5303092,Tea,2,1.5,3.0,Credit Card,In-store,2023-05-05
+TXN_3136657,Cake,ERROR,3.0,6.0,Cash,In-store,2023-09-21
+TXN_3865641,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-09-15
+TXN_1049697,Tea,3,UNKNOWN,4.5,Cash,In-store,2023-10-08
+TXN_3420316,Sandwich,3,4.0,12.0,,Takeaway,2023-10-31
+TXN_6568307,Coffee,1,2.0,2.0,Cash,In-store,2023-07-16
+TXN_8281347,Juice,4,3.0,12.0,Credit Card,In-store,2023-08-11
+TXN_8353202,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-06-14
+TXN_7377398,Juice,2,3.0,6.0,Cash,Takeaway,2023-02-26
+TXN_6915068,Juice,2,3.0,6.0,Cash,In-store,2023-11-26
+TXN_8704802,Smoothie,3,4.0,12.0,,,2023-08-30
+TXN_1983422,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-06-26
+TXN_1603186,Cake,3,3.0,,Cash,Takeaway,2023-10-13
+TXN_5572520,Smoothie,5,4.0,20.0,Cash,Takeaway,2023-05-14
+TXN_2021680,Juice,3,3.0,9.0,,Takeaway,2023-08-16
+TXN_9220900,Cookie,4,UNKNOWN,4.0,,,2023-06-19
+TXN_6123007,Coffee,3,2.0,6.0,Digital Wallet,,2023-05-28
+TXN_2832660,Smoothie,2,4.0,8.0,Credit Card,,2023-01-08
+TXN_7697496,Salad,1,5.0,5.0,ERROR,Takeaway,2023-06-18
+TXN_9802838,Tea,1,1.5,1.5,UNKNOWN,Takeaway,2023-02-15
+TXN_4011509,Smoothie,4,4.0,16.0,Digital Wallet,,2023-11-10
+TXN_6786730,Coffee,1,2.0,2.0,Credit Card,,2023-04-15
+TXN_3641356,Juice,3,UNKNOWN,9.0,Credit Card,In-store,2023-07-26
+TXN_8245502,Salad,1,5.0,5.0,Credit Card,,2023-03-16
+TXN_3645818,,1,1.0,1.0,Digital Wallet,Takeaway,2023-03-18
+TXN_1318238,Sandwich,1,4.0,UNKNOWN,Digital Wallet,Takeaway,2023-09-23
+TXN_1970180,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-08-02
+TXN_5415223,Tea,2,1.5,3.0,Cash,In-store,2023-09-02
+TXN_4777601,Tea,1,1.5,1.5,Credit Card,In-store,2023-08-18
+TXN_2023651,Sandwich,,4.0,ERROR,Cash,In-store,2023-05-25
+TXN_5110688,Salad,3,5.0,15.0,Digital Wallet,,2023-05-09
+TXN_7497122,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-03-23
+TXN_4870483,Coffee,1,2.0,2.0,,Takeaway,2023-03-03
+TXN_3003979,Tea,ERROR,1.5,1.5,Digital Wallet,Takeaway,2023-01-08
+TXN_3838923,Juice,4,3.0,12.0,UNKNOWN,Takeaway,2023-06-03
+TXN_1998143,,1,1.0,1.0,Digital Wallet,In-store,2023-12-10
+TXN_2458782,Salad,1,5.0,5.0,Cash,,2023-04-15
+TXN_1256513,Coffee,4,2.0,8.0,Credit Card,In-store,2023-02-21
+TXN_6266187,Tea,5,1.5,7.5,Credit Card,In-store,
+TXN_9432758,Cookie,3,1.0,3.0,Cash,Takeaway,2023-10-02
+TXN_1254663,Coffee,3,2.0,ERROR,,,2023-08-15
+TXN_7174856,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-05-03
+TXN_5548756,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-09-09
+TXN_2736267,Salad,5,5.0,25.0,ERROR,In-store,2023-03-17
+TXN_7595907,,5,ERROR,15.0,,In-store,2023-04-24
+TXN_1990997,Salad,1,5.0,5.0,Digital Wallet,,2023-03-27
+TXN_3820150,Tea,1,1.5,1.5,ERROR,,2023-05-10
+TXN_7325508,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-05-27
+TXN_5398134,Coffee,2,2.0,4.0,Credit Card,UNKNOWN,2023-10-01
+TXN_2150872,UNKNOWN,5,ERROR,15.0,Cash,Takeaway,2023-03-18
+TXN_6563365,Juice,ERROR,3.0,12.0,,Takeaway,UNKNOWN
+TXN_9669616,Coffee,ERROR,2.0,UNKNOWN,,ERROR,2023-06-03
+TXN_1936447,Cookie,2,1.0,2.0,Cash,,2023-10-28
+TXN_8469087,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-11-06
+TXN_5556985,Juice,3,3.0,9.0,Digital Wallet,In-store,ERROR
+TXN_8621589,Juice,5,3.0,15.0,Digital Wallet,,2023-11-15
+TXN_9901097,Coffee,1,2.0,2.0,Cash,,2023-01-07
+TXN_8783484,Smoothie,1,4.0,4.0,Cash,In-store,2023-11-20
+TXN_9599703,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-09-25
+TXN_1353248,Sandwich,3,4.0,12.0,Cash,UNKNOWN,2023-09-03
+TXN_2470745,Sandwich,ERROR,4.0,8.0,Digital Wallet,,2023-01-10
+TXN_1266598,Cake,4,3.0,12.0,Digital Wallet,,2023-04-05
+TXN_5445994,Juice,1,3.0,3.0,Credit Card,In-store,2023-06-11
+TXN_5689687,Cake,5,3.0,15.0,,In-store,2023-06-04
+TXN_2208733,Juice,1,3.0,3.0,,Takeaway,2023-06-20
+TXN_1547245,Sandwich,,4.0,,,Takeaway,2023-09-11
+TXN_4694285,Tea,3,1.5,4.5,,In-store,2023-01-25
+TXN_3829375,Juice,5,UNKNOWN,15.0,Cash,,2023-12-18
+TXN_1932224,Coffee,1,2.0,2.0,Credit Card,,2023-09-09
+TXN_5468153,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-12-15
+TXN_9363711,Coffee,5,2.0,10.0,Digital Wallet,Takeaway,2023-11-23
+TXN_6845073,Cookie,1,1.0,1.0,Credit Card,In-store,2023-04-05
+TXN_1621227,Coffee,2,2.0,4.0,Cash,,UNKNOWN
+TXN_1691313,Sandwich,2,4.0,8.0,Digital Wallet,Takeaway,2023-03-17
+TXN_4007522,Cake,2,3.0,UNKNOWN,Cash,Takeaway,2023-12-20
+TXN_3175177,Juice,3,3.0,9.0,Credit Card,,2023-10-24
+TXN_9282265,Salad,2,5.0,10.0,Credit Card,,2023-03-20
+TXN_8265257,Coffee,1,2.0,2.0,ERROR,In-store,2023-10-25
+TXN_5425668,Cookie,5,1.0,5.0,Cash,Takeaway,2023-04-09
+TXN_7738455,Tea,3,1.5,4.5,Digital Wallet,,2023-06-05
+TXN_7349681,Salad,1,ERROR,5.0,Cash,In-store,2023-08-09
+TXN_2660576,Sandwich,1,4.0,4.0,,,2023-05-15
+TXN_2101934,Smoothie,4,4.0,16.0,Cash,In-store,2023-11-27
+TXN_1525583,Sandwich,3,UNKNOWN,UNKNOWN,Cash,Takeaway,2023-05-20
+TXN_6110108,Tea,ERROR,1.5,7.5,,Takeaway,2023-02-10
+TXN_9205425,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-09-16
+TXN_9306482,Smoothie,2,4.0,8.0,Digital Wallet,Takeaway,2023-01-16
+TXN_8407849,Cookie,2,1.0,2.0,,,2023-05-05
+TXN_3162244,Sandwich,ERROR,4.0,20.0,Digital Wallet,In-store,2023-12-15
+TXN_9121687,Sandwich,2,4.0,8.0,ERROR,In-store,2023-05-13
+TXN_3182191,Cake,5,3.0,15.0,Digital Wallet,,2023-07-21
+TXN_4734366,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-08-20
+TXN_4430006,Juice,5,3.0,15.0,UNKNOWN,,2023-01-14
+TXN_7341975,Juice,2,3.0,6.0,Digital Wallet,,2023-07-29
+TXN_8787149,Juice,1,3.0,3.0,,ERROR,2023-04-20
+TXN_4224284,Cookie,2,1.0,2.0,UNKNOWN,Takeaway,2023-09-04
+TXN_2177436,Cake,,3.0,3.0,ERROR,Takeaway,2023-03-13
+TXN_5097542,Cake,5,3.0,15.0,Cash,,2023-05-15
+TXN_4260738,Coffee,2,2.0,4.0,,In-store,2023-11-15
+TXN_5402821,Salad,4,5.0,20.0,,,2023-11-29
+TXN_4130343,Coffee,4,2.0,8.0,Credit Card,In-store,2023-12-08
+TXN_3028667,Juice,2,3.0,6.0,,Takeaway,2023-11-24
+TXN_8592808,ERROR,1,4.0,4.0,Credit Card,,2023-04-02
+TXN_5875201,UNKNOWN,UNKNOWN,4.0,4.0,,In-store,2023-01-31
+TXN_6849062,Coffee,5,2.0,10.0,Cash,,2023-07-30
+TXN_4336844,Smoothie,4,4.0,16.0,,,2023-07-09
+TXN_6090715,Juice,3,3.0,9.0,Credit Card,In-store,2023-11-14
+TXN_9162014,Cake,1,3.0,3.0,Cash,,2023-07-21
+TXN_4751689,Smoothie,5,4.0,UNKNOWN,Cash,In-store,2023-07-28
+TXN_2200163,Coffee,4,2.0,8.0,Cash,UNKNOWN,2023-03-13
+TXN_7310903,Smoothie,3,4.0,12.0,Credit Card,,2023-09-10
+TXN_7155957,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-02-22
+TXN_4350828,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-02-16
+TXN_7539585,Smoothie,5,4.0,20.0,,,2023-10-20
+TXN_6868763,ERROR,3,3.0,9.0,Digital Wallet,In-store,2023-01-13
+TXN_6156180,Coffee,UNKNOWN,2.0,10.0,Cash,,2023-07-25
+TXN_4970127,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-12-09
+TXN_9567719,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-01-24
+TXN_2950265,Salad,3,5.0,15.0,Credit Card,,2023-08-23
+TXN_1556609,Sandwich,1,4.0,4.0,Digital Wallet,,2023-07-21
+TXN_2203547,Juice,3,3.0,9.0,,In-store,2023-07-01
+TXN_1084010,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-08-11
+TXN_4218637,Tea,5,1.5,7.5,Cash,,2023-08-31
+TXN_2245465,Salad,2,5.0,10.0,Digital Wallet,,2023-12-27
+TXN_4742049,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-09-10
+TXN_9889005,Cake,3,3.0,9.0,UNKNOWN,,2023-12-16
+TXN_4840522,Smoothie,3,4.0,12.0,,In-store,2023-06-16
+TXN_2585392,Salad,4,5.0,20.0,,,2023-07-12
+TXN_3135264,UNKNOWN,2,3.0,6.0,Digital Wallet,,2023-08-25
+TXN_2180562,Salad,2,5.0,10.0,,Takeaway,2023-07-02
+TXN_5905580,ERROR,3,1.0,3.0,Cash,Takeaway,2023-02-20
+TXN_5993677,Cake,4,3.0,12.0,,Takeaway,2023-01-28
+TXN_8984991,Smoothie,3,4.0,12.0,Credit Card,,2023-05-17
+TXN_3522597,UNKNOWN,3,1.5,4.5,Digital Wallet,In-store,2023-02-04
+TXN_6123633,Salad,3,5.0,15.0,UNKNOWN,,2023-01-16
+TXN_6769554,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-02-06
+TXN_5761414,Smoothie,1,4.0,4.0,Digital Wallet,,2023-10-02
+TXN_5157516,Salad,3,5.0,15.0,,In-store,2023-10-09
+TXN_2614633,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-04-23
+TXN_3781240,Cake,5,3.0,15.0,,Takeaway,2023-05-27
+TXN_7068823,,4,4.0,16.0,,Takeaway,2023-06-28
+TXN_2085081,Cake,2,3.0,6.0,Cash,,2023-03-14
+TXN_3399636,Juice,3,3.0,9.0,Digital Wallet,Takeaway,2023-08-07
+TXN_8587529,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-07-09
+TXN_1476775,Salad,3,5.0,15.0,Credit Card,,2023-11-01
+TXN_6945985,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-02-13
+TXN_4117627,Cake,3,3.0,9.0,Credit Card,In-store,2023-06-22
+TXN_7530300,Coffee,3,2.0,6.0,Digital Wallet,,2023-05-08
+TXN_7071783,Cookie,4,1.0,4.0,Cash,,2023-07-04
+TXN_3676305,Salad,5,5.0,25.0,Credit Card,,2023-06-14
+TXN_8867827,Tea,1,1.5,1.5,Digital Wallet,,2023-01-14
+TXN_9061106,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-11-04
+TXN_1245485,Cake,1,ERROR,3.0,Digital Wallet,ERROR,2023-05-15
+TXN_1357780,Tea,4,,6.0,,In-store,2023-10-23
+TXN_4075053,UNKNOWN,3,4.0,12.0,Digital Wallet,Takeaway,2023-02-27
+TXN_6113724,Coffee,1,ERROR,2.0,Digital Wallet,Takeaway,2023-03-26
+TXN_6496176,Cookie,4,1.0,4.0,,In-store,2023-07-26
+TXN_2381411,Coffee,5,2.0,10.0,Cash,In-store,2023-07-30
+TXN_9210096,Smoothie,3,4.0,12.0,,UNKNOWN,2023-05-25
+TXN_4563544,Sandwich,5,4.0,20.0,,ERROR,2023-06-10
+TXN_2546684,Juice,ERROR,3.0,UNKNOWN,Digital Wallet,Takeaway,2023-04-08
+TXN_4623468,Coffee,5,2.0,10.0,Credit Card,Takeaway,UNKNOWN
+TXN_2168277,Cookie,1,1.0,1.0,,Takeaway,2023-06-02
+TXN_9178545,Juice,4,3.0,12.0,Cash,In-store,2023-01-24
+TXN_8535886,Tea,5,1.5,7.5,Credit Card,In-store,2023-05-13
+TXN_1037486,Salad,5,5.0,25.0,Digital Wallet,In-store,
+TXN_7978452,Cake,5,3.0,15.0,Digital Wallet,,2023-10-03
+TXN_8488163,Sandwich,4,4.0,UNKNOWN,UNKNOWN,,2023-01-19
+TXN_6926855,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-01-12
+TXN_9869593,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-10-03
+TXN_3055407,Tea,2,1.5,3.0,UNKNOWN,,2023-06-03
+TXN_4981027,Coffee,3,2.0,6.0,,,2023-08-02
+TXN_5332773,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-05-04
+TXN_5946554,Cake,2,3.0,UNKNOWN,,,2023-03-01
+TXN_7508715,Smoothie,2,4.0,8.0,Cash,In-store,2023-12-11
+TXN_9728789,Cookie,3,1.0,3.0,Cash,In-store,2023-03-29
+TXN_8061866,Salad,4,5.0,20.0,Cash,Takeaway,2023-12-13
+TXN_8961034,Juice,2,3.0,6.0,,,2023-01-21
+TXN_1099119,Smoothie,4,4.0,16.0,Cash,,2023-02-09
+TXN_2421387,Cookie,4,1.0,4.0,,,2023-04-09
+TXN_8627017,Tea,4,1.5,6.0,Cash,In-store,2023-01-28
+TXN_7468084,Coffee,5,2.0,10.0,Credit Card,,2023-06-14
+TXN_1185069,Salad,1,5.0,5.0,Digital Wallet,UNKNOWN,2023-02-21
+TXN_5100941,Cookie,5,1.0,ERROR,Digital Wallet,,2023-07-11
+TXN_6428745,Cake,1,3.0,3.0,,Takeaway,2023-06-02
+TXN_4096757,Salad,5,5.0,25.0,Credit Card,In-store,2023-07-20
+TXN_6057914,Smoothie,2,4.0,8.0,Digital Wallet,ERROR,2023-03-18
+TXN_2517078,Sandwich,2,4.0,8.0,,In-store,2023-03-07
+TXN_2890321,Tea,3,1.5,4.5,Cash,In-store,2023-06-13
+TXN_4808812,Smoothie,4,4.0,16.0,UNKNOWN,,2023-05-31
+TXN_1866707,Smoothie,3,4.0,12.0,Cash,,2023-06-05
+TXN_9745609,Salad,3,5.0,15.0,,,2023-02-05
+TXN_8488298,Cake,3,3.0,9.0,Cash,,2023-11-03
+TXN_2515796,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-02-06
+TXN_2369294,Sandwich,2,4.0,8.0,Cash,Takeaway,2023-09-07
+TXN_9444736,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-04-23
+TXN_4764398,Sandwich,2,4.0,8.0,Credit Card,,2023-06-13
+TXN_8696392,Juice,,3.0,3.0,,,2023-04-16
+TXN_1993675,Cookie,3,1.0,3.0,Cash,Takeaway,2023-01-09
+TXN_7754136,Cookie,1,1.0,1.0,Credit Card,In-store,2023-07-12
+TXN_4873173,Coffee,5,2.0,10.0,Cash,Takeaway,2023-10-08
+TXN_7221126,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-10-11
+TXN_4537288,Cookie,1,1.0,1.0,Cash,,2023-02-25
+TXN_5492760,Cake,2,3.0,6.0,,Takeaway,ERROR
+TXN_5079166,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-04-15
+TXN_4597600,Cookie,5,1.0,,,Takeaway,2023-11-15
+TXN_6568440,Cookie,1,1.0,1.0,,Takeaway,2023-06-15
+TXN_1713639,Cookie,1,1.0,1.0,,,2023-08-04
+TXN_4780352,Salad,,5.0,5.0,Digital Wallet,Takeaway,2023-01-12
+TXN_6419344,Juice,1,3.0,3.0,Cash,In-store,2023-05-26
+TXN_3669068,Cake,5,3.0,15.0,Cash,Takeaway,2023-01-17
+TXN_2201248,Tea,1,UNKNOWN,1.5,Cash,Takeaway,2023-07-20
+TXN_4432252,Smoothie,5,4.0,20.0,Credit Card,,2023-02-16
+TXN_6595038,Cookie,2,ERROR,2.0,,,2023-02-08
+TXN_2940895,Cake,4,3.0,12.0,,UNKNOWN,2023-02-20
+TXN_9796122,Salad,3,5.0,15.0,,,UNKNOWN
+TXN_4069354,Salad,1,5.0,5.0,UNKNOWN,,2023-08-18
+TXN_9737509,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-11-27
+TXN_8749404,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-12-16
+TXN_2069068,Cake,5,3.0,15.0,,In-store,2023-06-15
+TXN_7010812,ERROR,2,5.0,10.0,Digital Wallet,In-store,2023-11-13
+TXN_6411385,Salad,4,5.0,20.0,Cash,Takeaway,2023-06-06
+TXN_4375698,Sandwich,ERROR,4.0,20.0,Credit Card,In-store,2023-12-30
+TXN_4768744,Tea,5,1.5,7.5,Cash,In-store,2023-05-14
+TXN_5260646,Tea,4,1.5,6.0,Cash,Takeaway,2023-11-18
+TXN_2393219,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-12-27
+TXN_4544172,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-05-20
+TXN_1180623,Sandwich,5,4.0,20.0,,In-store,2023-09-23
+TXN_8275137,Salad,4,5.0,20.0,Cash,ERROR,2023-11-16
+TXN_3758861,Smoothie,3,4.0,12.0,Credit Card,ERROR,2023-07-03
+TXN_6279736,Salad,1,5.0,5.0,,,2023-08-25
+TXN_8661276,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-01-07
+TXN_5974796,Sandwich,4,4.0,16.0,Cash,In-store,2023-11-09
+TXN_9880967,Cookie,ERROR,1.0,3.0,Credit Card,In-store,2023-01-15
+TXN_5452978,Salad,2,5.0,10.0,Cash,In-store,2023-04-10
+TXN_7231153,UNKNOWN,1,5.0,5.0,Cash,In-store,2023-06-15
+TXN_6455517,Cake,2,3.0,6.0,Cash,,2023-08-04
+TXN_4038488,ERROR,3,3.0,9.0,Credit Card,,2023-12-05
+TXN_3933290,Coffee,1,2.0,2.0,,,2023-08-05
+TXN_9655661,Juice,1,3.0,3.0,Digital Wallet,,2023-06-07
+TXN_7932830,UNKNOWN,2,3.0,6.0,,Takeaway,2023-01-08
+TXN_1931190,Cookie,3,1.0,3.0,UNKNOWN,Takeaway,2023-12-31
+TXN_8633758,,1,5.0,5.0,Credit Card,Takeaway,2023-09-24
+TXN_4887189,Smoothie,3,4.0,12.0,Cash,Takeaway,2023-07-19
+TXN_7687146,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-12-02
+TXN_9728414,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-01-11
+TXN_3081950,Cookie,1,1.0,1.0,Digital Wallet,ERROR,2023-05-01
+TXN_7589318,Cake,4,3.0,12.0,Cash,In-store,2023-09-21
+TXN_9452972,Sandwich,3,4.0,12.0,Digital Wallet,,2023-02-10
+TXN_9299563,Juice,5,3.0,15.0,Credit Card,,2023-03-27
+TXN_2273499,,3,2.0,ERROR,Cash,Takeaway,2023-01-27
+TXN_3374343,Cake,2,3.0,6.0,,,2023-09-02
+TXN_8732269,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-01-11
+TXN_6763296,Coffee,5,UNKNOWN,10.0,Cash,,2023-10-04
+TXN_3758250,Salad,3,5.0,15.0,Cash,In-store,2023-09-08
+TXN_7764304,Cake,ERROR,ERROR,3.0,Credit Card,Takeaway,2023-01-09
+TXN_8697749,Cookie,3,1.0,3.0,,Takeaway,2023-07-24
+TXN_6904247,,3,4.0,12.0,Credit Card,,2023-09-19
+TXN_6027798,Cookie,2,1.0,2.0,Digital Wallet,,2023-05-26
+TXN_4482692,Salad,2,5.0,10.0,ERROR,,2023-04-14
+TXN_8196921,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-05-19
+TXN_9289408,Coffee,4,2.0,8.0,Digital Wallet,,2023-09-23
+TXN_3771902,Juice,5,ERROR,15.0,Cash,Takeaway,2023-03-31
+TXN_8506937,Salad,1,5.0,,,In-store,2023-09-07
+TXN_6706566,UNKNOWN,3,1.0,3.0,Cash,,2023-09-01
+TXN_6217375,Smoothie,5,4.0,20.0,Cash,UNKNOWN,2023-12-07
+TXN_3779320,Tea,4,1.5,6.0,Credit Card,In-store,2023-03-27
+TXN_2894525,Juice,3,UNKNOWN,9.0,ERROR,Takeaway,2023-04-16
+TXN_9789876,Salad,4,5.0,20.0,Cash,Takeaway,2023-09-05
+TXN_9129403,Sandwich,3,4.0,12.0,Credit Card,,2023-12-05
+TXN_2944325,Sandwich,4,4.0,16.0,Cash,,2023-12-18
+TXN_5591155,Smoothie,4,4.0,16.0,,Takeaway,2023-05-14
+TXN_6532832,Cookie,5,1.0,ERROR,Cash,In-store,2023-06-23
+TXN_5992166,Juice,5,3.0,15.0,Cash,Takeaway,2023-10-01
+TXN_6895165,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-02-18
+TXN_3410147,Juice,ERROR,3.0,3.0,,,2023-09-30
+TXN_6269306,Smoothie,5,4.0,20.0,Credit Card,,2023-08-29
+TXN_2132747,Sandwich,2,4.0,8.0,,In-store,2023-12-19
+TXN_6241505,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-11-20
+TXN_7965585,Smoothie,5,4.0,20.0,,Takeaway,2023-01-30
+TXN_1950063,Salad,2,5.0,10.0,Cash,,2023-02-24
+TXN_4682737,Coffee,2,2.0,4.0,Cash,Takeaway,2023-02-03
+TXN_4376376,UNKNOWN,3,5.0,15.0,Digital Wallet,ERROR,2023-09-05
+TXN_9061471,Cake,1,3.0,3.0,Digital Wallet,Takeaway,2023-07-13
+TXN_8932070,ERROR,3,4.0,12.0,Digital Wallet,In-store,2023-12-03
+TXN_8410979,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-05-02
+TXN_3710523,Sandwich,3,4.0,12.0,Digital Wallet,,2023-10-03
+TXN_8014289,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-12-04
+TXN_1888294,Juice,3,3.0,9.0,Cash,,2023-07-03
+TXN_8628615,,1,2.0,2.0,Credit Card,Takeaway,2023-08-03
+TXN_2648236,Smoothie,2,4.0,8.0,Credit Card,In-store,2023-09-10
+TXN_1837817,Tea,2,1.5,3.0,Cash,ERROR,2023-08-13
+TXN_8467229,ERROR,3,1.5,4.5,,Takeaway,2023-02-02
+TXN_4197575,Salad,2,5.0,10.0,Credit Card,,2023-01-21
+TXN_5863650,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-08-09
+TXN_7371295,UNKNOWN,3,3.0,9.0,,,2023-03-28
+TXN_1292476,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-09-07
+TXN_4872708,Coffee,5,2.0,10.0,Cash,,2023-11-16
+TXN_1299936,Coffee,1,2.0,2.0,,Takeaway,2023-03-27
+TXN_2199236,Smoothie,5,4.0,20.0,,Takeaway,2023-10-06
+TXN_1311237,Cookie,4,1.0,4.0,Credit Card,,2023-11-11
+TXN_9265423,Juice,1,,3.0,,,2023-10-20
+TXN_5808749,Salad,1,5.0,5.0,Cash,Takeaway,2023-01-25
+TXN_7677646,Sandwich,5,4.0,20.0,,,2023-02-15
+TXN_3894165,Smoothie,5,4.0,20.0,Credit Card,,2023-03-31
+TXN_5270067,Cake,3,3.0,9.0,Digital Wallet,UNKNOWN,2023-03-09
+TXN_9326761,Tea,1,1.5,1.5,,,2023-01-02
+TXN_2168513,Cake,1,3.0,3.0,Digital Wallet,In-store,2023-02-09
+TXN_3947116,Sandwich,1,4.0,4.0,,Takeaway,2023-01-13
+TXN_7248722,Cake,3,3.0,9.0,Cash,Takeaway,2023-04-06
+TXN_9989458,Smoothie,3,4.0,12.0,Cash,,2023-02-16
+TXN_1850339,Cookie,5,1.0,5.0,Cash,Takeaway,2023-01-17
+TXN_9934619,Cookie,1,1.0,1.0,,In-store,2023-02-11
+TXN_4551353,Tea,5,1.5,7.5,Digital Wallet,In-store,2023-08-17
+TXN_6657245,Sandwich,1,4.0,4.0,,In-store,2023-10-25
+TXN_1786141,Smoothie,4,4.0,16.0,ERROR,,2023-03-12
+TXN_6405088,Juice,1,3.0,3.0,,In-store,2023-07-24
+TXN_1185003,ERROR,5,3.0,15.0,Cash,Takeaway,2023-01-06
+TXN_4550558,Cookie,,1.0,,Credit Card,In-store,2023-08-04
+TXN_9555291,ERROR,3,4.0,12.0,Credit Card,,2023-09-21
+TXN_8571432,Juice,2,3.0,6.0,Cash,,2023-12-07
+TXN_6744096,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-11-15
+TXN_8512204,UNKNOWN,4,4.0,16.0,Cash,Takeaway,2023-06-01
+TXN_3485502,Juice,2,3.0,6.0,,,2023-12-25
+TXN_5188843,Smoothie,2,4.0,8.0,Cash,In-store,2023-02-06
+TXN_4821343,Cookie,1,1.0,1.0,Credit Card,In-store,2023-09-16
+TXN_4988100,Coffee,1,2.0,2.0,Digital Wallet,In-store,ERROR
+TXN_7791428,Smoothie,5,,20.0,Digital Wallet,Takeaway,2023-10-10
+TXN_8725610,Sandwich,2,4.0,8.0,,Takeaway,2023-02-11
+TXN_8404563,Tea,1,1.5,1.5,Cash,In-store,2023-01-22
+TXN_8942133,Salad,3,5.0,15.0,Cash,Takeaway,2023-10-04
+TXN_1122699,UNKNOWN,5,5.0,25.0,Digital Wallet,In-store,2023-10-14
+TXN_9230208,Juice,3,3.0,9.0,Credit Card,,2023-05-13
+TXN_4932916,UNKNOWN,1,2.0,2.0,,Takeaway,2023-12-13
+TXN_8980468,Smoothie,5,4.0,20.0,Cash,,2023-08-24
+TXN_4175635,Salad,3,5.0,15.0,UNKNOWN,Takeaway,2023-05-26
+TXN_2851446,Salad,2,,10.0,Credit Card,Takeaway,2023-10-08
+TXN_8359693,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-10-23
+TXN_9432268,Salad,UNKNOWN,5.0,20.0,,Takeaway,2023-01-25
+TXN_2244902,Coffee,5,2.0,10.0,Credit Card,,2023-02-13
+TXN_5561958,Smoothie,4,4.0,16.0,Digital Wallet,,2023-07-24
+TXN_6963106,Sandwich,1,4.0,4.0,Cash,In-store,2023-06-01
+TXN_6008133,Coffee,3,2.0,6.0,Digital Wallet,UNKNOWN,2023-11-08
+TXN_9119194,Cake,UNKNOWN,3.0,9.0,Cash,Takeaway,2023-01-29
+TXN_2551074,Cookie,1,1.0,1.0,Cash,,2023-09-17
+TXN_1899827,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-06-24
+TXN_3046572,Salad,4,5.0,20.0,Cash,ERROR,2023-05-16
+TXN_6397921,,1,4.0,4.0,,In-store,2023-12-01
+TXN_8701063,Sandwich,2,4.0,8.0,,,2023-08-23
+TXN_9157625,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-02-10
+TXN_7865037,Coffee,1,2.0,2.0,Digital Wallet,,2023-06-05
+TXN_8410376,Coffee,4,2.0,8.0,Digital Wallet,,2023-07-02
+TXN_4192665,Coffee,1,2.0,2.0,Cash,,2023-07-15
+TXN_5433077,Cake,4,3.0,12.0,Cash,In-store,2023-11-29
+TXN_1844925,Tea,5,1.5,7.5,Cash,,2023-10-21
+TXN_7215311,Tea,1,1.5,1.5,,,2023-07-31
+TXN_8003664,Sandwich,1,4.0,4.0,Credit Card,UNKNOWN,2023-11-26
+TXN_3872616,Cake,2,3.0,6.0,,Takeaway,2023-10-23
+TXN_3659483,Smoothie,3,4.0,,Cash,,2023-05-14
+TXN_1688499,Smoothie,2,4.0,8.0,Credit Card,,2023-03-23
+TXN_5632556,Juice,4,3.0,ERROR,Digital Wallet,In-store,2023-05-16
+TXN_7954416,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-06-04
+TXN_7845656,Juice,3,3.0,9.0,Credit Card,Takeaway,UNKNOWN
+TXN_7421687,Coffee,5,2.0,10.0,Credit Card,In-store,2023-11-18
+TXN_2444134,,2,4.0,8.0,Credit Card,In-store,2023-01-16
+TXN_3793672,Cookie,5,1.0,5.0,Credit Card,,2023-01-14
+TXN_1903825,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-04-01
+TXN_4267136,Tea,1,1.5,1.5,Credit Card,In-store,2023-08-02
+TXN_6281616,Coffee,4,2.0,8.0,,,2023-08-19
+TXN_6567287,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,
+TXN_3743107,Coffee,4,2.0,8.0,Cash,,2023-01-14
+TXN_6739664,Salad,3,5.0,15.0,Cash,,2023-09-12
+TXN_8343149,Juice,UNKNOWN,3.0,15.0,Digital Wallet,In-store,2023-10-28
+TXN_2376870,ERROR,5,4.0,20.0,Digital Wallet,,
+TXN_2025634,UNKNOWN,1,4.0,4.0,,,UNKNOWN
+TXN_7187140,Juice,2,3.0,6.0,Credit Card,In-store,2023-05-25
+TXN_6988675,Coffee,1,2.0,2.0,,In-store,2023-02-24
+TXN_1108326,Cake,2,3.0,ERROR,,Takeaway,ERROR
+TXN_6544160,Salad,UNKNOWN,5.0,5.0,UNKNOWN,ERROR,2023-02-05
+TXN_3053494,,5,3.0,15.0,Digital Wallet,In-store,2023-06-11
+TXN_9653700,ERROR,1,3.0,3.0,Credit Card,,2023-03-12
+TXN_4623303,Smoothie,3,4.0,12.0,,In-store,2023-01-29
+TXN_7568175,Salad,1,5.0,5.0,Cash,In-store,2023-11-06
+TXN_4968258,Smoothie,2,4.0,8.0,,Takeaway,2023-05-14
+TXN_8843061,Smoothie,1,4.0,4.0,Cash,Takeaway,2023-11-10
+TXN_5666241,Cookie,ERROR,1.0,4.0,,Takeaway,2023-07-18
+TXN_7079566,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-10-20
+TXN_3937788,Smoothie,1,4.0,4.0,Cash,In-store,2023-06-27
+TXN_3397034,Cake,4,3.0,12.0,,ERROR,2023-04-11
+TXN_8343414,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-02-28
+TXN_4204491,Smoothie,2,4.0,8.0,Digital Wallet,,2023-04-25
+TXN_4801327,Cake,5,3.0,15.0,Cash,In-store,2023-02-03
+TXN_4276482,Sandwich,4,4.0,16.0,,Takeaway,2023-08-26
+TXN_6025054,Coffee,1,2.0,2.0,Credit Card,Takeaway,2023-03-10
+TXN_1485725,Salad,5,5.0,25.0,,In-store,2023-12-10
+TXN_9929033,Coffee,2,2.0,4.0,Cash,Takeaway,2023-02-17
+TXN_1888706,Cookie,1,1.0,1.0,,Takeaway,2023-11-26
+TXN_7495804,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-11-24
+TXN_5133476,Juice,4,3.0,12.0,ERROR,,2023-03-17
+TXN_5542500,Sandwich,3,UNKNOWN,12.0,Credit Card,,2023-07-19
+TXN_5895330,Salad,5,5.0,25.0,,In-store,2023-05-12
+TXN_5351447,Salad,4,5.0,20.0,,,2023-07-20
+TXN_8505782,Cookie,2,1.0,2.0,,In-store,2023-11-24
+TXN_8365530,,4,UNKNOWN,16.0,,Takeaway,2023-03-10
+TXN_2357107,Sandwich,1,4.0,4.0,,In-store,2023-07-05
+TXN_1371708,Cookie,2,1.0,2.0,,Takeaway,2023-03-14
+TXN_6265785,ERROR,5,5.0,25.0,Credit Card,Takeaway,2023-08-26
+TXN_6806563,Coffee,1,2.0,2.0,,,2023-04-16
+TXN_8183734,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-08-25
+TXN_6882503,Tea,1,1.5,1.5,,In-store,2023-01-02
+TXN_2785654,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-02-21
+TXN_1453579,Sandwich,5,4.0,20.0,,,2023-01-21
+TXN_1121833,Coffee,4,2.0,8.0,Credit Card,In-store,2023-03-16
+TXN_1277989,UNKNOWN,5,1.5,7.5,,In-store,2023-08-09
+TXN_8249996,UNKNOWN,UNKNOWN,1.0,4.0,Digital Wallet,,2023-09-19
+TXN_7471281,Sandwich,5,4.0,20.0,,,2023-06-16
+TXN_1512159,Cake,2,3.0,6.0,Credit Card,In-store,2023-11-25
+TXN_4008899,Salad,4,5.0,20.0,,,2023-05-07
+TXN_4566950,Coffee,2,2.0,4.0,Cash,Takeaway,2023-09-29
+TXN_6648081,Salad,4,5.0,20.0,,Takeaway,2023-04-24
+TXN_5094936,Coffee,4,2.0,8.0,,In-store,2023-07-12
+TXN_8154928,Tea,3,1.5,ERROR,Credit Card,,2023-07-26
+TXN_6550707,Coffee,1,2.0,,Digital Wallet,,2023-03-01
+TXN_3676019,Juice,4,3.0,12.0,Digital Wallet,,2023-11-07
+TXN_2486026,Tea,5,ERROR,7.5,Digital Wallet,In-store,2023-03-26
+TXN_9644830,Cookie,1,1.0,1.0,,,2023-11-24
+TXN_3219378,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-12-04
+TXN_6372515,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-11-22
+TXN_4692681,Tea,2,1.5,3.0,,,2023-06-02
+TXN_9364172,Tea,4,1.5,6.0,,Takeaway,2023-03-18
+TXN_4745933,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-11-05
+TXN_6540267,Salad,2,5.0,10.0,,Takeaway,2023-09-26
+TXN_6994245,Coffee,4,2.0,8.0,Digital Wallet,In-store,2023-12-30
+TXN_8973007,Coffee,5,2.0,10.0,,Takeaway,2023-02-07
+TXN_5108183,Smoothie,,4.0,16.0,Credit Card,ERROR,2023-08-31
+TXN_8103630,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-03-08
+TXN_2575160,Tea,5,1.5,7.5,,UNKNOWN,2023-01-02
+TXN_8002309,Sandwich,1,4.0,4.0,,,2023-04-04
+TXN_3252542,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-09-22
+TXN_4775220,Juice,3,3.0,9.0,,Takeaway,2023-07-21
+TXN_4413197,Tea,4,1.5,6.0,Digital Wallet,,2023-09-06
+TXN_1283149,Salad,2,5.0,10.0,Credit Card,In-store,2023-01-23
+TXN_6822426,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-05-27
+TXN_8210816,Salad,4,5.0,20.0,Digital Wallet,Takeaway,2023-08-12
+TXN_5896728,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-10-06
+TXN_4407308,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-09-19
+TXN_7710078,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-12-05
+TXN_5206046,Sandwich,3,4.0,12.0,,In-store,UNKNOWN
+TXN_6016707,Juice,1,3.0,3.0,Cash,In-store,2023-06-27
+TXN_7895436,Cake,3,3.0,9.0,,,2023-09-09
+TXN_3600632,UNKNOWN,4,2.0,8.0,Cash,Takeaway,2023-12-09
+TXN_4565969,Coffee,3,2.0,6.0,,Takeaway,2023-03-16
+TXN_7821478,Cake,4,,12.0,Cash,In-store,2023-05-24
+TXN_2971555,Cake,1,3.0,3.0,Cash,,2023-02-24
+TXN_1465364,Tea,4,1.5,6.0,Digital Wallet,In-store,ERROR
+TXN_9664173,Sandwich,1,4.0,4.0,,In-store,2023-03-20
+TXN_4049270,,5,2.0,10.0,Digital Wallet,In-store,2023-07-28
+TXN_4731715,Coffee,5,2.0,10.0,,,2023-03-14
+TXN_3377626,Cookie,5,1.0,5.0,Cash,In-store,2023-07-23
+TXN_5753111,Salad,1,5.0,5.0,Credit Card,,2023-04-25
+TXN_2054549,Smoothie,UNKNOWN,4.0,4.0,UNKNOWN,In-store,2023-04-07
+TXN_6996548,Coffee,UNKNOWN,2.0,2.0,Credit Card,,2023-06-24
+TXN_6761402,ERROR,1,2.0,2.0,,Takeaway,2023-08-31
+TXN_1983842,Cake,5,3.0,15.0,Digital Wallet,ERROR,2023-03-16
+TXN_4982165,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-04-12
+TXN_5679295,Tea,5,ERROR,7.5,,Takeaway,2023-04-30
+TXN_9194266,Salad,5,5.0,25.0,Cash,,2023-10-30
+TXN_1141920,Coffee,4,2.0,8.0,Digital Wallet,,2023-10-26
+TXN_8878500,Salad,4,5.0,20.0,,,2023-02-24
+TXN_1012349,UNKNOWN,4,3.0,12.0,Cash,In-store,2023-07-08
+TXN_3811655,Smoothie,2,4.0,ERROR,,,UNKNOWN
+TXN_1581562,Coffee,2,2.0,4.0,Cash,In-store,2023-01-01
+TXN_6762236,Juice,4,3.0,12.0,UNKNOWN,In-store,2023-01-17
+TXN_1041891,Cookie,5,1.0,5.0,,,2023-08-09
+TXN_6467796,,5,2.0,10.0,Credit Card,Takeaway,2023-10-25
+TXN_8701045,UNKNOWN,2,3.0,6.0,Cash,In-store,2023-06-07
+TXN_9656325,ERROR,2,2.0,4.0,Credit Card,Takeaway,2023-03-31
+TXN_2716560,Sandwich,4,4.0,16.0,Credit Card,Takeaway,2023-08-29
+TXN_4141941,Coffee,2,2.0,4.0,Digital Wallet,In-store,2023-05-18
+TXN_4633505,,3,1.5,4.5,Digital Wallet,Takeaway,2023-08-25
+TXN_5283053,Juice,4,3.0,12.0,Digital Wallet,,2023-04-30
+TXN_1054912,Sandwich,3,4.0,12.0,Cash,,2023-08-02
+TXN_9100081,Juice,1,3.0,3.0,Cash,,2023-08-18
+TXN_5129701,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-11-09
+TXN_7021592,Salad,4,5.0,20.0,Credit Card,In-store,2023-07-01
+TXN_8644119,Sandwich,ERROR,4.0,20.0,,,2023-10-01
+TXN_3041142,Smoothie,3,4.0,12.0,Digital Wallet,ERROR,2023-12-22
+TXN_5618631,Coffee,5,2.0,10.0,Credit Card,In-store,2023-12-21
+TXN_6496379,Sandwich,1,4.0,4.0,Cash,Takeaway,2023-12-24
+TXN_1486119,Cookie,4,1.0,4.0,,UNKNOWN,2023-08-24
+TXN_2386202,Salad,4,5.0,20.0,Cash,In-store,2023-01-22
+TXN_6836109,Coffee,4,2.0,8.0,,Takeaway,2023-04-09
+TXN_9190061,Salad,5,5.0,25.0,Cash,Takeaway,2023-06-14
+TXN_1691512,Smoothie,1,4.0,4.0,,UNKNOWN,2023-03-25
+TXN_1059293,UNKNOWN,5,4.0,20.0,UNKNOWN,,2023-12-04
+TXN_8813052,Tea,4,1.5,6.0,,In-store,UNKNOWN
+TXN_2495471,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-10-22
+TXN_7708201,Salad,3,5.0,15.0,Cash,,2023-01-04
+TXN_2038871,Tea,2,1.5,3.0,,Takeaway,2023-07-15
+TXN_7195393,Salad,2,5.0,10.0,Credit Card,In-store,2023-01-24
+TXN_8022892,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-08-07
+TXN_4298189,Coffee,1,2.0,2.0,Digital Wallet,In-store,2023-10-13
+TXN_4967446,Sandwich,1,4.0,4.0,ERROR,In-store,2023-07-11
+TXN_3368231,Tea,3,1.5,4.5,,,2023-08-11
+TXN_7353699,Tea,5,1.5,7.5,Digital Wallet,,2023-07-20
+TXN_6888998,Coffee,5,2.0,10.0,,,2023-02-27
+TXN_3541304,Sandwich,3,4.0,12.0,Cash,In-store,2023-04-22
+TXN_8188818,Tea,2,1.5,3.0,ERROR,,2023-10-07
+TXN_9431971,Smoothie,1,4.0,4.0,Credit Card,ERROR,2023-07-17
+TXN_4543742,Coffee,3,2.0,6.0,Digital Wallet,,2023-03-28
+TXN_5961027,Cake,2,3.0,6.0,Cash,In-store,
+TXN_1807140,Salad,ERROR,5.0,5.0,Cash,,2023-03-22
+TXN_3007866,Juice,4,3.0,12.0,Credit Card,In-store,2023-04-14
+TXN_6779377,Smoothie,5,4.0,20.0,,In-store,2023-10-06
+TXN_7053830,Coffee,3,2.0,6.0,Digital Wallet,,2023-02-14
+TXN_3660048,Cake,1,,3.0,Credit Card,ERROR,
+TXN_6522299,Tea,2,1.5,3.0,Cash,ERROR,2023-08-29
+TXN_5811766,Cake,5,UNKNOWN,15.0,Digital Wallet,In-store,UNKNOWN
+TXN_2848421,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-08-07
+TXN_4935533,UNKNOWN,1,4.0,4.0,,In-store,2023-06-12
+TXN_2389320,Coffee,2,2.0,4.0,,Takeaway,2023-07-26
+TXN_8423155,Coffee,1,2.0,2.0,,Takeaway,2023-07-03
+TXN_6053617,Sandwich,2,4.0,8.0,Credit Card,,2023-11-25
+TXN_8384372,Tea,4,1.5,6.0,Digital Wallet,,2023-08-07
+TXN_3426338,Salad,1,5.0,5.0,Cash,In-store,2023-07-31
+TXN_4581359,Juice,2,3.0,6.0,Credit Card,,2023-03-22
+TXN_3561451,Salad,4,5.0,20.0,Credit Card,,2023-05-31
+TXN_7768989,Sandwich,2,4.0,ERROR,Cash,In-store,2023-10-02
+TXN_5963316,Tea,2,1.5,,Credit Card,Takeaway,2023-06-25
+TXN_4265942,Coffee,5,2.0,10.0,,UNKNOWN,2023-04-24
+TXN_6014389,Cookie,5,1.0,5.0,Credit Card,In-store,2023-07-21
+TXN_7358729,Cookie,2,1.0,2.0,Cash,Takeaway,2023-02-25
+TXN_9815521,Sandwich,3,4.0,12.0,Credit Card,In-store,2023-05-26
+TXN_8325221,,2,2.0,4.0,Credit Card,ERROR,2023-11-17
+TXN_8267031,Cake,,3.0,6.0,,Takeaway,2023-03-28
+TXN_1950187,Tea,2,1.5,3.0,Credit Card,Takeaway,2023-04-13
+TXN_9518691,Salad,2,5.0,10.0,Credit Card,ERROR,2023-03-30
+TXN_3612790,Smoothie,1,,4.0,,,2023-09-01
+TXN_5436816,Salad,3,5.0,15.0,Credit Card,,2023-08-04
+TXN_7896586,Sandwich,2,4.0,8.0,Credit Card,,2023-09-04
+TXN_5835004,Smoothie,5,4.0,20.0,Credit Card,In-store,2023-04-14
+TXN_3774886,Sandwich,3,4.0,12.0,,,2023-06-01
+TXN_5950951,Salad,1,5.0,,Credit Card,In-store,2023-04-10
+TXN_3918096,Juice,4,3.0,12.0,,UNKNOWN,2023-08-17
+TXN_2786231,Juice,1,3.0,3.0,Cash,Takeaway,2023-08-17
+TXN_3803063,,4,ERROR,12.0,Credit Card,Takeaway,2023-11-23
+TXN_4262451,Coffee,1,2.0,2.0,Digital Wallet,Takeaway,2023-10-16
+TXN_4773210,Coffee,1,2.0,2.0,Credit Card,,2023-11-29
+TXN_1231366,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-11-28
+TXN_6596377,Cookie,5,ERROR,5.0,,,2023-08-02
+TXN_2713279,Cookie,4,1.0,4.0,Digital Wallet,In-store,2023-02-12
+TXN_4247602,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-07-13
+TXN_2446298,Juice,ERROR,3.0,15.0,,In-store,2023-05-21
+TXN_7258784,,4,2.0,8.0,Cash,In-store,2023-09-21
+TXN_5164540,Tea,2,1.5,3.0,,Takeaway,2023-01-05
+TXN_6488040,Salad,1,5.0,ERROR,Digital Wallet,Takeaway,2023-05-20
+TXN_9850842,Tea,3,ERROR,4.5,ERROR,,2023-01-23
+TXN_7269738,Cookie,3,1.0,3.0,Cash,,2023-05-26
+TXN_2638760,Cake,5,3.0,15.0,Cash,,2023-02-09
+TXN_3459152,Cake,ERROR,3.0,9.0,Digital Wallet,,2023-06-28
+TXN_8013818,Tea,2,1.5,3.0,,UNKNOWN,2023-07-24
+TXN_8077367,Tea,,UNKNOWN,7.5,Credit Card,,2023-02-27
+TXN_6643922,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-06-24
+TXN_8388056,Salad,1,5.0,5.0,Credit Card,,2023-06-23
+TXN_4728936,Juice,4,3.0,12.0,Digital Wallet,Takeaway,2023-02-27
+TXN_6386388,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-05-21
+TXN_9443285,Cake,2,3.0,6.0,Credit Card,,2023-05-27
+TXN_6377838,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-02-19
+TXN_7483986,Salad,2,5.0,10.0,,Takeaway,2023-03-24
+TXN_7719510,Juice,3,3.0,9.0,Credit Card,Takeaway,2023-08-14
+TXN_7908153,Cookie,3,1.0,3.0,Cash,In-store,2023-01-19
+TXN_3083412,Coffee,5,UNKNOWN,10.0,Credit Card,In-store,UNKNOWN
+TXN_8159649,,4,2.0,8.0,,In-store,2023-06-15
+TXN_5391160,Juice,2,3.0,6.0,Cash,In-store,2023-03-09
+TXN_8324715,Sandwich,5,4.0,20.0,Credit Card,,2023-03-21
+TXN_7353685,Sandwich,2,4.0,,,In-store,UNKNOWN
+TXN_1985223,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-09-21
+TXN_2944460,Salad,1,5.0,5.0,Digital Wallet,In-store,2023-04-16
+TXN_6957157,Cake,1,3.0,3.0,,,2023-02-01
+TXN_5693294,,3,3.0,9.0,Credit Card,,2023-12-30
+TXN_2887257,Cookie,3,1.0,3.0,Credit Card,In-store,2023-08-27
+TXN_3986876,Cake,3,3.0,9.0,Cash,Takeaway,2023-11-06
+TXN_1066604,Sandwich,5,4.0,20.0,Credit Card,,2023-05-18
+TXN_2494494,Coffee,1,2.0,2.0,Cash,,2023-06-13
+TXN_4464373,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-04-22
+TXN_7844770,Cake,2,3.0,6.0,Digital Wallet,,2023-01-31
+TXN_9968943,Smoothie,1,4.0,4.0,Digital Wallet,ERROR,2023-07-25
+TXN_4051488,Cookie,4,1.0,4.0,,Takeaway,2023-06-09
+TXN_2668838,Cake,4,3.0,12.0,,Takeaway,2023-05-11
+TXN_8039752,,2,2.0,4.0,,Takeaway,2023-11-28
+TXN_3388908,Cookie,4,ERROR,4.0,,Takeaway,2023-11-22
+TXN_2096487,ERROR,5,4.0,20.0,Digital Wallet,Takeaway,2023-08-09
+TXN_8795794,Sandwich,3,4.0,12.0,Cash,In-store,2023-02-13
+TXN_4627457,Cake,3,3.0,9.0,,In-store,2023-12-13
+TXN_2352308,Cookie,2,1.0,2.0,Cash,,2023-11-10
+TXN_3980743,Salad,1,5.0,5.0,,Takeaway,2023-09-21
+TXN_6538210,Smoothie,1,4.0,4.0,,In-store,2023-12-29
+TXN_3749051,,ERROR,4.0,12.0,,Takeaway,2023-04-19
+TXN_6683798,Cookie,1,1.0,ERROR,Digital Wallet,Takeaway,2023-07-26
+TXN_7246683,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-05-17
+TXN_6755348,,5,4.0,20.0,,,2023-06-23
+TXN_3691228,Cake,3,3.0,9.0,Cash,Takeaway,2023-10-26
+TXN_7407946,Salad,3,5.0,15.0,Credit Card,,2023-03-26
+TXN_8635803,Tea,2,1.5,3.0,Cash,,2023-03-17
+TXN_9550508,Smoothie,5,ERROR,20.0,,,2023-11-18
+TXN_8010562,Sandwich,1,4.0,4.0,Cash,,2023-07-23
+TXN_2501648,Cake,2,3.0,6.0,Credit Card,UNKNOWN,2023-12-05
+TXN_9455679,Salad,5,5.0,25.0,,Takeaway,2023-05-18
+TXN_8105705,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-10-17
+TXN_9676096,Cake,3,3.0,9.0,Digital Wallet,,2023-04-05
+TXN_8476828,,3,1.5,4.5,ERROR,Takeaway,2023-10-25
+TXN_2126034,Coffee,4,,8.0,Cash,In-store,2023-10-30
+TXN_2151258,Cake,3,3.0,9.0,Credit Card,UNKNOWN,2023-08-09
+TXN_3672345,Tea,3,1.5,4.5,Credit Card,,2023-10-17
+TXN_6793298,Tea,2,1.5,3.0,Credit Card,,2023-04-14
+TXN_3951329,Sandwich,ERROR,4.0,4.0,Credit Card,Takeaway,2023-12-28
+TXN_7480853,Smoothie,2,ERROR,8.0,Digital Wallet,In-store,2023-10-07
+TXN_4944024,Smoothie,2,4.0,8.0,,Takeaway,2023-09-26
+TXN_6687528,Juice,2,3.0,6.0,,,2023-05-06
+TXN_5531648,Coffee,5,2.0,10.0,Cash,Takeaway,2023-01-23
+TXN_8789736,Coffee,2,2.0,4.0,Credit Card,,2023-05-06
+TXN_9938977,Cake,5,3.0,15.0,Cash,In-store,2023-12-18
+TXN_2730798,Tea,4,1.5,6.0,Credit Card,,2023-12-01
+TXN_3749801,Cake,5,3.0,UNKNOWN,Credit Card,Takeaway,2023-01-03
+TXN_3326626,Cake,2,3.0,6.0,Cash,Takeaway,2023-09-26
+TXN_4843989,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-09-30
+TXN_6606514,Juice,1,3.0,3.0,Credit Card,In-store,2023-06-25
+TXN_6187752,Smoothie,5,4.0,20.0,,Takeaway,2023-12-24
+TXN_1666190,Smoothie,4,4.0,16.0,,Takeaway,2023-07-28
+TXN_9438576,Cookie,1,1.0,1.0,Credit Card,In-store,2023-05-05
+TXN_1344947,Cake,3,3.0,9.0,,Takeaway,2023-02-16
+TXN_4978922,Cookie,4,1.0,4.0,Cash,,
+TXN_3951552,Salad,2,UNKNOWN,10.0,Cash,In-store,2023-03-25
+TXN_3916668,Juice,2,3.0,6.0,Digital Wallet,,2023-05-14
+TXN_4789941,Sandwich,3,4.0,12.0,Credit Card,,2023-04-17
+TXN_6957001,Tea,4,1.5,6.0,UNKNOWN,In-store,2023-08-08
+TXN_3536893,Salad,2,5.0,10.0,,,2023-05-16
+TXN_4519915,Smoothie,,4.0,4.0,Digital Wallet,In-store,2023-05-15
+TXN_3269434,Juice,1,3.0,3.0,Cash,,2023-02-01
+TXN_3291988,Juice,2,3.0,6.0,Credit Card,,2023-07-03
+TXN_7083611,Cake,2,3.0,6.0,,ERROR,2023-05-15
+TXN_1875220,Tea,3,1.5,4.5,Cash,In-store,2023-03-07
+TXN_1926712,Coffee,5,2.0,UNKNOWN,Credit Card,,2023-01-31
+TXN_5552114,Sandwich,2,4.0,8.0,,In-store,2023-06-13
+TXN_5672583,Juice,2,3.0,,Cash,Takeaway,2023-04-09
+TXN_3717444,Smoothie,3,4.0,12.0,ERROR,,2023-09-07
+TXN_1899114,Tea,3,1.5,4.5,Digital Wallet,Takeaway,2023-04-05
+TXN_2625388,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-02-09
+TXN_7153665,Salad,5,5.0,25.0,Cash,In-store,2023-07-31
+TXN_9161256,Smoothie,2,4.0,8.0,Digital Wallet,In-store,2023-01-01
+TXN_2010060,UNKNOWN,1,3.0,3.0,Cash,,2023-11-09
+TXN_9077843,Tea,3,1.5,4.5,,,2023-03-28
+TXN_5611262,UNKNOWN,2,5.0,10.0,Digital Wallet,In-store,2023-05-22
+TXN_3255254,Juice,4,3.0,12.0,Cash,,2023-03-23
+TXN_9275800,Smoothie,3,4.0,12.0,Cash,,2023-05-01
+TXN_2430215,ERROR,2,1.0,2.0,Digital Wallet,,2023-04-10
+TXN_1372003,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-10-13
+TXN_7364110,Coffee,5,2.0,10.0,Cash,,
+TXN_7202644,Smoothie,5,4.0,20.0,,Takeaway,2023-08-01
+TXN_5330387,Coffee,3,2.0,6.0,,,2023-10-21
+TXN_2119809,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-04-21
+TXN_5587224,Salad,2,5.0,10.0,ERROR,In-store,2023-01-05
+TXN_6332132,Juice,3,3.0,9.0,UNKNOWN,Takeaway,UNKNOWN
+TXN_2185661,Sandwich,4,4.0,,Cash,,2023-03-16
+TXN_2491186,Salad,5,5.0,25.0,,,2023-11-28
+TXN_1891217,Tea,5,1.5,7.5,,,2023-04-02
+TXN_8977555,Cake,2,3.0,ERROR,Cash,,2023-07-21
+TXN_7179922,Cake,2,3.0,6.0,,In-store,2023-09-05
+TXN_5114283,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-05-28
+TXN_1528454,Coffee,2,2.0,4.0,,In-store,2023-03-22
+TXN_5615114,Tea,4,1.5,6.0,Digital Wallet,ERROR,2023-10-31
+TXN_4968659,Tea,5,1.5,7.5,Credit Card,,2023-03-18
+TXN_4858666,Cake,3,3.0,9.0,Credit Card,,2023-03-18
+TXN_3502394,UNKNOWN,3,2.0,6.0,Credit Card,In-store,2023-09-02
+TXN_4754723,Coffee,2,2.0,4.0,Credit Card,,
+TXN_1902009,UNKNOWN,2,3.0,6.0,Credit Card,,2023-04-12
+TXN_8492074,Tea,3,1.5,4.5,Digital Wallet,In-store,2023-11-12
+TXN_6355908,Sandwich,3,4.0,12.0,Credit Card,,2023-03-28
+TXN_6856530,Smoothie,5,4.0,20.0,Digital Wallet,,2023-11-11
+TXN_1180397,Smoothie,3,4.0,12.0,Credit Card,Takeaway,2023-04-05
+TXN_4747863,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-10-04
+TXN_3979966,Smoothie,5,4.0,20.0,,Takeaway,2023-08-23
+TXN_5127984,Sandwich,3,4.0,12.0,Cash,In-store,2023-11-12
+TXN_9904214,Sandwich,5,4.0,20.0,,Takeaway,2023-03-13
+TXN_9948753,Tea,2,1.5,3.0,,Takeaway,2023-05-09
+TXN_8263172,ERROR,2,3.0,6.0,,Takeaway,2023-12-30
+TXN_1196223,Juice,3,3.0,9.0,Digital Wallet,In-store,2023-10-14
+TXN_2401073,Coffee,4,2.0,8.0,Credit Card,,2023-02-10
+TXN_9639089,Juice,4,3.0,12.0,Credit Card,In-store,2023-05-14
+TXN_8654093,Coffee,3,2.0,6.0,Digital Wallet,UNKNOWN,2023-11-29
+TXN_1038397,Cookie,3,1.0,3.0,,In-store,2023-05-20
+TXN_8872715,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,UNKNOWN
+TXN_4638979,Salad,1,5.0,5.0,,,2023-06-28
+TXN_5506097,,5,4.0,20.0,Cash,Takeaway,2023-05-04
+TXN_9579984,Salad,5,5.0,25.0,Credit Card,,2023-12-25
+TXN_6087578,Tea,1,1.5,1.5,Credit Card,,2023-12-17
+TXN_5297299,Coffee,5,2.0,10.0,,,2023-10-04
+TXN_7526174,Juice,3,3.0,9.0,Credit Card,,2023-08-06
+TXN_5401244,Salad,1,5.0,5.0,Credit Card,In-store,2023-07-08
+TXN_7470034,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,
+TXN_7775760,Cake,4,3.0,,,,2023-02-21
+TXN_5820892,Juice,1,3.0,3.0,Digital Wallet,ERROR,2023-11-14
+TXN_3801338,Sandwich,3,4.0,12.0,Credit Card,,2023-11-03
+TXN_1521861,ERROR,5,3.0,15.0,Cash,In-store,2023-04-02
+TXN_8365857,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-10-06
+TXN_9349657,Cookie,2,1.0,2.0,Credit Card,In-store,2023-03-14
+TXN_4503716,Cake,1,3.0,3.0,,,2023-11-12
+TXN_5679014,Coffee,1,2.0,2.0,,In-store,2023-06-12
+TXN_1161606,Sandwich,5,4.0,20.0,Credit Card,Takeaway,2023-09-20
+TXN_5938359,Cookie,2,1.0,2.0,Credit Card,,2023-06-02
+TXN_7565894,Salad,1,5.0,5.0,Cash,Takeaway,2023-07-15
+TXN_1987311,Smoothie,1,4.0,4.0,,In-store,2023-08-03
+TXN_4656387,Cookie,2,1.0,2.0,Digital Wallet,,2023-07-25
+TXN_9277276,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-09-15
+TXN_1576076,Coffee,3,2.0,6.0,Cash,Takeaway,2023-10-07
+TXN_3676632,Smoothie,4,4.0,16.0,Credit Card,,2023-12-11
+TXN_9945457,Cookie,4,1.0,4.0,Cash,,2023-06-28
+TXN_6508674,ERROR,2,3.0,6.0,,Takeaway,2023-02-09
+TXN_4579086,Cake,2,3.0,6.0,Credit Card,In-store,2023-07-20
+TXN_2421873,Coffee,2,2.0,4.0,Credit Card,,2023-02-18
+TXN_3601382,Salad,3,5.0,15.0,,,2023-02-12
+TXN_2323650,Tea,4,1.5,6.0,Digital Wallet,,2023-10-09
+TXN_3587916,Salad,3,5.0,15.0,Cash,In-store,2023-07-09
+TXN_8914956,Cookie,2,1.0,2.0,Credit Card,,2023-05-13
+TXN_9080521,Coffee,2,2.0,4.0,Credit Card,In-store,2023-01-24
+TXN_1450705,Cookie,5,1.0,5.0,,,2023-10-07
+TXN_9648941,Coffee,2,2.0,4.0,Cash,Takeaway,2023-06-30
+TXN_9989719,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-11-26
+TXN_8409154,Cake,4,3.0,12.0,Digital Wallet,,2023-06-20
+TXN_4630633,Sandwich,1,4.0,4.0,UNKNOWN,Takeaway,2023-10-22
+TXN_8332592,Juice,UNKNOWN,3.0,15.0,,,2023-03-25
+TXN_5736595,Coffee,3,2.0,6.0,Credit Card,ERROR,2023-08-14
+TXN_2264883,Juice,2,3.0,6.0,Credit Card,Takeaway,2023-12-24
+TXN_6137394,Sandwich,1,4.0,4.0,ERROR,In-store,2023-11-22
+TXN_4127927,Salad,5,5.0,25.0,,Takeaway,2023-08-04
+TXN_7256205,Juice,4,3.0,ERROR,Cash,,2023-04-08
+TXN_1766527,UNKNOWN,4,5.0,UNKNOWN,Digital Wallet,,2023-02-07
+TXN_7591982,Salad,1,5.0,5.0,Cash,,2023-02-28
+TXN_5530273,Cake,3,3.0,9.0,Digital Wallet,ERROR,2023-01-13
+TXN_2958213,,5,1.0,5.0,UNKNOWN,,2023-08-15
+TXN_2057961,Juice,2,3.0,6.0,,In-store,2023-10-04
+TXN_9705027,Cookie,2,1.0,,Cash,,UNKNOWN
+TXN_6367976,Juice,1,3.0,3.0,Digital Wallet,,2023-10-16
+TXN_9921277,Cake,,3.0,3.0,,Takeaway,2023-01-29
+TXN_4867316,Sandwich,1,4.0,4.0,Digital Wallet,,2023-11-28
+TXN_6704173,Smoothie,2,4.0,8.0,Credit Card,,2023-07-24
+TXN_9510130,Salad,4,5.0,20.0,Cash,,2023-03-06
+TXN_1192009,Coffee,1,2.0,2.0,ERROR,,2023-05-18
+TXN_2899889,Salad,2,5.0,10.0,,In-store,2023-12-09
+TXN_7172693,,5,5.0,25.0,Credit Card,In-store,2023-03-23
+TXN_6862603,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-04-17
+TXN_5761207,Smoothie,3,4.0,12.0,Credit Card,,2023-04-19
+TXN_9852820,Salad,2,5.0,10.0,Credit Card,In-store,2023-08-27
+TXN_5939783,Cookie,2,1.0,2.0,,Takeaway,UNKNOWN
+TXN_2062604,Coffee,2,2.0,4.0,Cash,In-store,ERROR
+TXN_9531812,Sandwich,2,4.0,8.0,Digital Wallet,In-store,2023-02-04
+TXN_1423173,Smoothie,5,4.0,20.0,Credit Card,,2023-10-02
+TXN_9811007,Cookie,5,1.0,5.0,Credit Card,,2023-03-07
+TXN_4346813,Salad,5,5.0,25.0,,ERROR,2023-07-07
+TXN_4383311,Cake,2,UNKNOWN,6.0,UNKNOWN,In-store,2023-09-23
+TXN_5935353,,2,ERROR,8.0,Credit Card,ERROR,2023-05-01
+TXN_6778796,Cake,5,3.0,15.0,Cash,,2023-11-29
+TXN_2119373,Salad,4,5.0,20.0,Credit Card,In-store,2023-06-30
+TXN_6803555,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-05-31
+TXN_7010218,Cookie,4,1.0,4.0,,Takeaway,2023-04-29
+TXN_1707537,Cake,3,3.0,ERROR,Digital Wallet,Takeaway,2023-10-17
+TXN_8470187,Juice,3,3.0,9.0,,Takeaway,2023-06-28
+TXN_6087604,Sandwich,4,4.0,16.0,Digital Wallet,,2023-01-27
+TXN_9825905,Coffee,1,2.0,2.0,Digital Wallet,ERROR,2023-01-04
+TXN_2086557,Smoothie,2,4.0,8.0,Cash,In-store,2023-01-13
+TXN_9077087,Juice,1,3.0,3.0,,In-store,2023-05-08
+TXN_7714902,Coffee,4,2.0,8.0,Cash,,2023-09-10
+TXN_2154477,Cake,4,3.0,12.0,,ERROR,2023-02-11
+TXN_5949199,Tea,5,1.5,7.5,,In-store,2023-02-28
+TXN_8209124,Coffee,2,2.0,4.0,Cash,,2023-10-05
+TXN_7519611,UNKNOWN,4,1.5,6.0,Credit Card,In-store,2023-10-08
+TXN_1318943,UNKNOWN,2,2.0,UNKNOWN,Cash,In-store,2023-06-13
+TXN_4502922,,1,4.0,4.0,Credit Card,Takeaway,2023-06-23
+TXN_4554194,Smoothie,3,UNKNOWN,12.0,Credit Card,Takeaway,2023-10-04
+TXN_3418612,Tea,3,1.5,4.5,Digital Wallet,,2023-01-31
+TXN_2539469,Cake,2,3.0,6.0,Credit Card,Takeaway,2023-09-24
+TXN_2764544,Juice,4,3.0,12.0,Cash,In-store,2023-04-02
+TXN_8672939,Smoothie,1,4.0,4.0,,ERROR,2023-11-02
+TXN_1499346,Cake,5,3.0,15.0,,,2023-12-09
+TXN_9930357,Juice,1,3.0,3.0,Credit Card,,UNKNOWN
+TXN_7631216,Juice,5,3.0,15.0,Credit Card,,2023-02-16
+TXN_3116803,Coffee,1,2.0,2.0,Credit Card,In-store,2023-09-10
+TXN_6050844,Tea,2,1.5,3.0,,ERROR,2023-03-12
+TXN_7403963,Sandwich,4,4.0,16.0,Cash,In-store,2023-07-27
+TXN_2708387,Tea,4,1.5,6.0,Credit Card,,2023-11-12
+TXN_7916758,Smoothie,1,4.0,4.0,,Takeaway,2023-10-14
+TXN_2944717,Cookie,2,1.0,2.0,Cash,,2023-12-11
+TXN_7571571,Sandwich,2,4.0,8.0,Credit Card,,2023-04-09
+TXN_7250085,Coffee,4,2.0,8.0,,Takeaway,2023-09-19
+TXN_1892102,ERROR,3,4.0,12.0,Cash,,2023-03-23
+TXN_7039529,Cookie,3,1.0,,Digital Wallet,In-store,2023-01-19
+TXN_1452931,Tea,1,1.5,1.5,Digital Wallet,,2023-07-08
+TXN_5148201,Smoothie,5,4.0,20.0,UNKNOWN,,2023-11-18
+TXN_7322317,Tea,1,UNKNOWN,UNKNOWN,,,2023-03-16
+TXN_4648214,Salad,1,5.0,5.0,,,2023-02-15
+TXN_7902691,Juice,ERROR,3.0,9.0,Digital Wallet,Takeaway,2023-10-13
+TXN_4966750,Cookie,3,1.0,3.0,Digital Wallet,In-store,2023-12-24
+TXN_7740239,Tea,2,1.5,3.0,,,2023-01-26
+TXN_6901162,,3,4.0,12.0,Digital Wallet,In-store,
+TXN_3689579,,2,4.0,8.0,Digital Wallet,Takeaway,2023-12-02
+TXN_7770188,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-10-28
+TXN_5088167,Coffee,5,2.0,10.0,Credit Card,UNKNOWN,2023-09-02
+TXN_1865302,Cookie,5,1.0,5.0,Credit Card,In-store,2023-08-16
+TXN_4224423,Juice,3,3.0,9.0,Cash,Takeaway,2023-08-27
+TXN_8269956,Smoothie,UNKNOWN,4.0,20.0,,Takeaway,2023-08-02
+TXN_9263959,Cookie,,1.0,5.0,Cash,,UNKNOWN
+TXN_3879052,Coffee,3,2.0,6.0,Credit Card,,2023-12-14
+TXN_7340284,ERROR,5,1.0,5.0,,Takeaway,2023-09-05
+TXN_9809696,Smoothie,1,4.0,4.0,,Takeaway,2023-01-05
+TXN_5719592,Coffee,1,2.0,2.0,Credit Card,In-store,2023-08-07
+TXN_6121301,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-01-07
+TXN_2097987,Sandwich,2,4.0,8.0,Digital Wallet,In-store,
+TXN_7514279,Salad,1,5.0,5.0,Credit Card,In-store,2023-02-04
+TXN_5153408,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-08-22
+TXN_4678948,Juice,3,3.0,9.0,UNKNOWN,Takeaway,2023-07-02
+TXN_8918253,UNKNOWN,3,UNKNOWN,12.0,Digital Wallet,,2023-09-07
+TXN_7292662,Sandwich,1,4.0,4.0,,In-store,ERROR
+TXN_1209852,Cookie,2,1.0,2.0,Credit Card,In-store,2023-11-18
+TXN_4367311,Coffee,5,2.0,10.0,,In-store,2023-02-26
+TXN_5985513,ERROR,ERROR,4.0,8.0,Credit Card,,2023-08-02
+TXN_2086325,Coffee,2,2.0,4.0,Credit Card,,2023-08-14
+TXN_4062032,Tea,5,1.5,7.5,Digital Wallet,,2023-10-28
+TXN_4329558,,4,2.0,8.0,,,2023-04-22
+TXN_2029301,Tea,5,1.5,7.5,Digital Wallet,,2023-08-06
+TXN_4508067,Smoothie,5,4.0,20.0,Credit Card,Takeaway,2023-03-19
+TXN_6637315,Cake,3,3.0,9.0,Cash,,2023-12-02
+TXN_3660347,Smoothie,5,4.0,20.0,,In-store,UNKNOWN
+TXN_4251500,Cookie,4,1.0,,Digital Wallet,Takeaway,2023-11-11
+TXN_1516961,Sandwich,3,4.0,12.0,Credit Card,Takeaway,2023-11-01
+TXN_5033660,Coffee,2,2.0,4.0,ERROR,,2023-09-12
+TXN_9506595,,3,1.5,4.5,Cash,In-store,2023-07-10
+TXN_6646684,Cookie,3,1.0,3.0,Cash,,2023-06-01
+TXN_6866644,Sandwich,1,4.0,4.0,,,2023-07-22
+TXN_7228322,Cookie,1,1.0,UNKNOWN,Credit Card,,2023-02-18
+TXN_3595118,Juice,2,3.0,6.0,Cash,In-store,2023-02-03
+TXN_4040941,Cookie,1,1.0,1.0,Cash,In-store,2023-02-20
+TXN_7753584,Coffee,4,2.0,8.0,,Takeaway,
+TXN_4738349,Smoothie,2,4.0,8.0,Digital Wallet,,2023-02-06
+TXN_9436284,Coffee,3,2.0,6.0,Credit Card,,2023-03-28
+TXN_1221801,Smoothie,2,4.0,8.0,,,2023-06-17
+TXN_3185929,Salad,3,5.0,15.0,,Takeaway,2023-07-27
+TXN_2332609,,5,4.0,20.0,Credit Card,In-store,2023-05-17
+TXN_4183705,Tea,2,1.5,3.0,Credit Card,In-store,2023-11-23
+TXN_5459138,Smoothie,2,4.0,8.0,Digital Wallet,In-store,
+TXN_7435096,,4,1.5,6.0,,In-store,2023-10-21
+TXN_2561471,Sandwich,1,4.0,4.0,,In-store,2023-07-12
+TXN_3098503,Salad,1,5.0,,Credit Card,Takeaway,2023-05-31
+TXN_1148060,Cookie,5,1.0,5.0,Cash,,2023-10-12
+TXN_5151780,Salad,4,5.0,20.0,Cash,Takeaway,2023-06-24
+TXN_3398955,Cookie,3,1.0,3.0,Cash,ERROR,2023-10-19
+TXN_8140360,Coffee,4,2.0,8.0,Digital Wallet,Takeaway,2023-05-05
+TXN_4448318,Coffee,4,2.0,8.0,Digital Wallet,UNKNOWN,2023-08-07
+TXN_8341520,Sandwich,3,4.0,ERROR,,Takeaway,2023-06-24
+TXN_9883214,Juice,3,3.0,9.0,,,2023-04-04
+TXN_2912934,Cookie,5,1.0,5.0,Credit Card,,2023-04-01
+TXN_7694996,Salad,4,5.0,20.0,UNKNOWN,In-store,2023-03-11
+TXN_5660244,Cake,5,3.0,15.0,Digital Wallet,,2023-10-04
+TXN_7873479,Cookie,1,1.0,1.0,Credit Card,Takeaway,2023-03-18
+TXN_7771516,Sandwich,3,4.0,12.0,UNKNOWN,,2023-05-26
+TXN_1166001,,UNKNOWN,3.0,15.0,Cash,ERROR,
+TXN_6775304,Tea,4,1.5,6.0,Cash,In-store,2023-03-08
+TXN_3801966,Sandwich,4,4.0,16.0,Digital Wallet,In-store,2023-01-14
+TXN_2849095,,3,2.0,6.0,Digital Wallet,In-store,2023-07-13
+TXN_1749930,Salad,5,5.0,25.0,UNKNOWN,In-store,2023-07-01
+TXN_2210925,Juice,4,3.0,12.0,Cash,In-store,2023-07-06
+TXN_6810969,,1,4.0,4.0,UNKNOWN,In-store,2023-03-08
+TXN_2651789,Cookie,1,1.0,1.0,,Takeaway,2023-02-10
+TXN_7750963,Tea,4,1.5,6.0,Credit Card,In-store,2023-06-09
+TXN_8134280,Cookie,1,1.0,1.0,Digital Wallet,Takeaway,2023-01-29
+TXN_2231082,Cake,UNKNOWN,3.0,15.0,Cash,In-store,2023-05-03
+TXN_2014042,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-10-27
+TXN_1132293,Tea,4,1.5,6.0,ERROR,,2023-07-05
+TXN_3550177,Salad,5,5.0,25.0,Cash,,2023-09-13
+TXN_5326795,Cookie,2,1.0,2.0,,,2023-04-05
+TXN_1993503,Cookie,4,1.0,4.0,Credit Card,ERROR,2023-08-16
+TXN_4097922,Salad,3,5.0,15.0,Cash,,2023-01-16
+TXN_2317041,Tea,3,ERROR,4.5,Cash,In-store,2023-01-15
+TXN_4648031,Tea,4,1.5,6.0,Digital Wallet,,2023-09-04
+TXN_4942960,Juice,1,3.0,3.0,ERROR,Takeaway,2023-04-12
+TXN_8740501,Salad,5,5.0,25.0,,,2023-02-05
+TXN_4523273,Cake,4,UNKNOWN,12.0,Digital Wallet,,2023-10-17
+TXN_7276478,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-09-07
+TXN_6036240,Cake,4,3.0,12.0,Credit Card,In-store,2023-10-30
+TXN_1449866,Salad,4,5.0,20.0,Cash,,2023-09-21
+TXN_2882871,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-08-30
+TXN_1047450,Coffee,2,2.0,4.0,Cash,In-store,2023-11-19
+TXN_9673685,Salad,1,5.0,5.0,Cash,In-store,2023-12-11
+TXN_3547569,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-08-04
+TXN_2866587,Sandwich,3,4.0,12.0,Credit Card,,2023-09-16
+TXN_1629218,Coffee,ERROR,2.0,6.0,Digital Wallet,,2023-06-27
+TXN_2964982,Sandwich,1,4.0,4.0,Digital Wallet,In-store,2023-04-15
+TXN_5974791,Cookie,2,1.0,2.0,Cash,,2023-10-22
+TXN_1005472,Coffee,4,2.0,8.0,Credit Card,,2023-04-21
+TXN_7202898,Cookie,4,1.0,4.0,ERROR,ERROR,2023-07-18
+TXN_4511996,UNKNOWN,3,3.0,9.0,Digital Wallet,,2023-09-18
+TXN_9896694,Sandwich,4,4.0,16.0,Cash,,2023-02-16
+TXN_9881555,UNKNOWN,5,3.0,15.0,Cash,In-store,2023-04-09
+TXN_9853220,Cookie,UNKNOWN,1.0,5.0,Credit Card,In-store,2023-04-02
+TXN_2354774,Coffee,5,2.0,10.0,,In-store,UNKNOWN
+TXN_5723229,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-06-23
+TXN_1065721,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-12-06
+TXN_4921791,Salad,4,5.0,20.0,Credit Card,,UNKNOWN
+TXN_3692789,Sandwich,,4.0,8.0,Credit Card,ERROR,UNKNOWN
+TXN_8155446,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-12-20
+TXN_2253852,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-08-26
+TXN_2810187,Coffee,ERROR,2.0,8.0,ERROR,In-store,2023-10-17
+TXN_4962500,Juice,5,3.0,15.0,,Takeaway,UNKNOWN
+TXN_6994752,Juice,4,3.0,12.0,Cash,Takeaway,2023-06-17
+TXN_7598654,Coffee,3,2.0,6.0,Credit Card,,2023-11-26
+TXN_8039560,,5,2.0,10.0,Digital Wallet,,2023-03-29
+TXN_6785331,Cake,1,3.0,3.0,,,2023-04-12
+TXN_8260297,Salad,2,5.0,10.0,Cash,In-store,2023-07-04
+TXN_7152012,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-04-02
+TXN_7907366,Coffee,4,2.0,8.0,Digital Wallet,UNKNOWN,2023-01-13
+TXN_3830888,Coffee,4,2.0,8.0,,In-store,2023-02-20
+TXN_1565027,UNKNOWN,3,1.5,,,,2023-03-16
+TXN_5618377,Sandwich,2,4.0,8.0,,In-store,2023-04-02
+TXN_3645674,Tea,4,1.5,6.0,Cash,Takeaway,2023-07-18
+TXN_2464236,Cookie,5,1.0,5.0,Digital Wallet,,2023-04-02
+TXN_4543793,Sandwich,2,4.0,8.0,Cash,In-store,2023-10-12
+TXN_5745921,Sandwich,2,4.0,8.0,,In-store,2023-03-01
+TXN_7229419,Salad,2,5.0,10.0,,Takeaway,2023-05-15
+TXN_9247075,Salad,3,5.0,15.0,,In-store,2023-07-05
+TXN_6960459,Coffee,1,2.0,ERROR,Credit Card,In-store,2023-07-24
+TXN_4679083,Cake,5,3.0,UNKNOWN,,Takeaway,2023-12-25
+TXN_3313534,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-01-05
+TXN_4969431,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-04-11
+TXN_2977905,Smoothie,3,4.0,12.0,,,2023-06-23
+TXN_5341204,Coffee,UNKNOWN,2.0,2.0,,,2023-07-24
+TXN_2147706,Juice,5,3.0,,UNKNOWN,,2023-03-23
+TXN_3663592,Smoothie,2,4.0,8.0,,Takeaway,2023-08-26
+TXN_4459351,Smoothie,5,4.0,20.0,Credit Card,,2023-12-08
+TXN_2976052,Cookie,5,1.0,5.0,,Takeaway,2023-11-01
+TXN_1373048,Salad,5,5.0,25.0,,In-store,2023-08-31
+TXN_2575331,Cookie,5,1.0,5.0,Cash,In-store,2023-03-20
+TXN_4764236,Juice,1,3.0,3.0,Digital Wallet,,2023-05-29
+TXN_3544380,Juice,1,3.0,3.0,Credit Card,In-store,2023-09-13
+TXN_2104473,Cake,3,3.0,9.0,Digital Wallet,Takeaway,2023-01-01
+TXN_3819405,Juice,4,3.0,12.0,Digital Wallet,In-store,2023-02-16
+TXN_3512665,Salad,5,5.0,25.0,Credit Card,,2023-10-16
+TXN_1696813,Cookie,3,1.0,3.0,Cash,In-store,2023-04-02
+TXN_4631228,UNKNOWN,1,3.0,3.0,Digital Wallet,ERROR,2023-10-07
+TXN_2084232,,4,1.5,6.0,Digital Wallet,Takeaway,2023-10-11
+TXN_5399303,Coffee,2,2.0,4.0,ERROR,UNKNOWN,2023-11-02
+TXN_1251960,Sandwich,5,ERROR,20.0,Digital Wallet,Takeaway,2023-11-20
+TXN_1984774,Tea,3,1.5,4.5,Cash,Takeaway,2023-11-13
+TXN_9886794,Cake,1,3.0,3.0,Cash,,2023-06-06
+TXN_3821298,,5,4.0,20.0,Credit Card,ERROR,2023-04-26
+TXN_1057760,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-02-20
+TXN_2294778,Cookie,,1.0,3.0,Digital Wallet,,2023-05-29
+TXN_6091431,Tea,3,1.5,4.5,Credit Card,,2023-11-16
+TXN_1728644,Coffee,1,2.0,2.0,Cash,Takeaway,2023-04-07
+TXN_6993624,Cake,4,3.0,12.0,Cash,,2023-05-09
+TXN_4003831,Cookie,1,1.0,1.0,Credit Card,,UNKNOWN
+TXN_9018366,Juice,5,ERROR,15.0,Cash,,2023-03-31
+TXN_7708810,Smoothie,1,4.0,4.0,Cash,,2023-06-09
+TXN_8726874,Sandwich,2,4.0,8.0,,Takeaway,2023-09-30
+TXN_4190431,Tea,3,1.5,4.5,Digital Wallet,,2023-09-23
+TXN_5201123,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-07-12
+TXN_6172528,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-05-18
+TXN_1193551,Cookie,1,1.0,1.0,,Takeaway,2023-01-07
+TXN_9877722,Sandwich,5,4.0,20.0,Digital Wallet,In-store,UNKNOWN
+TXN_2702861,Cookie,4,ERROR,4.0,Digital Wallet,Takeaway,2023-06-02
+TXN_4255580,ERROR,1,,3.0,Cash,,
+TXN_1256851,Sandwich,4,4.0,16.0,UNKNOWN,In-store,2023-07-29
+TXN_4146795,Tea,5,1.5,7.5,Cash,In-store,2023-10-29
+TXN_2203873,Tea,3,1.5,4.5,Digital Wallet,,2023-01-26
+TXN_5018462,Smoothie,5,4.0,20.0,Cash,In-store,2023-11-28
+TXN_6133971,Smoothie,5,4.0,20.0,Credit Card,,2023-04-18
+TXN_1417400,Cookie,2,1.0,2.0,Cash,In-store,2023-03-20
+TXN_4239859,Juice,1,ERROR,3.0,,ERROR,2023-02-03
+TXN_5369010,,4,5.0,20.0,Cash,Takeaway,2023-04-23
+TXN_4877436,Juice,4,3.0,12.0,,,2023-10-08
+TXN_9697670,,3,3.0,9.0,Cash,Takeaway,2023-12-29
+TXN_8643596,Coffee,5,2.0,10.0,Credit Card,,2023-03-29
+TXN_1654784,Cookie,5,1.0,5.0,,In-store,2023-12-31
+TXN_4422898,Salad,2,5.0,10.0,Credit Card,In-store,2023-04-20
+TXN_4175191,Sandwich,2,4.0,8.0,Cash,ERROR,2023-11-20
+TXN_3196388,Salad,3,5.0,15.0,Cash,In-store,2023-03-04
+TXN_6960031,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-04-25
+TXN_8963106,Coffee,5,2.0,10.0,Cash,In-store,2023-04-01
+TXN_7167980,Smoothie,3,4.0,ERROR,ERROR,,2023-10-05
+TXN_8732716,Tea,3,1.5,4.5,,,2023-12-29
+TXN_3530118,Cake,5,3.0,15.0,Digital Wallet,UNKNOWN,2023-11-14
+TXN_7875743,Cake,5,3.0,15.0,Cash,Takeaway,2023-04-17
+TXN_1526920,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,ERROR
+TXN_1933315,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-09-29
+TXN_5674503,Cake,3,3.0,9.0,ERROR,Takeaway,2023-12-14
+TXN_5252187,Sandwich,1,4.0,4.0,Cash,,2023-01-20
+TXN_4668931,Juice,3,3.0,9.0,Cash,In-store,2023-07-09
+TXN_2504703,Smoothie,5,4.0,20.0,Digital Wallet,Takeaway,2023-01-09
+TXN_3113428,Juice,2,3.0,6.0,Cash,In-store,2023-10-30
+TXN_9663941,Juice,4,3.0,12.0,Cash,In-store,ERROR
+TXN_7595115,Sandwich,2,4.0,8.0,,Takeaway,2023-04-17
+TXN_9034955,Cookie,1,1.0,1.0,Credit Card,In-store,2023-09-07
+TXN_7856009,Cake,2,3.0,6.0,,,2023-05-27
+TXN_2375919,Sandwich,3,4.0,12.0,,ERROR,2023-11-23
+TXN_9344399,Cookie,2,1.0,2.0,UNKNOWN,,2023-12-04
+TXN_1091243,Sandwich,2,4.0,8.0,,In-store,2023-01-06
+TXN_8800741,Coffee,4,,8.0,,,2023-06-26
+TXN_3546303,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-09-11
+TXN_7595096,Juice,1,3.0,3.0,,UNKNOWN,2023-11-02
+TXN_4788849,Cookie,1,UNKNOWN,1.0,,Takeaway,2023-03-13
+TXN_7838802,Cookie,2,1.0,2.0,Credit Card,Takeaway,2023-11-20
+TXN_6736326,Salad,2,5.0,10.0,Credit Card,In-store,2023-04-14
+TXN_2536021,Cookie,5,1.0,5.0,UNKNOWN,Takeaway,2023-10-02
+TXN_2065683,UNKNOWN,3,UNKNOWN,6.0,,,2023-09-21
+TXN_5538696,Coffee,2,2.0,4.0,ERROR,In-store,2023-08-30
+TXN_8434651,,4,3.0,12.0,Digital Wallet,,2023-01-27
+TXN_4635386,Tea,1,1.5,1.5,Credit Card,Takeaway,ERROR
+TXN_5466291,Salad,1,5.0,5.0,Credit Card,ERROR,2023-09-19
+TXN_2643389,Sandwich,2,4.0,8.0,Credit Card,,2023-08-24
+TXN_9817135,Salad,1,5.0,5.0,Digital Wallet,ERROR,2023-03-25
+TXN_7426086,Coffee,4,2.0,8.0,,ERROR,2023-01-13
+TXN_9327861,Tea,5,1.5,7.5,Credit Card,In-store,2023-07-17
+TXN_3971440,Cake,4,3.0,12.0,Digital Wallet,Takeaway,2023-10-22
+TXN_8494583,Cookie,5,1.0,5.0,Credit Card,In-store,2023-11-29
+TXN_8083377,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-01-06
+TXN_6883187,Juice,2,ERROR,6.0,ERROR,,2023-11-16
+TXN_8340038,Tea,1,1.5,1.5,Digital Wallet,In-store,2023-07-15
+TXN_2275799,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-10-04
+TXN_3497691,Smoothie,4,4.0,16.0,Credit Card,,2023-09-06
+TXN_5881237,Cookie,2,1.0,2.0,,,2023-08-14
+TXN_2271705,Tea,5,1.5,7.5,,,2023-07-20
+TXN_1640172,Salad,UNKNOWN,5.0,5.0,,,2023-04-13
+TXN_4618211,Smoothie,4,4.0,16.0,Cash,,2023-09-12
+TXN_9618563,Smoothie,1,4.0,4.0,,Takeaway,2023-02-24
+TXN_4374260,Cookie,1,1.0,,Cash,UNKNOWN,2023-04-20
+TXN_1946773,Sandwich,4,4.0,16.0,Cash,,2023-08-28
+TXN_4387523,Cake,3,3.0,9.0,,,2023-02-07
+TXN_7661094,Salad,4,5.0,20.0,Cash,,2023-07-21
+TXN_6766664,Coffee,3,2.0,6.0,,,2023-05-21
+TXN_9055374,Sandwich,1,4.0,,,Takeaway,UNKNOWN
+TXN_1861717,Tea,2,1.5,3.0,Cash,In-store,2023-11-10
+TXN_3421079,Smoothie,1,4.0,4.0,Credit Card,In-store,2023-12-18
+TXN_1637131,ERROR,4,ERROR,6.0,Cash,,UNKNOWN
+TXN_7636536,Cookie,2,1.0,2.0,Cash,,2023-05-06
+TXN_4971607,Smoothie,5,4.0,20.0,Cash,In-store,2023-03-30
+TXN_1852436,Juice,4,ERROR,12.0,,,ERROR
+TXN_9701622,Cookie,5,1.0,5.0,Digital Wallet,,2023-09-24
+TXN_6966241,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-04-13
+TXN_9252700,UNKNOWN,3,3.0,9.0,Credit Card,,2023-08-24
+TXN_1124900,,4,4.0,16.0,Credit Card,In-store,2023-09-08
+TXN_3964624,Tea,3,1.5,4.5,,In-store,2023-09-20
+TXN_2226371,Cake,1,3.0,3.0,Cash,,2023-11-18
+TXN_5744797,Cake,,ERROR,3.0,Cash,In-store,2023-12-20
+TXN_5777164,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-02-07
+TXN_5817802,Coffee,5,2.0,10.0,,In-store,2023-02-13
+TXN_3787234,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-03-15
+TXN_4525646,Cake,3,3.0,9.0,Credit Card,,2023-07-07
+TXN_7004303,UNKNOWN,3,4.0,12.0,Cash,In-store,2023-10-06
+TXN_8649416,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-09-21
+TXN_3219599,UNKNOWN,2,3.0,6.0,,,2023-08-22
+TXN_1394131,Juice,4,3.0,12.0,,Takeaway,2023-06-13
+TXN_9237291,Juice,2,3.0,6.0,Credit Card,ERROR,2023-09-22
+TXN_9520855,Cake,4,3.0,12.0,,,2023-01-11
+TXN_4565080,Smoothie,4,4.0,16.0,Digital Wallet,In-store,2023-09-28
+TXN_8348710,Coffee,1,2.0,2.0,Cash,In-store,2023-12-27
+TXN_5127819,Juice,3,3.0,9.0,ERROR,,2023-04-03
+TXN_7496394,Smoothie,4,4.0,16.0,,,2023-06-12
+TXN_8495889,Cake,1,3.0,3.0,Cash,Takeaway,2023-06-26
+TXN_5064188,Sandwich,4,4.0,16.0,Credit Card,UNKNOWN,2023-12-08
+TXN_6104335,Smoothie,2,4.0,8.0,Credit Card,,2023-11-13
+TXN_5313435,Salad,4,5.0,UNKNOWN,Cash,,2023-02-18
+TXN_6700745,Juice,3,3.0,,,In-store,2023-04-23
+TXN_9897215,Cake,3,3.0,,Credit Card,,2023-11-22
+TXN_7764175,Salad,3,5.0,15.0,Cash,In-store,2023-09-02
+TXN_3027490,Cookie,3,1.0,3.0,ERROR,Takeaway,2023-02-25
+TXN_5368297,Smoothie,2,4.0,8.0,,Takeaway,2023-10-04
+TXN_2053125,Salad,1,5.0,5.0,Digital Wallet,,2023-07-26
+TXN_2522828,Smoothie,4,4.0,16.0,Credit Card,,2023-01-15
+TXN_6616787,UNKNOWN,2,3.0,6.0,ERROR,In-store,2023-09-29
+TXN_6419317,Sandwich,4,4.0,16.0,Credit Card,ERROR,2023-02-25
+TXN_5939950,Sandwich,2,4.0,8.0,Cash,ERROR,2023-06-16
+TXN_4607296,Cake,5,3.0,15.0,ERROR,In-store,2023-04-02
+TXN_8316135,Salad,3,5.0,15.0,Digital Wallet,Takeaway,2023-11-06
+TXN_7910956,Coffee,5,2.0,10.0,Digital Wallet,In-store,2023-07-21
+TXN_1142233,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-09-01
+TXN_9810581,,1,3.0,3.0,Cash,,2023-11-20
+TXN_2588566,,3,5.0,15.0,,Takeaway,2023-01-10
+TXN_3786518,Salad,1,5.0,,Credit Card,In-store,2023-09-16
+TXN_2009407,Juice,5,UNKNOWN,15.0,Cash,Takeaway,2023-05-05
+TXN_9163155,UNKNOWN,4,2.0,UNKNOWN,Credit Card,Takeaway,2023-04-23
+TXN_8272750,Salad,5,ERROR,25.0,,,2023-05-18
+TXN_2532563,Salad,4,5.0,20.0,,Takeaway,
+TXN_8532735,Coffee,2,2.0,4.0,Cash,Takeaway,2023-07-28
+TXN_1697299,Smoothie,3,4.0,12.0,Cash,In-store,2023-10-08
+TXN_5785639,Salad,1,5.0,5.0,Credit Card,,2023-04-10
+TXN_8445753,Tea,4,1.5,6.0,Cash,Takeaway,2023-04-07
+TXN_3641519,,5,1.0,5.0,Digital Wallet,In-store,2023-06-08
+TXN_1985278,Sandwich,3,4.0,12.0,,In-store,2023-02-13
+TXN_6612143,Tea,5,1.5,7.5,Cash,In-store,2023-11-07
+TXN_8352416,Salad,1,5.0,,Digital Wallet,In-store,2023-07-26
+TXN_5498693,Cake,4,3.0,12.0,UNKNOWN,,2023-05-13
+TXN_2644561,,4,4.0,16.0,Digital Wallet,,2023-09-13
+TXN_8912001,Cookie,ERROR,1.0,1.0,Credit Card,,2023-03-27
+TXN_8330837,Juice,3,3.0,9.0,Digital Wallet,,2023-10-13
+TXN_3703482,Cake,4,3.0,,,UNKNOWN,2023-01-08
+TXN_3455103,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-04-22
+TXN_1496962,Smoothie,5,4.0,20.0,,In-store,2023-12-17
+TXN_4216294,Tea,4,1.5,6.0,Cash,In-store,2023-10-19
+TXN_3002889,Coffee,3,2.0,6.0,Digital Wallet,UNKNOWN,2023-10-22
+TXN_4275827,UNKNOWN,2,1.5,3.0,Cash,Takeaway,2023-04-21
+TXN_6044312,Cake,2,3.0,6.0,ERROR,In-store,2023-01-03
+TXN_4008135,Cookie,5,1.0,5.0,Cash,Takeaway,2023-11-25
+TXN_5336876,Smoothie,ERROR,4.0,12.0,Credit Card,,2023-07-07
+TXN_8990020,Sandwich,4,4.0,16.0,ERROR,In-store,2023-09-09
+TXN_5654331,Coffee,4,2.0,8.0,Cash,In-store,2023-07-31
+TXN_1213938,Salad,5,5.0,25.0,Digital Wallet,Takeaway,2023-07-06
+TXN_2522182,Salad,2,5.0,,Digital Wallet,In-store,2023-11-11
+TXN_5329431,Sandwich,3,4.0,,Credit Card,In-store,2023-10-03
+TXN_9647494,,2,4.0,8.0,Credit Card,UNKNOWN,2023-10-21
+TXN_8482887,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-10-29
+TXN_3883425,Smoothie,5,4.0,20.0,Digital Wallet,UNKNOWN,2023-07-09
+TXN_4434185,Smoothie,5,ERROR,20.0,Credit Card,Takeaway,2023-04-30
+TXN_7388851,Smoothie,1,4.0,4.0,Digital Wallet,,2023-09-30
+TXN_8460225,Smoothie,5,4.0,20.0,ERROR,In-store,2023-02-23
+TXN_5471175,Cookie,4,1.0,4.0,Cash,,2023-04-16
+TXN_1874601,Coffee,4,2.0,8.0,,,2023-12-10
+TXN_3641001,Smoothie,3,4.0,12.0,Digital Wallet,ERROR,2023-11-10
+TXN_6446441,Salad,3,5.0,15.0,Digital Wallet,,2023-02-18
+TXN_9718216,Juice,4,3.0,12.0,,UNKNOWN,2023-07-07
+TXN_7391138,Tea,5,1.5,7.5,Cash,,2023-08-23
+TXN_9548077,Tea,2,1.5,3.0,Cash,In-store,2023-07-05
+TXN_9185022,Sandwich,3,4.0,12.0,Digital Wallet,In-store,2023-06-19
+TXN_6841993,Juice,3,3.0,9.0,Cash,Takeaway,2023-09-15
+TXN_1701766,Cake,4,3.0,12.0,,,2023-11-22
+TXN_9541057,Juice,4,3.0,12.0,Cash,In-store,2023-04-24
+TXN_4699706,Coffee,5,2.0,10.0,,In-store,2023-12-04
+TXN_2451247,Tea,4,1.5,6.0,Digital Wallet,Takeaway,2023-02-14
+TXN_6272908,Juice,3,3.0,9.0,Cash,Takeaway,2023-12-01
+TXN_9093708,Sandwich,3,UNKNOWN,12.0,Credit Card,In-store,2023-12-08
+TXN_7785034,Smoothie,4,4.0,16.0,UNKNOWN,Takeaway,2023-11-09
+TXN_4048690,Cake,3,3.0,9.0,Cash,In-store,2023-09-06
+TXN_4971992,Cake,2,3.0,6.0,,,2023-09-24
+TXN_6738516,Sandwich,UNKNOWN,4.0,20.0,Cash,,2023-10-07
+TXN_3919995,Tea,3,1.5,4.5,Cash,Takeaway,2023-01-26
+TXN_3522385,Smoothie,4,4.0,16.0,Credit Card,Takeaway,2023-03-19
+TXN_3140020,Juice,5,3.0,15.0,,In-store,2023-06-19
+TXN_9756401,Salad,3,5.0,15.0,Cash,In-store,2023-02-04
+TXN_1937081,Cake,2,3.0,6.0,Credit Card,,2023-06-07
+TXN_9668584,Cookie,2,UNKNOWN,2.0,Digital Wallet,,2023-12-13
+TXN_2544072,Cookie,1,1.0,1.0,,In-store,2023-08-17
+TXN_7260110,Salad,5,5.0,25.0,Credit Card,In-store,2023-03-07
+TXN_1588687,Coffee,2,2.0,4.0,Digital Wallet,Takeaway,2023-08-22
+TXN_2886505,Tea,3,1.5,4.5,,,2023-09-05
+TXN_3864453,Cookie,5,1.0,5.0,Digital Wallet,,2023-11-15
+TXN_5346027,Sandwich,2,4.0,8.0,,UNKNOWN,2023-12-19
+TXN_3674876,Smoothie,5,4.0,20.0,Cash,Takeaway,
+TXN_8690361,Smoothie,3,4.0,12.0,,,2023-07-12
+TXN_8419805,Cake,5,3.0,15.0,,In-store,2023-07-24
+TXN_3125699,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-02-05
+TXN_5106316,Sandwich,5,4.0,UNKNOWN,Digital Wallet,Takeaway,2023-01-23
+TXN_5666369,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-07-17
+TXN_7712807,Smoothie,4,4.0,16.0,Credit Card,,2023-02-17
+TXN_8199561,Cookie,4,1.0,4.0,UNKNOWN,,2023-07-31
+TXN_4334932,Coffee,2,2.0,4.0,ERROR,In-store,2023-12-27
+TXN_4082099,Juice,2,3.0,6.0,Credit Card,In-store,2023-06-01
+TXN_9191700,Tea,5,1.5,7.5,,In-store,2023-10-01
+TXN_2249212,Cake,2,3.0,6.0,ERROR,,
+TXN_9921392,Coffee,5,2.0,10.0,,,2023-06-28
+TXN_7125395,Salad,1,,5.0,Cash,Takeaway,2023-07-23
+TXN_4521701,Cake,4,3.0,12.0,,In-store,2023-10-08
+TXN_4243930,UNKNOWN,5,4.0,20.0,Cash,In-store,2023-06-07
+TXN_1418829,Smoothie,1,4.0,4.0,,Takeaway,2023-09-19
+TXN_8955306,Coffee,3,2.0,6.0,Credit Card,In-store,2023-10-14
+TXN_7851403,Coffee,5,2.0,10.0,Credit Card,Takeaway,2023-03-06
+TXN_5288715,Juice,3,3.0,9.0,Digital Wallet,,2023-04-19
+TXN_7108056,Juice,3,3.0,9.0,Credit Card,,2023-01-25
+TXN_9950775,UNKNOWN,4,5.0,20.0,Credit Card,Takeaway,2023-02-20
+TXN_9688601,Juice,1,3.0,3.0,,In-store,2023-10-16
+TXN_9924732,Sandwich,UNKNOWN,4.0,,Credit Card,In-store,2023-01-18
+TXN_8807429,Cookie,4,1.0,4.0,Digital Wallet,,2023-07-21
+TXN_3340550,Juice,2,3.0,6.0,Digital Wallet,ERROR,2023-05-02
+TXN_4380808,Juice,4,3.0,12.0,,In-store,2023-04-30
+TXN_6403012,Juice,5,3.0,15.0,Cash,In-store,2023-07-23
+TXN_4176272,Coffee,1,2.0,2.0,Digital Wallet,,2023-06-06
+TXN_9293877,Juice,ERROR,3.0,15.0,Digital Wallet,,2023-08-24
+TXN_8609510,UNKNOWN,5,3.0,15.0,,Takeaway,2023-05-08
+TXN_2294776,Juice,4,3.0,12.0,Credit Card,Takeaway,2023-04-10
+TXN_8068515,Cookie,1,1.0,UNKNOWN,Cash,Takeaway,2023-06-16
+TXN_7915173,UNKNOWN,3,1.0,3.0,Cash,Takeaway,
+TXN_2556999,Tea,1,1.5,1.5,Credit Card,Takeaway,2023-08-14
+TXN_3816131,Juice,3,3.0,9.0,,ERROR,2023-01-23
+TXN_6564856,Tea,5,1.5,7.5,Digital Wallet,Takeaway,2023-02-16
+TXN_4822256,Smoothie,1,4.0,4.0,Credit Card,,2023-11-11
+TXN_9397870,Cake,2,ERROR,6.0,,,2023-05-23
+TXN_4976485,Salad,5,5.0,25.0,UNKNOWN,Takeaway,2023-07-10
+TXN_4856060,Juice,1,3.0,3.0,Cash,,2023-07-29
+TXN_3967103,Coffee,5,2.0,10.0,Cash,,2023-11-14
+TXN_8746881,Cake,2,3.0,6.0,UNKNOWN,,2023-11-07
+TXN_4569448,,1,3.0,3.0,,,UNKNOWN
+TXN_8732682,Salad,5,5.0,25.0,Credit Card,In-store,2023-04-07
+TXN_3687257,Tea,4,1.5,UNKNOWN,Credit Card,Takeaway,2023-03-27
+TXN_3616839,Cake,4,3.0,12.0,Digital Wallet,,2023-04-01
+TXN_2875074,Cake,4,3.0,12.0,Credit Card,Takeaway,2023-02-06
+TXN_5470909,Cookie,4,1.0,ERROR,Credit Card,In-store,2023-10-21
+TXN_5680657,ERROR,5,3.0,15.0,Cash,In-store,2023-05-16
+TXN_3587915,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-06-24
+TXN_9406938,Salad,1,5.0,5.0,ERROR,,2023-10-09
+TXN_9342366,Smoothie,3,4.0,12.0,Credit Card,,2023-02-18
+TXN_3101697,,3,5.0,15.0,Cash,In-store,2023-05-29
+TXN_6146889,Juice,UNKNOWN,3.0,6.0,,Takeaway,2023-09-01
+TXN_7226052,Sandwich,3,4.0,12.0,Cash,In-store,2023-02-21
+TXN_3422336,Tea,ERROR,1.5,7.5,,Takeaway,2023-08-02
+TXN_8644398,Sandwich,4,4.0,16.0,,Takeaway,2023-02-08
+TXN_8112788,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-08-07
+TXN_4179583,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-06-13
+TXN_3787265,Salad,1,5.0,5.0,Credit Card,In-store,2023-12-16
+TXN_3577683,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-09-17
+TXN_1310741,Sandwich,3,4.0,12.0,,Takeaway,2023-07-25
+TXN_2862856,Cake,5,3.0,15.0,,Takeaway,2023-02-01
+TXN_4940237,Cake,2,3.0,6.0,Cash,Takeaway,2023-08-03
+TXN_8765822,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-03-22
+TXN_3205813,Juice,3,3.0,9.0,Cash,In-store,2023-04-25
+TXN_8436045,Cake,,3.0,15.0,Credit Card,,2023-08-08
+TXN_5751040,Tea,5,1.5,7.5,Cash,ERROR,2023-02-27
+TXN_4657291,Coffee,UNKNOWN,2.0,4.0,UNKNOWN,Takeaway,2023-05-05
+TXN_8018572,Cookie,5,1.0,ERROR,,In-store,2023-10-09
+TXN_3454877,Sandwich,5,4.0,20.0,Credit Card,,2023-04-19
+TXN_1837764,Tea,3,1.5,4.5,Cash,In-store,2023-07-30
+TXN_4120124,Coffee,1,2.0,2.0,,,2023-06-08
+TXN_1661682,ERROR,5,4.0,20.0,Digital Wallet,,2023-07-13
+TXN_1927404,Juice,1,3.0,3.0,Digital Wallet,,2023-12-22
+TXN_9147596,Coffee,2,,4.0,Digital Wallet,Takeaway,2023-10-08
+TXN_5012988,Salad,3,5.0,,Credit Card,,2023-08-17
+TXN_1534763,Cookie,2,1.0,2.0,Cash,Takeaway,2023-09-17
+TXN_4485458,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-12-08
+TXN_9288882,Sandwich,3,4.0,12.0,,In-store,2023-04-23
+TXN_3964550,Tea,3,1.5,4.5,Credit Card,Takeaway,2023-06-09
+TXN_2509803,Coffee,1,ERROR,2.0,UNKNOWN,,2023-02-22
+TXN_3769567,UNKNOWN,1,1.0,1.0,Digital Wallet,In-store,2023-02-10
+TXN_4529101,Cookie,2,1.0,2.0,Digital Wallet,In-store,2023-09-17
+TXN_2391534,Cookie,3,1.0,3.0,Credit Card,,2023-05-06
+TXN_8379919,Cookie,3,1.0,3.0,Digital Wallet,,2023-12-04
+TXN_6474636,,3,1.5,4.5,,In-store,2023-10-25
+TXN_6219977,Cookie,2,1.0,2.0,Credit Card,,2023-12-17
+TXN_5731238,Cake,2,3.0,ERROR,Credit Card,,2023-03-27
+TXN_7825796,Tea,2,1.5,3.0,,,2023-04-03
+TXN_2375667,Salad,1,5.0,5.0,Cash,,2023-12-28
+TXN_5213761,Coffee,3,2.0,6.0,Digital Wallet,Takeaway,2023-08-18
+TXN_1427485,Coffee,3,2.0,6.0,Credit Card,,2023-07-19
+TXN_5954991,Sandwich,3,4.0,12.0,,Takeaway,2023-08-07
+TXN_8860270,,1,4.0,4.0,Cash,Takeaway,2023-11-06
+TXN_6482416,Coffee,1,2.0,2.0,,UNKNOWN,2023-07-20
+TXN_4916611,Juice,5,3.0,15.0,,Takeaway,2023-05-21
+TXN_4814244,Smoothie,3,4.0,12.0,ERROR,In-store,2023-06-01
+TXN_7968892,Tea,2,1.5,3.0,,In-store,2023-10-02
+TXN_9535721,Cake,5,3.0,15.0,Digital Wallet,In-store,2023-08-03
+TXN_2161372,Juice,1,3.0,3.0,Credit Card,Takeaway,2023-12-17
+TXN_8877714,Juice,5,3.0,15.0,,,2023-03-28
+TXN_5478129,Juice,4,3.0,12.0,Credit Card,,2023-01-22
+TXN_7267366,Sandwich,3,4.0,12.0,Digital Wallet,Takeaway,2023-06-02
+TXN_4696403,,3,1.0,3.0,Cash,ERROR,2023-08-19
+TXN_2480808,UNKNOWN,1,,4.0,Credit Card,,2023-03-30
+TXN_8688603,Coffee,2,2.0,4.0,Cash,,2023-05-05
+TXN_6148811,Tea,5,1.5,ERROR,Credit Card,Takeaway,2023-06-18
+TXN_2827259,Tea,3,1.5,ERROR,Credit Card,Takeaway,
+TXN_4382406,Coffee,5,2.0,10.0,,Takeaway,2023-09-26
+TXN_5426507,Juice,2,3.0,6.0,Cash,Takeaway,2023-06-13
+TXN_3855408,Cookie,1,1.0,1.0,Cash,Takeaway,2023-06-02
+TXN_6992783,Tea,1,1.5,1.5,Digital Wallet,Takeaway,2023-01-29
+TXN_8801160,Salad,2,5.0,10.0,Cash,In-store,
+TXN_2638810,Tea,2,1.5,3.0,,Takeaway,2023-11-16
+TXN_9158251,Salad,2,5.0,10.0,Credit Card,,2023-03-24
+TXN_3390610,Sandwich,2,4.0,8.0,,,2023-02-01
+TXN_6498876,Sandwich,3,4.0,12.0,,Takeaway,2023-08-20
+TXN_1627038,Juice,4,3.0,12.0,,Takeaway,2023-12-25
+TXN_2785262,Salad,3,5.0,15.0,Cash,Takeaway,2023-08-30
+TXN_9944730,Tea,1,1.5,1.5,Digital Wallet,,2023-04-10
+TXN_7002929,Cookie,1,1.0,1.0,,In-store,2023-01-30
+TXN_7484886,Smoothie,3,4.0,12.0,,,2023-04-17
+TXN_7316790,Coffee,1,2.0,UNKNOWN,Credit Card,In-store,2023-11-07
+TXN_4663529,Sandwich,5,4.0,20.0,Digital Wallet,ERROR,2023-12-24
+TXN_2675174,Salad,2,5.0,10.0,,Takeaway,2023-12-04
+TXN_4350798,ERROR,1,5.0,5.0,Credit Card,In-store,2023-11-23
+TXN_7229543,Cake,1,3.0,3.0,Credit Card,UNKNOWN,2023-07-10
+TXN_4330643,Cookie,3,1.0,3.0,Cash,Takeaway,2023-05-15
+TXN_2003488,Juice,3,3.0,9.0,,Takeaway,2023-09-25
+TXN_2206884,UNKNOWN,5,5.0,25.0,Credit Card,,2023-06-22
+TXN_3492393,Coffee,1,2.0,2.0,,In-store,2023-05-29
+TXN_3894660,Juice,2,3.0,6.0,,,2023-02-09
+TXN_5766532,Smoothie,5,4.0,UNKNOWN,Cash,In-store,2023-06-23
+TXN_5476485,Juice,2,3.0,6.0,Cash,In-store,2023-01-07
+TXN_9335226,Sandwich,5,4.0,20.0,,,2023-05-08
+TXN_2581559,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-03-25
+TXN_9146123,Coffee,2,2.0,4.0,Digital Wallet,,2023-12-12
+TXN_1335256,Coffee,5,2.0,10.0,,Takeaway,2023-08-04
+TXN_5968921,Salad,5,5.0,25.0,Credit Card,Takeaway,2023-10-10
+TXN_6895558,Coffee,2,2.0,4.0,Credit Card,UNKNOWN,2023-04-10
+TXN_6428404,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-02-06
+TXN_6762311,Juice,1,3.0,3.0,Credit Card,Takeaway,ERROR
+TXN_1190402,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-12-01
+TXN_9607633,UNKNOWN,2,1.0,2.0,Digital Wallet,,2023-08-25
+TXN_3787941,Tea,2,1.5,3.0,,,ERROR
+TXN_6349424,Sandwich,5,4.0,20.0,Cash,Takeaway,2023-02-24
+TXN_1401771,Sandwich,2,4.0,8.0,Cash,,2023-12-08
+TXN_9188733,Salad,ERROR,5.0,15.0,,In-store,2023-08-19
+TXN_3334632,,1,ERROR,2.0,Credit Card,Takeaway,2023-11-20
+TXN_3851928,Juice,3,3.0,9.0,Credit Card,In-store,2023-02-07
+TXN_8267915,Sandwich,2,4.0,8.0,,Takeaway,2023-03-22
+TXN_3726397,Salad,5,5.0,25.0,,Takeaway,2023-01-30
+TXN_1210058,Tea,5,1.5,7.5,,,2023-11-25
+TXN_7791293,Salad,3,5.0,15.0,Credit Card,Takeaway,2023-04-08
+TXN_6343367,Juice,2,3.0,6.0,,In-store,2023-09-17
+TXN_2653224,Juice,3,3.0,9.0,Digital Wallet,,2023-03-27
+TXN_6300001,Tea,ERROR,1.5,1.5,Digital Wallet,,2023-06-07
+TXN_4693942,Sandwich,4,4.0,16.0,Cash,Takeaway,2023-12-16
+TXN_3562418,UNKNOWN,2,4.0,8.0,Digital Wallet,UNKNOWN,2023-08-13
+TXN_7963324,Coffee,3,2.0,6.0,,Takeaway,2023-12-09
+TXN_5563486,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-03-13
+TXN_3679582,,5,2.0,10.0,Credit Card,In-store,2023-04-11
+TXN_6932752,Smoothie,5,4.0,20.0,,,2023-09-20
+TXN_5697414,Cake,5,3.0,15.0,Credit Card,In-store,2023-02-16
+TXN_5434310,Smoothie,3,4.0,12.0,Cash,,2023-11-21
+TXN_8435360,UNKNOWN,3,1.5,4.5,Credit Card,In-store,2023-07-03
+TXN_5422843,Sandwich,2,4.0,8.0,Cash,In-store,2023-07-21
+TXN_1704041,Coffee,4,2.0,ERROR,Credit Card,,2023-05-21
+TXN_9729178,Coffee,3,2.0,6.0,Credit Card,,2023-05-28
+TXN_4663964,Cookie,4,,4.0,Digital Wallet,In-store,2023-06-29
+TXN_6805057,Cookie,4,1.0,4.0,Credit Card,,2023-10-15
+TXN_8162690,Salad,2,5.0,10.0,Digital Wallet,,2023-05-08
+TXN_7089712,Cake,5,3.0,15.0,Cash,,2023-08-13
+TXN_8077812,Salad,5,UNKNOWN,25.0,Cash,In-store,2023-01-16
+TXN_4834450,Cake,2,3.0,6.0,Cash,,2023-06-26
+TXN_9081686,Cookie,5,1.0,5.0,,,2023-06-11
+TXN_6650875,Cookie,5,1.0,5.0,Credit Card,Takeaway,2023-01-29
+TXN_2133223,Cake,3,3.0,9.0,Cash,,2023-11-17
+TXN_5879154,Salad,2,5.0,10.0,ERROR,Takeaway,2023-06-28
+TXN_9575926,Sandwich,3,4.0,12.0,Credit Card,UNKNOWN,2023-12-12
+TXN_5425911,Smoothie,1,4.0,4.0,Digital Wallet,,2023-11-30
+TXN_5604021,Sandwich,UNKNOWN,4.0,4.0,Cash,Takeaway,2023-09-10
+TXN_9860308,Smoothie,2,4.0,8.0,Digital Wallet,,2023-02-20
+TXN_5908078,UNKNOWN,1,2.0,2.0,UNKNOWN,In-store,2023-03-23
+TXN_3507013,Juice,1,ERROR,3.0,Digital Wallet,In-store,2023-01-16
+TXN_7896733,Cake,4,3.0,12.0,Digital Wallet,,2023-06-03
+TXN_3092390,Sandwich,3,UNKNOWN,12.0,,In-store,2023-07-24
+TXN_8131570,Salad,4,5.0,20.0,,In-store,2023-12-02
+TXN_3898445,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-06-17
+TXN_8588758,Sandwich,4,4.0,16.0,Credit Card,In-store,ERROR
+TXN_7641606,Coffee,3,2.0,6.0,Credit Card,Takeaway,2023-12-26
+TXN_1414039,Juice,4,3.0,12.0,,UNKNOWN,2023-02-13
+TXN_2322162,ERROR,5,3.0,15.0,Digital Wallet,,2023-11-12
+TXN_6190857,Tea,1,1.5,1.5,,In-store,2023-10-14
+TXN_7652830,UNKNOWN,2,3.0,6.0,,,2023-08-15
+TXN_1688292,UNKNOWN,3,,9.0,Credit Card,In-store,
+TXN_1805937,Juice,3,3.0,9.0,Credit Card,,2023-06-12
+TXN_7390866,Tea,5,1.5,7.5,,Takeaway,
+TXN_4717715,Sandwich,3,4.0,12.0,Digital Wallet,,2023-07-27
+TXN_1237674,,3,1.5,4.5,Credit Card,UNKNOWN,2023-10-04
+TXN_9686177,Cake,3,3.0,9.0,,In-store,
+TXN_2672972,Sandwich,1,4.0,4.0,Digital Wallet,Takeaway,2023-06-15
+TXN_9582818,,1,4.0,4.0,Cash,In-store,2023-10-27
+TXN_6970542,Sandwich,4,4.0,16.0,Credit Card,,2023-08-04
+TXN_6091542,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-01-17
+TXN_4184461,Salad,2,5.0,10.0,Digital Wallet,In-store,2023-02-22
+TXN_3224397,Cookie,4,1.0,4.0,Digital Wallet,Takeaway,2023-05-15
+TXN_2772639,Tea,4,1.5,6.0,Credit Card,In-store,2023-08-30
+TXN_4385826,UNKNOWN,2,1.5,3.0,Credit Card,Takeaway,2023-08-02
+TXN_5109348,Cake,4,3.0,12.0,Digital Wallet,In-store,2023-02-10
+TXN_6137985,Coffee,5,2.0,UNKNOWN,Credit Card,In-store,2023-03-15
+TXN_3895871,ERROR,1,1.0,1.0,,In-store,2023-05-30
+TXN_3526255,Smoothie,4,4.0,16.0,UNKNOWN,Takeaway,2023-06-23
+TXN_7310356,Juice,4,3.0,12.0,Digital Wallet,,2023-10-20
+TXN_9054074,Cake,1,3.0,3.0,Credit Card,Takeaway,2023-10-15
+TXN_7538724,Sandwich,1,4.0,4.0,,In-store,2023-05-17
+TXN_6715991,Juice,1,3.0,3.0,Cash,,2023-06-18
+TXN_2271725,Smoothie,5,4.0,20.0,Cash,,2023-12-21
+TXN_1488481,Coffee,4,2.0,8.0,Credit Card,Takeaway,2023-07-28
+TXN_4600894,,5,5.0,25.0,Digital Wallet,,2023-09-17
+TXN_3494652,Coffee,1,2.0,2.0,,,2023-05-23
+TXN_2860281,Smoothie,4,4.0,16.0,Cash,,2023-09-19
+TXN_1232346,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-01-04
+TXN_1911093,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-10-07
+TXN_1672229,Cookie,2,1.0,2.0,Cash,,2023-11-12
+TXN_7056162,Smoothie,3,4.0,12.0,Digital Wallet,In-store,2023-03-04
+TXN_2064049,Salad,4,5.0,20.0,Credit Card,Takeaway,2023-09-21
+TXN_8191202,Cookie,2,UNKNOWN,2.0,Digital Wallet,In-store,2023-01-14
+TXN_4518505,Tea,UNKNOWN,1.5,7.5,Cash,,2023-05-09
+TXN_2823220,Salad,4,5.0,UNKNOWN,,In-store,2023-05-17
+TXN_6826409,Sandwich,1,4.0,4.0,Credit Card,Takeaway,2023-10-21
+TXN_2954833,Coffee,1,2.0,2.0,,,2023-01-29
+TXN_5309677,Coffee,4,2.0,8.0,Cash,In-store,2023-08-09
+TXN_6011106,Juice,2,3.0,6.0,Digital Wallet,,2023-09-07
+TXN_4714592,Tea,1,1.5,1.5,Cash,,2023-06-02
+TXN_6704284,Salad,2,5.0,10.0,Credit Card,Takeaway,2023-08-31
+TXN_9506076,Salad,5,5.0,25.0,,,2023-01-17
+TXN_2354394,Tea,4,1.5,6.0,Cash,In-store,2023-04-17
+TXN_3436344,Smoothie,2,4.0,8.0,,,2023-02-28
+TXN_7826516,Cake,4,3.0,12.0,Credit Card,,2023-06-21
+TXN_2699745,Coffee,4,2.0,8.0,,In-store,2023-12-30
+TXN_6097664,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-11-27
+TXN_3858288,Tea,2,1.5,3.0,,,2023-04-12
+TXN_1272815,Juice,4,3.0,12.0,Credit Card,,2023-08-07
+TXN_4755623,Juice,3,3.0,9.0,Cash,,2023-11-23
+TXN_8261045,Tea,3,1.5,4.5,Cash,,2023-01-21
+TXN_2217015,Coffee,3,2.0,6.0,,Takeaway,2023-04-17
+TXN_1660104,Smoothie,2,4.0,8.0,Credit Card,Takeaway,2023-02-04
+TXN_6589078,Tea,3,1.5,4.5,Digital Wallet,,2023-08-03
+TXN_6306555,Smoothie,1,4.0,4.0,Digital Wallet,Takeaway,2023-04-12
+TXN_1208561,,ERROR,,20.0,Credit Card,,2023-08-19
+TXN_8751702,,5,,15.0,Cash,,2023-02-13
+TXN_2079029,Cake,5,3.0,15.0,Cash,In-store,2023-05-11
+TXN_5737641,Cookie,1,1.0,1.0,ERROR,,2023-02-16
+TXN_2845506,Tea,2,1.5,3.0,Digital Wallet,Takeaway,2023-12-30
+TXN_8565799,Smoothie,4,4.0,16.0,Credit Card,In-store,2023-04-22
+TXN_3052584,Salad,1,5.0,5.0,Cash,In-store,2023-01-21
+TXN_1530892,Juice,2,3.0,6.0,Digital Wallet,,2023-09-09
+TXN_3392953,Coffee,1,2.0,,Digital Wallet,Takeaway,2023-01-06
+TXN_4606893,Juice,5,3.0,15.0,Digital Wallet,In-store,2023-05-24
+TXN_7300653,Cookie,5,1.0,5.0,ERROR,,2023-04-24
+TXN_1759063,Cookie,2,1.0,2.0,Digital Wallet,Takeaway,2023-09-09
+TXN_1706896,Smoothie,3,4.0,12.0,Cash,,2023-07-15
+TXN_3325234,Tea,ERROR,1.5,1.5,ERROR,In-store,2023-08-26
+TXN_5536245,Smoothie,4,4.0,16.0,Cash,,
+TXN_1976619,Coffee,2,2.0,4.0,Digital Wallet,,2023-08-02
+TXN_7953750,Sandwich,5,4.0,20.0,Cash,In-store,2023-06-16
+TXN_9162296,UNKNOWN,3,4.0,12.0,Cash,In-store,2023-05-10
+TXN_8367194,Juice,1,3.0,3.0,Digital Wallet,Takeaway,2023-02-04
+TXN_6744733,Sandwich,1,4.0,,Cash,Takeaway,UNKNOWN
+TXN_4959078,Cake,2,3.0,6.0,Digital Wallet,Takeaway,2023-09-13
+TXN_4552137,Tea,2,1.5,3.0,,In-store,2023-04-05
+TXN_1748121,Cake,2,3.0,6.0,,In-store,2023-12-07
+TXN_7922350,Coffee,2,2.0,4.0,UNKNOWN,Takeaway,2023-05-09
+TXN_1944293,Coffee,3,2.0,6.0,,In-store,2023-02-25
+TXN_4528914,Salad,,5.0,5.0,ERROR,In-store,2023-08-06
+TXN_1928401,Sandwich,5,4.0,20.0,Digital Wallet,In-store,2023-06-15
+TXN_7621213,Coffee,ERROR,2.0,6.0,,In-store,2023-03-07
+TXN_7861799,Cookie,2,1.0,2.0,Cash,Takeaway,2023-05-23
+TXN_5244674,Cake,5,3.0,15.0,,,2023-04-27
+TXN_9679675,Coffee,1,2.0,2.0,Cash,,2023-07-07
+TXN_2562041,Cake,5,3.0,15.0,Cash,Takeaway,2023-12-24
+TXN_2738904,Smoothie,4,4.0,16.0,Digital Wallet,,2023-11-23
+TXN_7359190,Salad,UNKNOWN,5.0,15.0,,,2023-12-19
+TXN_9266499,Cake,1,3.0,ERROR,Digital Wallet,UNKNOWN,2023-02-16
+TXN_9196229,Sandwich,5,4.0,20.0,Credit Card,,2023-12-08
+TXN_3740505,,2,1.5,3.0,,,2023-11-21
+TXN_4308634,Coffee,3,2.0,6.0,Cash,In-store,2023-02-14
+TXN_3450880,Tea,3,1.5,4.5,,In-store,2023-05-29
+TXN_6838411,Coffee,1,2.0,2.0,Cash,,2023-07-04
+TXN_7548396,Tea,2,1.5,3.0,Digital Wallet,,2023-04-06
+TXN_8786286,Sandwich,5,4.0,20.0,Digital Wallet,,2023-05-28
+TXN_7439400,Salad,3,5.0,15.0,,Takeaway,2023-06-28
+TXN_7461658,Coffee,3,2.0,6.0,Credit Card,,2023-08-13
+TXN_6017034,Cake,4,3.0,12.0,UNKNOWN,,2023-10-06
+TXN_3649492,Salad,4,5.0,20.0,Digital Wallet,,2023-12-01
+TXN_4071743,ERROR,5,2.0,10.0,,Takeaway,2023-07-06
+TXN_8150967,Smoothie,3,4.0,12.0,Cash,,2023-01-08
+TXN_3792683,Salad,4,5.0,20.0,Digital Wallet,In-store,2023-08-06
+TXN_4006067,Juice,4,3.0,12.0,Cash,Takeaway,2023-01-30
+TXN_1975184,Coffee,,2.0,UNKNOWN,Digital Wallet,,2023-01-15
+TXN_3456242,Sandwich,5,4.0,20.0,Credit Card,,2023-04-28
+TXN_1928131,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-04-17
+TXN_8318388,Cake,5,3.0,15.0,UNKNOWN,UNKNOWN,2023-11-26
+TXN_8270768,Juice,5,3.0,15.0,Digital Wallet,Takeaway,2023-02-28
+TXN_4157300,Tea,4,1.5,6.0,Cash,Takeaway,2023-09-23
+TXN_3224156,Cookie,1,1.0,1.0,Credit Card,In-store,2023-03-16
+TXN_3105633,,1,2.0,2.0,,In-store,2023-03-30
+TXN_1964893,Smoothie,1,4.0,4.0,,ERROR,ERROR
+TXN_7936851,Sandwich,3,4.0,12.0,,,2023-10-07
+TXN_6393305,Salad,5,5.0,25.0,Digital Wallet,In-store,2023-10-19
+TXN_7326720,Cake,2,3.0,6.0,ERROR,In-store,2023-12-08
+TXN_3069563,Sandwich,2,4.0,8.0,Cash,UNKNOWN,2023-04-25
+TXN_1728427,Coffee,5,2.0,10.0,Cash,,2023-02-11
+TXN_9176288,Tea,2,1.5,3.0,Digital Wallet,In-store,2023-02-08
+TXN_9071439,Juice,3,3.0,9.0,Credit Card,,2023-02-05
+TXN_4659954,,3,4.0,12.0,Credit Card,In-store,
+TXN_1841204,Salad,3,5.0,15.0,Digital Wallet,In-store,2023-04-18
+TXN_8963470,Salad,,5.0,10.0,,In-store,2023-06-01
+TXN_8330240,Sandwich,4,4.0,16.0,Digital Wallet,,2023-06-06
+TXN_3534588,Salad,1,5.0,5.0,Cash,ERROR,2023-07-05
+TXN_2749289,Smoothie,2,4.0,,Digital Wallet,Takeaway,2023-05-05
+TXN_6587628,Coffee,5,2.0,10.0,,In-store,2023-05-09
+TXN_1711872,Juice,1,3.0,3.0,,Takeaway,2023-01-27
+TXN_3809533,Juice,2,,ERROR,Digital Wallet,Takeaway,2023-02-02
+TXN_4339925,Cookie,1,1.0,1.0,Cash,Takeaway,2023-11-23
+TXN_1183208,Smoothie,5,4.0,20.0,ERROR,,2023-08-26
+TXN_9089045,Coffee,,2.0,10.0,Cash,In-store,2023-03-12
+TXN_9503145,Juice,5,3.0,15.0,Digital Wallet,,2023-09-21
+TXN_8999360,Juice,3,3.0,9.0,Cash,Takeaway,2023-09-27
+TXN_6188262,Juice,1,3.0,3.0,Cash,Takeaway,2023-10-24
+TXN_5967452,Juice,5,3.0,15.0,Credit Card,,2023-03-07
+TXN_9053365,Cookie,1,1.0,1.0,Digital Wallet,In-store,2023-07-15
+TXN_3706457,Tea,5,1.5,7.5,Credit Card,Takeaway,2023-07-18
+TXN_9612533,Cake,2,3.0,6.0,Digital Wallet,In-store,2023-01-26
+TXN_4948026,Tea,4,1.5,6.0,Digital Wallet,In-store,2023-07-02
+TXN_8741663,Smoothie,1,4.0,4.0,Credit Card,Takeaway,2023-01-21
+TXN_7249396,Cake,1,3.0,3.0,Cash,,2023-09-26
+TXN_8104914,Cookie,1,1.0,1.0,,Takeaway,UNKNOWN
+TXN_8922585,Salad,5,5.0,25.0,Credit Card,UNKNOWN,2023-06-22
+TXN_2112522,Sandwich,5,4.0,20.0,Digital Wallet,Takeaway,2023-04-30
+TXN_2338617,ERROR,2,3.0,6.0,Digital Wallet,UNKNOWN,2023-01-12
+TXN_2464054,Coffee,ERROR,2.0,10.0,,Takeaway,2023-08-18
+TXN_6133115,Smoothie,5,4.0,20.0,,In-store,2023-12-08
+TXN_8408353,Tea,1,1.5,1.5,Credit Card,UNKNOWN,2023-12-13
+TXN_6420902,Cake,3,3.0,9.0,Credit Card,Takeaway,2023-11-22
+TXN_9400245,Salad,1,5.0,5.0,,In-store,2023-02-24
+TXN_4767609,Coffee,3,2.0,6.0,Digital Wallet,In-store,2023-10-15
+TXN_1425591,Smoothie,1,4.0,4.0,Cash,,2023-09-10
+TXN_2292088,ERROR,1,4.0,4.0,Digital Wallet,Takeaway,2023-03-04
+TXN_6706599,Cake,1,3.0,3.0,,Takeaway,2023-09-20
+TXN_4365321,Salad,4,5.0,20.0,Cash,In-store,2023-03-09
+TXN_4457299,Smoothie,3,4.0,12.0,Credit Card,In-store,2023-09-19
+TXN_4671375,Tea,1,1.5,1.5,,,2023-06-28
+TXN_1184715,Cake,2,3.0,6.0,,,2023-09-10
+TXN_5981429,Juice,2,,6.0,Digital Wallet,,2023-12-24
+TXN_9036527,Smoothie,4,4.0,16.0,Digital Wallet,,2023-06-27
+TXN_2464706,Cake,4,UNKNOWN,12.0,Digital Wallet,Takeaway,2023-11-09
+TXN_8844497,Sandwich,3,4.0,12.0,,Takeaway,2023-11-18
+TXN_5171519,Salad,3,5.0,15.0,,In-store,2023-04-06
+TXN_6049240,Juice,1,3.0,3.0,Cash,,2023-05-31
+TXN_4428252,Sandwich,3,4.0,12.0,,Takeaway,2023-10-31
+TXN_8344810,Smoothie,2,4.0,8.0,,UNKNOWN,
+TXN_8502079,Tea,UNKNOWN,1.5,3.0,Cash,,2023-04-20
+TXN_9460419,Cake,1,3.0,3.0,,Takeaway,UNKNOWN
+TXN_1169615,Smoothie,5,4.0,20.0,Digital Wallet,In-store,2023-03-16
+TXN_9778251,Tea,ERROR,1.5,6.0,,Takeaway,2023-11-09
+TXN_1949093,Smoothie,2,4.0,8.0,Cash,,2023-02-05
+TXN_8253472,Cake,1,3.0,3.0,,,UNKNOWN
+TXN_9357808,Sandwich,4,4.0,16.0,Cash,,2023-05-20
+TXN_9026468,Sandwich,2,4.0,8.0,Credit Card,ERROR,2023-08-23
+TXN_8273780,Salad,2,5.0,10.0,Digital Wallet,Takeaway,2023-10-15
+TXN_4224427,Juice,4,3.0,12.0,Cash,Takeaway,2023-01-23
+TXN_5344848,Salad,1,5.0,5.0,Digital Wallet,Takeaway,2023-09-27
+TXN_6411708,Coffee,4,2.0,8.0,Credit Card,In-store,2023-05-20
+TXN_7495283,Cake,UNKNOWN,3.0,15.0,Credit Card,Takeaway,2023-04-14
+TXN_8153550,Cookie,2,1.0,2.0,Cash,Takeaway,2023-10-12
+TXN_8807600,UNKNOWN,1,4.0,4.0,Cash,Takeaway,2023-09-24
+TXN_5921442,Smoothie,4,4.0,16.0,Cash,Takeaway,2023-02-04
+TXN_9496697,Tea,1,1.5,1.5,,In-store,2023-09-27
+TXN_3130865,Juice,3,3.0,9.0,,In-store,UNKNOWN
+TXN_2818204,Cake,1,3.0,3.0,Digital Wallet,,2023-03-09
+TXN_4122925,ERROR,4,1.0,4.0,,Takeaway,2023-10-20
+TXN_9407169,Sandwich,1,4.0,4.0,Digital Wallet,,2023-01-28
+TXN_8966400,Cake,5,3.0,15.0,Credit Card,Takeaway,2023-11-29
+TXN_1191659,Coffee,4,2.0,ERROR,Credit Card,In-store,2023-11-21
+TXN_9187008,Tea,4,1.5,6.0,ERROR,,2023-09-16
+TXN_1958525,Cookie,3,1.0,3.0,,Takeaway,2023-10-08
+TXN_6487003,Coffee,ERROR,2.0,8.0,Credit Card,Takeaway,2023-11-15
+TXN_4125474,ERROR,2,5.0,10.0,Credit Card,In-store,2023-08-02
+TXN_4556831,Juice,2,3.0,6.0,Digital Wallet,In-store,2023-05-28
+TXN_3546629,Juice,5,3.0,15.0,,In-store,2023-03-04
+TXN_2153100,Tea,2,UNKNOWN,3.0,Cash,,2023-12-29
+TXN_4723089,Sandwich,4,4.0,16.0,Cash,In-store,2023-05-23
+TXN_8545707,Cake,5,3.0,15.0,,Takeaway,2023-02-14
+TXN_8938445,Cake,3,3.0,9.0,,In-store,2023-11-07
+TXN_5846013,Tea,2,1.5,3.0,Digital Wallet,,2023-12-20
+TXN_6494265,Coffee,2,2.0,4.0,,,2023-05-24
+TXN_8563793,Juice,4,3.0,12.0,,In-store,2023-03-26
+TXN_8866974,Smoothie,3,4.0,12.0,Digital Wallet,Takeaway,2023-03-14
+TXN_9954652,Coffee,2,2.0,4.0,Cash,In-store,2023-09-12
+TXN_5762440,Sandwich,5,4.0,20.0,Cash,In-store,2023-03-05
+TXN_6120851,Salad,5,5.0,25.0,Cash,Takeaway,2023-02-04
+TXN_3124078,Cake,4,3.0,12.0,UNKNOWN,In-store,2023-08-06
+TXN_7936002,Salad,2,5.0,10.0,Digital Wallet,,2023-01-26
+TXN_8076061,Tea,4,1.5,6.0,Cash,In-store,2023-04-01
+TXN_9668108,Cake,1,3.0,3.0,Cash,In-store,2023-01-20
+TXN_3528020,Cookie,1,1.0,1.0,,Takeaway,2023-08-26
+TXN_5548914,Juice,2,3.0,ERROR,Digital Wallet,In-store,2023-11-04
+TXN_4302199,Tea,3,1.5,4.5,,,2023-02-16
+TXN_9933628,Smoothie,5,4.0,20.0,Cash,In-store,2023-07-20
+TXN_6796890,Tea,4,1.5,6.0,UNKNOWN,,2023-08-24
+TXN_4583012,ERROR,5,4.0,20.0,Digital Wallet,,2023-02-27
+TXN_8567525,Cookie,2,1.0,2.0,,Takeaway,2023-12-30
+TXN_9226047,Smoothie,3,4.0,12.0,Cash,,UNKNOWN
+TXN_3142496,Smoothie,UNKNOWN,4.0,4.0,Cash,Takeaway,2023-07-27
+TXN_3297457,Cake,2,3.0,6.0,,UNKNOWN,2023-01-03
+TXN_2858441,Sandwich,2,4.0,8.0,Credit Card,In-store,2023-12-14
+TXN_1784478,Juice,5,3.0,15.0,Cash,,2023-07-31
+TXN_9594133,Cake,5,3.0,,ERROR,,
+TXN_1741685,Juice,5,3.0,15.0,Cash,,2023-08-18
+TXN_1538510,Coffee,5,2.0,10.0,Digital Wallet,,2023-05-22
+TXN_3897619,Sandwich,3,4.0,12.0,Cash,Takeaway,2023-02-24
+TXN_2739140,Smoothie,4,4.0,16.0,UNKNOWN,In-store,2023-07-05
+TXN_4766549,Smoothie,2,4.0,,Cash,,2023-10-20
+TXN_7851634,UNKNOWN,4,4.0,16.0,,,2023-01-08
+TXN_7672686,Coffee,2,2.0,4.0,,UNKNOWN,2023-08-30
+TXN_9659401,,3,,3.0,Digital Wallet,,2023-06-02
+TXN_5255387,Coffee,4,2.0,8.0,Digital Wallet,,2023-03-02
+TXN_7695629,Cookie,3,,3.0,Digital Wallet,,2023-12-02
+TXN_6170729,Sandwich,3,4.0,12.0,Cash,In-store,2023-11-07


### PR DESCRIPTION
Added dirty_cafe_sales.csv containing 10,000+ rows of cafe sales transactions with various data quality issues (missing, malformed, and error values) for use in data cleaning and analysis exercises.